### PR TITLE
use ActiveRecord::Base for more coverage of models.

### DIFF
--- a/lib/sorbet_rails/tasks/rails_rbi.rake
+++ b/lib/sorbet_rails/tasks/rails_rbi.rake
@@ -16,7 +16,7 @@ namespace :rails_rbi do
   task models: :environment do
     # need to eager load to see all models
     Rails.application.eager_load!
-    all_models = ApplicationRecord.descendants
+    all_models = ActiveRecord::Base.descendants
     file_path = Rails.root.join('app', 'models', 'models.rbi')
     File.write(file_path, ModelsRbiFormatter.new(all_models).generate_rbi)
   end


### PR DESCRIPTION
`ActiveRecord::Base` covers more classes than `ApplicationRecord`. It also covers outdated models in old gems.