### PR TITLE
Use instance_method when trying to find instance methods of a model

### DIFF
--- a/lib/sorbet_rails/models_rbi_formatter.rb
+++ b/lib/sorbet_rails/models_rbi_formatter.rb
@@ -55,6 +55,12 @@ class ModelsRbiFormatter
       @columns_hash = model_class.columns_hash
       @generated_sigs = ActiveSupport::HashWithIndifferentAccess.new
       @generated_class_sigs = ActiveSupport::HashWithIndifferentAccess.new
+      begin
+        # Load all dynamic instance methods of this model by instantiating a fake model
+        @model_class.new
+      rescue StandardError
+        puts "Note: Unable to create new instance of #{model_class.name}"
+      end
     end
 
     def generate_rbi
@@ -65,7 +71,7 @@ class ModelsRbiFormatter
       @buffer = []
       @buffer << draw_class_header
 
-      @model_class.new.methods.sort.each do |method_name|
+      @model_class.instance_methods.sort.each do |method_name|
         expected_sig = @generated_sigs[method_name]
         next unless expected_sig.present?
 


### PR DESCRIPTION
Currently, I create an instance of a model to retrieve all instance methods of the class. It doesn't work for singleton, because <Model>.new will raise an exception. The script'd fail to generate files for that class. However, we need to use <Model>.new to load all dynamic methods that can be added to a class.

I found out that once we call <Model>.new, we can use `<Model>.instance_method` to get all instance methods reliably. In this PR I change the logic to use <Model>.instance_method, and try to call <Model>.new when it's possible, just to include all dynamic methods 

