### PR TITLE
fix generating correct type for column storing array of values

### DIFF
--- a/lib/sorbet_rails/model_rbi_formatter.rb
+++ b/lib/sorbet_rails/model_rbi_formatter.rb
@@ -222,6 +222,9 @@ class ModelRbiFormatter
 
   def type_for_column_def(column_def)
     strict_type = RUBY_TO_SORBET_TYPE_MAPPING[column_def.type] || 'T.untyped'
+    if column_def.array?
+      strict_type = "T::Array[#{strict_type}]"
+    end
     column_def.null ? "T.nilable(#{strict_type})" : strict_type
   end
 


### PR DESCRIPTION
Fix it so that columns that are array will be typed correctly. For example, if a `standards` column in `items` table are added like following
```
    add_column :items, :correct_answers, :text, array: true, default: []
```
We will generate following sigs
```
  sig { returns(T.nilable(T::Array[String])) }
  def correct_answers(); end

  sig { params(value: T.nilable(T::Array[String])).void }
  def correct_answers=(value); end
```