### PR TITLE
fix the list of methods owner considered autogenerated

### DIFF
--- a/lib/sorbet_rails/model_rbi_formatter.rb
+++ b/lib/sorbet_rails/model_rbi_formatter.rb
@@ -274,8 +274,9 @@ class ModelRbiFormatter
     (
       [
         "ActiveRecord::AttributeMethods::GeneratedAttributeMethods",
-        "#{@model_class.name}::GeneratedAssociationMethods",
+        "GeneratedAssociationMethods",
         "ActiveRecord::Querying",
+        "ActiveRecord::AttributeMethods::PrimaryKey",
       ].any? { |k| owner_name.include?(k) } ||
       [
         "lib/active_record/enum.rb",


### PR DESCRIPTION
Fix it so that:
- `id` and `id=` are whitelisted
- We respect generated methods added to a parent model class. Eg if `SpecificItem` subclasses `Item`, we do not filter out methods added in `Item::GeneratedAssociationMethods` when generating `SpecificItem` rbi.