### PR TITLE
Add ActiveRecord::Associations::CollectionProxy

### DIFF
--- a/lib/sorbet-rails/model_rbi_formatter.rb
+++ b/lib/sorbet-rails/model_rbi_formatter.rb
@@ -190,8 +190,8 @@ class ModelRbiFormatter
     # TODO allow people to specify the possible values of polymorphic associations
     assoc_class = assoc_should_be_untyped?(reflection) ? "T.untyped" : reflection.class_name
     relation_class = relation_should_be_untyped?(reflection) ?
-      "ActiveRecord::Relation[T.untyped]" :
-      "#{assoc_class}::Relation"
+      "ActiveRecord::Associations::CollectionProxy[T.untyped]" :
+      "#{assoc_class}::CollectionProxy"
     @generated_sigs.merge!({
       "#{assoc_name}" => { ret: relation_class },
       "#{assoc_name}=" => {
@@ -237,6 +237,12 @@ class ModelRbiFormatter
       # typed: strong
 
       class #{@model_class.name}::Relation < ActiveRecord::Relation
+        include #{@model_class.name}::NamedScope
+        extend T::Generic
+        Elem = type_member(fixed: #{@model_class.name})
+      end
+
+      class #{@model_class.name}::CollectionProxy < ActiveRecord::Associations::CollectionProxy
         include #{@model_class.name}::NamedScope
         extend T::Generic
         Elem = type_member(fixed: #{@model_class.name})

--- a/rbi/activerecord.rbi
+++ b/rbi/activerecord.rbi
@@ -25,6 +25,23 @@ class ActiveRecord::Relation
   def find(*args); end
 end
 
+class ActiveRecord::Associations::CollectionProxy < ActiveRecord::Relation
+  extend T::Generic
+
+  Elem = type_member
+
+  # -- << and aliases
+  sig { params(records: T.any(Elem, T::Array[Elem])).returns(T.self_type) }
+  def <<(*records); end
+  sig { params(records: T.any(Elem, T::Array[Elem])).returns(T.self_type) }
+  def append(*records); end
+  sig { params(records: T.any(Elem, T::Array[Elem])).returns(T.self_type) }
+  def push(*records); end
+  sig { params(records: T.any(Elem, T::Array[Elem])).returns(T.self_type) }
+  def concat(*records); end
+end
+
+
 module ActiveRecord::Querying::Typed
   extend T::Sig
   extend T::Generic

--- a/spec/test_data/models/expected_potion.rbi
+++ b/spec/test_data/models/expected_potion.rbi
@@ -8,6 +8,12 @@ class Potion::Relation < ActiveRecord::Relation
   Elem = type_member(fixed: Potion)
 end
 
+class Potion::CollectionProxy < ActiveRecord::Associations::CollectionProxy
+  include Potion::NamedScope
+  extend T::Generic
+  Elem = type_member(fixed: Potion)
+end
+
 class Potion < ApplicationRecord
   extend T::Sig
   extend T::Generic

--- a/spec/test_data/models/expected_wand.rbi
+++ b/spec/test_data/models/expected_wand.rbi
@@ -8,6 +8,12 @@ class Wand::Relation < ActiveRecord::Relation
   Elem = type_member(fixed: Wand)
 end
 
+class Wand::CollectionProxy < ActiveRecord::Associations::CollectionProxy
+  include Wand::NamedScope
+  extend T::Generic
+  Elem = type_member(fixed: Wand)
+end
+
 class Wand < ApplicationRecord
   extend T::Sig
   extend T::Generic

--- a/spec/test_data/models/expected_wizard.rbi
+++ b/spec/test_data/models/expected_wizard.rbi
@@ -8,6 +8,12 @@ class Wizard::Relation < ActiveRecord::Relation
   Elem = type_member(fixed: Wizard)
 end
 
+class Wizard::CollectionProxy < ActiveRecord::Associations::CollectionProxy
+  include Wizard::NamedScope
+  extend T::Generic
+  Elem = type_member(fixed: Wizard)
+end
+
 class Wizard < ApplicationRecord
   extend T::Sig
   extend T::Generic
@@ -62,10 +68,10 @@ class Wizard < ApplicationRecord
   sig { params(value: T.nilable(String)).void }
   def parent_email=(value); end
 
-  sig { returns(SpellBook::Relation) }
+  sig { returns(SpellBook::CollectionProxy) }
   def spell_books(); end
 
-  sig { params(value: T.any(T::Array[SpellBook], SpellBook::Relation)).void }
+  sig { params(value: T.any(T::Array[SpellBook], SpellBook::CollectionProxy)).void }
   def spell_books=(value); end
 
   sig { returns(DateTime) }

--- a/spec/test_data/models/expected_wizard_wo_spellbook.rbi
+++ b/spec/test_data/models/expected_wizard_wo_spellbook.rbi
@@ -8,6 +8,12 @@ class Wizard::Relation < ActiveRecord::Relation
   Elem = type_member(fixed: Wizard)
 end
 
+class Wizard::CollectionProxy < ActiveRecord::Associations::CollectionProxy
+  include Wizard::NamedScope
+  extend T::Generic
+  Elem = type_member(fixed: Wizard)
+end
+
 class Wizard < ApplicationRecord
   extend T::Sig
   extend T::Generic
@@ -62,10 +68,10 @@ class Wizard < ApplicationRecord
   sig { params(value: T.nilable(String)).void }
   def parent_email=(value); end
 
-  sig { returns(ActiveRecord::Relation[T.untyped]) }
+  sig { returns(ActiveRecord::Associations::CollectionProxy[T.untyped]) }
   def spell_books(); end
 
-  sig { params(value: T.any(T::Array[SpellBook], ActiveRecord::Relation[T.untyped])).void }
+  sig { params(value: T.any(T::Array[SpellBook], ActiveRecord::Associations::CollectionProxy[T.untyped])).void }
   def spell_books=(value); end
 
   sig { returns(DateTime) }


### PR DESCRIPTION
Add signatures for ActiveRecord::Associations::CollectionProxy and
update generated model definitions for associations to use
CollectionProxy instead of Relation.