### PR TITLE
ActiveRecord "unscoped" query method

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,19 @@ Because Sorbet's initial setup tries to flag files at whichever typecheck level 
 
 It is worth going through the list of files that is ignored and resolve them (and auto upgrade the types of other files; see [initial setup](#initial-setup) above). Usually this will make many more files able to be typechecked.
 
+### `unscoped` with a block
+
+[unscoped method](https://apidock.com/rails/ActiveRecord/Scoping/Default/ClassMethods/unscoped) by default, when no block is provided returns a Relation.
+When a block is provided `unscoped` calls the block and returns its result which type is unknown.
+To avoid that either override `unscoped` definition or in your code replace:
+```ruby
+Model.unscoped do … end
+```
+with
+```ruby
+Model.unscoped.scoping do … end
+```
+
 ## Contributing
 
 Contributions and ideas are welcome! Please see [our contributing guide](CONTRIBUTING.md) and don't hesitate to open an issue or send a pull request to improve the functionality of this gem.

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ It is worth going through the list of files that is ignored and resolve them (an
 
 [unscoped method](https://apidock.com/rails/ActiveRecord/Scoping/Default/ClassMethods/unscoped) by default, when no block is provided returns a Relation.
 When a block is provided `unscoped` calls the block and returns its result which type is unknown.
-To avoid that either override `unscoped` definition or in your code replace:
+The gem opts to define `unscoped` as returning a Relation. To avoid that, either override `unscoped` definition or in your code replace:
 ```ruby
 Model.unscoped do … end
 ```

--- a/lib/sorbet-rails/model_rbi_formatter.rb
+++ b/lib/sorbet-rails/model_rbi_formatter.rb
@@ -342,6 +342,7 @@ class ModelRbiFormatter
         prefix = ""
         prefix = "*" if arg_def[:arg_type] == :rest
         prefix = "**" if arg_def[:arg_type] == :keyrest
+        prefix = "&" if arg_def[:arg_type] == :block
 
         "#{prefix}#{arg_def[:name]}"
       }.join(", ")

--- a/lib/sorbet-rails/model_rbi_formatter.rb
+++ b/lib/sorbet-rails/model_rbi_formatter.rb
@@ -85,7 +85,7 @@ class ModelRbiFormatter
     # rails/activerecord/lib/active_record/querying.rb:21
     @generated_scope_sigs["all"] = { ret: "#{@model_class.name}::Relation" }
     @generated_scope_sigs["unscoped"] = {
-      ret: "T.untyped",
+      ret: "#{@model_class.name}::Relation",
       args: [
         { name: :block, arg_type: :block, value_type: 'T.nilable(T.proc.void)' },
       ]

--- a/lib/sorbet-rails/model_rbi_formatter.rb
+++ b/lib/sorbet-rails/model_rbi_formatter.rb
@@ -84,6 +84,12 @@ class ModelRbiFormatter
     # All is a named scope that most method from ActiveRecord::Querying delegate to
     # rails/activerecord/lib/active_record/querying.rb:21
     @generated_scope_sigs["all"] = { ret: "#{@model_class.name}::Relation" }
+    @generated_scope_sigs["unscoped"] = {
+      ret: "T.untyped",
+      args: [
+        { name: :block, arg_type: :block, value_type: 'T.nilable(T.proc.void)' },
+      ]
+    }
     # It's not possible to typedef all methods in ActiveRecord::Querying module to have the
     # matching type. By generating model-specific sig, we can typedef these methods to return
     # <Model>::Relation class.

--- a/spec/test_data/v4.2/expected_potion.rbi
+++ b/spec/test_data/v4.2/expected_potion.rbi
@@ -39,7 +39,7 @@ module Potion::ModelRelationShared
   sig { returns(Potion::Relation) }
   def all(); end
 
-  sig { params(block: T.nilable(T.proc.void)).returns(T.untyped) }
+  sig { params(block: T.nilable(T.proc.void)).returns(Potion::Relation) }
   def unscoped(block); end
 
   sig { params(args: T.untyped).returns(Potion::Relation) }

--- a/spec/test_data/v4.2/expected_potion.rbi
+++ b/spec/test_data/v4.2/expected_potion.rbi
@@ -39,6 +39,9 @@ module Potion::ModelRelationShared
   sig { returns(Potion::Relation) }
   def all(); end
 
+  sig { params(block: T.nilable(T.proc.void)).returns(T.untyped) }
+  def unscoped(block); end
+
   sig { params(args: T.untyped).returns(Potion::Relation) }
   def recent(*args); end
 

--- a/spec/test_data/v4.2/expected_potion.rbi
+++ b/spec/test_data/v4.2/expected_potion.rbi
@@ -40,75 +40,75 @@ module Potion::ModelRelationShared
   def all(); end
 
   sig { params(block: T.nilable(T.proc.void)).returns(Potion::Relation) }
-  def unscoped(block); end
+  def unscoped(&block); end
 
   sig { params(args: T.untyped).returns(Potion::Relation) }
   def recent(*args); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
-  def select(*args, block); end
+  def select(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
-  def order(*args, block); end
+  def order(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
-  def reorder(*args, block); end
+  def reorder(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
-  def group(*args, block); end
+  def group(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
-  def limit(*args, block); end
+  def limit(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
-  def offset(*args, block); end
+  def offset(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
-  def joins(*args, block); end
+  def joins(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
-  def where(*args, block); end
+  def where(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
-  def rewhere(*args, block); end
+  def rewhere(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
-  def preload(*args, block); end
+  def preload(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
-  def eager_load(*args, block); end
+  def eager_load(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
-  def includes(*args, block); end
+  def includes(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
-  def from(*args, block); end
+  def from(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
-  def lock(*args, block); end
+  def lock(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
-  def readonly(*args, block); end
+  def readonly(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
-  def having(*args, block); end
+  def having(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
-  def create_with(*args, block); end
+  def create_with(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
-  def distinct(*args, block); end
+  def distinct(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
-  def references(*args, block); end
+  def references(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
-  def none(*args, block); end
+  def none(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
-  def unscope(*args, block); end
+  def unscope(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
-  def except(*args, block); end
+  def except(*args, &block); end
 
 end

--- a/spec/test_data/v4.2/expected_spell_book.rbi
+++ b/spec/test_data/v4.2/expected_spell_book.rbi
@@ -72,6 +72,9 @@ module SpellBook::ModelRelationShared
   sig { returns(SpellBook::Relation) }
   def all(); end
 
+  sig { params(block: T.nilable(T.proc.void)).returns(T.untyped) }
+  def unscoped(block); end
+
   sig { params(args: T.untyped).returns(SpellBook::Relation) }
   def recent(*args); end
 

--- a/spec/test_data/v4.2/expected_spell_book.rbi
+++ b/spec/test_data/v4.2/expected_spell_book.rbi
@@ -72,7 +72,7 @@ module SpellBook::ModelRelationShared
   sig { returns(SpellBook::Relation) }
   def all(); end
 
-  sig { params(block: T.nilable(T.proc.void)).returns(T.untyped) }
+  sig { params(block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
   def unscoped(block); end
 
   sig { params(args: T.untyped).returns(SpellBook::Relation) }

--- a/spec/test_data/v4.2/expected_spell_book.rbi
+++ b/spec/test_data/v4.2/expected_spell_book.rbi
@@ -73,75 +73,75 @@ module SpellBook::ModelRelationShared
   def all(); end
 
   sig { params(block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
-  def unscoped(block); end
+  def unscoped(&block); end
 
   sig { params(args: T.untyped).returns(SpellBook::Relation) }
   def recent(*args); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
-  def select(*args, block); end
+  def select(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
-  def order(*args, block); end
+  def order(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
-  def reorder(*args, block); end
+  def reorder(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
-  def group(*args, block); end
+  def group(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
-  def limit(*args, block); end
+  def limit(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
-  def offset(*args, block); end
+  def offset(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
-  def joins(*args, block); end
+  def joins(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
-  def where(*args, block); end
+  def where(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
-  def rewhere(*args, block); end
+  def rewhere(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
-  def preload(*args, block); end
+  def preload(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
-  def eager_load(*args, block); end
+  def eager_load(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
-  def includes(*args, block); end
+  def includes(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
-  def from(*args, block); end
+  def from(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
-  def lock(*args, block); end
+  def lock(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
-  def readonly(*args, block); end
+  def readonly(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
-  def having(*args, block); end
+  def having(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
-  def create_with(*args, block); end
+  def create_with(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
-  def distinct(*args, block); end
+  def distinct(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
-  def references(*args, block); end
+  def references(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
-  def none(*args, block); end
+  def none(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
-  def unscope(*args, block); end
+  def unscope(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
-  def except(*args, block); end
+  def except(*args, &block); end
 
 end

--- a/spec/test_data/v4.2/expected_wand.rbi
+++ b/spec/test_data/v4.2/expected_wand.rbi
@@ -168,6 +168,9 @@ module Wand::ModelRelationShared
   sig { returns(Wand::Relation) }
   def all(); end
 
+  sig { params(block: T.nilable(T.proc.void)).returns(T.untyped) }
+  def unscoped(block); end
+
   sig { params(args: T.untyped).returns(Wand::Relation) }
   def basilisk_horn(*args); end
 

--- a/spec/test_data/v4.2/expected_wand.rbi
+++ b/spec/test_data/v4.2/expected_wand.rbi
@@ -169,7 +169,7 @@ module Wand::ModelRelationShared
   def all(); end
 
   sig { params(block: T.nilable(T.proc.void)).returns(Wand::Relation) }
-  def unscoped(block); end
+  def unscoped(&block); end
 
   sig { params(args: T.untyped).returns(Wand::Relation) }
   def basilisk_horn(*args); end
@@ -187,69 +187,69 @@ module Wand::ModelRelationShared
   def unicorn_tail_hair(*args); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
-  def select(*args, block); end
+  def select(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
-  def order(*args, block); end
+  def order(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
-  def reorder(*args, block); end
+  def reorder(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
-  def group(*args, block); end
+  def group(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
-  def limit(*args, block); end
+  def limit(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
-  def offset(*args, block); end
+  def offset(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
-  def joins(*args, block); end
+  def joins(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
-  def where(*args, block); end
+  def where(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
-  def rewhere(*args, block); end
+  def rewhere(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
-  def preload(*args, block); end
+  def preload(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
-  def eager_load(*args, block); end
+  def eager_load(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
-  def includes(*args, block); end
+  def includes(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
-  def from(*args, block); end
+  def from(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
-  def lock(*args, block); end
+  def lock(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
-  def readonly(*args, block); end
+  def readonly(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
-  def having(*args, block); end
+  def having(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
-  def create_with(*args, block); end
+  def create_with(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
-  def distinct(*args, block); end
+  def distinct(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
-  def references(*args, block); end
+  def references(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
-  def none(*args, block); end
+  def none(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
-  def unscope(*args, block); end
+  def unscope(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
-  def except(*args, block); end
+  def except(*args, &block); end
 
 end

--- a/spec/test_data/v4.2/expected_wand.rbi
+++ b/spec/test_data/v4.2/expected_wand.rbi
@@ -168,7 +168,7 @@ module Wand::ModelRelationShared
   sig { returns(Wand::Relation) }
   def all(); end
 
-  sig { params(block: T.nilable(T.proc.void)).returns(T.untyped) }
+  sig { params(block: T.nilable(T.proc.void)).returns(Wand::Relation) }
   def unscoped(block); end
 
   sig { params(args: T.untyped).returns(Wand::Relation) }

--- a/spec/test_data/v4.2/expected_wizard.rbi
+++ b/spec/test_data/v4.2/expected_wizard.rbi
@@ -129,7 +129,7 @@ module Wizard::ModelRelationShared
   sig { returns(Wizard::Relation) }
   def all(); end
 
-  sig { params(block: T.nilable(T.proc.void)).returns(T.untyped) }
+  sig { params(block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
   def unscoped(block); end
 
   sig { params(args: T.untyped).returns(Wizard::Relation) }

--- a/spec/test_data/v4.2/expected_wizard.rbi
+++ b/spec/test_data/v4.2/expected_wizard.rbi
@@ -129,6 +129,9 @@ module Wizard::ModelRelationShared
   sig { returns(Wizard::Relation) }
   def all(); end
 
+  sig { params(block: T.nilable(T.proc.void)).returns(T.untyped) }
+  def unscoped(block); end
+
   sig { params(args: T.untyped).returns(Wizard::Relation) }
   def Gryffindor(*args); end
 

--- a/spec/test_data/v4.2/expected_wizard.rbi
+++ b/spec/test_data/v4.2/expected_wizard.rbi
@@ -130,7 +130,7 @@ module Wizard::ModelRelationShared
   def all(); end
 
   sig { params(block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def unscoped(block); end
+  def unscoped(&block); end
 
   sig { params(args: T.untyped).returns(Wizard::Relation) }
   def Gryffindor(*args); end
@@ -148,69 +148,69 @@ module Wizard::ModelRelationShared
   def recent(*args); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def select(*args, block); end
+  def select(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def order(*args, block); end
+  def order(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def reorder(*args, block); end
+  def reorder(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def group(*args, block); end
+  def group(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def limit(*args, block); end
+  def limit(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def offset(*args, block); end
+  def offset(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def joins(*args, block); end
+  def joins(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def where(*args, block); end
+  def where(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def rewhere(*args, block); end
+  def rewhere(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def preload(*args, block); end
+  def preload(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def eager_load(*args, block); end
+  def eager_load(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def includes(*args, block); end
+  def includes(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def from(*args, block); end
+  def from(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def lock(*args, block); end
+  def lock(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def readonly(*args, block); end
+  def readonly(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def having(*args, block); end
+  def having(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def create_with(*args, block); end
+  def create_with(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def distinct(*args, block); end
+  def distinct(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def references(*args, block); end
+  def references(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def none(*args, block); end
+  def none(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def unscope(*args, block); end
+  def unscope(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def except(*args, block); end
+  def except(*args, &block); end
 
 end

--- a/spec/test_data/v4.2/expected_wizard_wo_spellbook.rbi
+++ b/spec/test_data/v4.2/expected_wizard_wo_spellbook.rbi
@@ -129,7 +129,7 @@ module Wizard::ModelRelationShared
   sig { returns(Wizard::Relation) }
   def all(); end
 
-  sig { params(block: T.nilable(T.proc.void)).returns(T.untyped) }
+  sig { params(block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
   def unscoped(block); end
 
   sig { params(args: T.untyped).returns(Wizard::Relation) }

--- a/spec/test_data/v4.2/expected_wizard_wo_spellbook.rbi
+++ b/spec/test_data/v4.2/expected_wizard_wo_spellbook.rbi
@@ -129,6 +129,9 @@ module Wizard::ModelRelationShared
   sig { returns(Wizard::Relation) }
   def all(); end
 
+  sig { params(block: T.nilable(T.proc.void)).returns(T.untyped) }
+  def unscoped(block); end
+
   sig { params(args: T.untyped).returns(Wizard::Relation) }
   def Gryffindor(*args); end
 

--- a/spec/test_data/v4.2/expected_wizard_wo_spellbook.rbi
+++ b/spec/test_data/v4.2/expected_wizard_wo_spellbook.rbi
@@ -130,7 +130,7 @@ module Wizard::ModelRelationShared
   def all(); end
 
   sig { params(block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def unscoped(block); end
+  def unscoped(&block); end
 
   sig { params(args: T.untyped).returns(Wizard::Relation) }
   def Gryffindor(*args); end
@@ -148,69 +148,69 @@ module Wizard::ModelRelationShared
   def recent(*args); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def select(*args, block); end
+  def select(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def order(*args, block); end
+  def order(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def reorder(*args, block); end
+  def reorder(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def group(*args, block); end
+  def group(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def limit(*args, block); end
+  def limit(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def offset(*args, block); end
+  def offset(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def joins(*args, block); end
+  def joins(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def where(*args, block); end
+  def where(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def rewhere(*args, block); end
+  def rewhere(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def preload(*args, block); end
+  def preload(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def eager_load(*args, block); end
+  def eager_load(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def includes(*args, block); end
+  def includes(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def from(*args, block); end
+  def from(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def lock(*args, block); end
+  def lock(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def readonly(*args, block); end
+  def readonly(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def having(*args, block); end
+  def having(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def create_with(*args, block); end
+  def create_with(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def distinct(*args, block); end
+  def distinct(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def references(*args, block); end
+  def references(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def none(*args, block); end
+  def none(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def unscope(*args, block); end
+  def unscope(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def except(*args, block); end
+  def except(*args, &block); end
 
 end

--- a/spec/test_data/v5.0/expected_potion.rbi
+++ b/spec/test_data/v5.0/expected_potion.rbi
@@ -39,7 +39,7 @@ module Potion::ModelRelationShared
   sig { returns(Potion::Relation) }
   def all(); end
 
-  sig { params(block: T.nilable(T.proc.void)).returns(T.untyped) }
+  sig { params(block: T.nilable(T.proc.void)).returns(Potion::Relation) }
   def unscoped(block); end
 
   sig { params(args: T.untyped).returns(Potion::Relation) }

--- a/spec/test_data/v5.0/expected_potion.rbi
+++ b/spec/test_data/v5.0/expected_potion.rbi
@@ -40,84 +40,84 @@ module Potion::ModelRelationShared
   def all(); end
 
   sig { params(block: T.nilable(T.proc.void)).returns(Potion::Relation) }
-  def unscoped(block); end
+  def unscoped(&block); end
 
   sig { params(args: T.untyped).returns(Potion::Relation) }
   def recent(*args); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
-  def select(*args, block); end
+  def select(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
-  def order(*args, block); end
+  def order(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
-  def reorder(*args, block); end
+  def reorder(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
-  def group(*args, block); end
+  def group(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
-  def limit(*args, block); end
+  def limit(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
-  def offset(*args, block); end
+  def offset(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
-  def joins(*args, block); end
+  def joins(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
-  def left_joins(*args, block); end
+  def left_joins(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
-  def left_outer_joins(*args, block); end
+  def left_outer_joins(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
-  def where(*args, block); end
+  def where(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
-  def rewhere(*args, block); end
+  def rewhere(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
-  def preload(*args, block); end
+  def preload(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
-  def eager_load(*args, block); end
+  def eager_load(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
-  def includes(*args, block); end
+  def includes(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
-  def from(*args, block); end
+  def from(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
-  def lock(*args, block); end
+  def lock(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
-  def readonly(*args, block); end
+  def readonly(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
-  def or(*args, block); end
+  def or(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
-  def having(*args, block); end
+  def having(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
-  def create_with(*args, block); end
+  def create_with(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
-  def distinct(*args, block); end
+  def distinct(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
-  def references(*args, block); end
+  def references(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
-  def none(*args, block); end
+  def none(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
-  def unscope(*args, block); end
+  def unscope(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
-  def except(*args, block); end
+  def except(*args, &block); end
 
 end

--- a/spec/test_data/v5.0/expected_potion.rbi
+++ b/spec/test_data/v5.0/expected_potion.rbi
@@ -39,6 +39,9 @@ module Potion::ModelRelationShared
   sig { returns(Potion::Relation) }
   def all(); end
 
+  sig { params(block: T.nilable(T.proc.void)).returns(T.untyped) }
+  def unscoped(block); end
+
   sig { params(args: T.untyped).returns(Potion::Relation) }
   def recent(*args); end
 

--- a/spec/test_data/v5.0/expected_spell_book.rbi
+++ b/spec/test_data/v5.0/expected_spell_book.rbi
@@ -72,6 +72,9 @@ module SpellBook::ModelRelationShared
   sig { returns(SpellBook::Relation) }
   def all(); end
 
+  sig { params(block: T.nilable(T.proc.void)).returns(T.untyped) }
+  def unscoped(block); end
+
   sig { params(args: T.untyped).returns(SpellBook::Relation) }
   def recent(*args); end
 

--- a/spec/test_data/v5.0/expected_spell_book.rbi
+++ b/spec/test_data/v5.0/expected_spell_book.rbi
@@ -73,84 +73,84 @@ module SpellBook::ModelRelationShared
   def all(); end
 
   sig { params(block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
-  def unscoped(block); end
+  def unscoped(&block); end
 
   sig { params(args: T.untyped).returns(SpellBook::Relation) }
   def recent(*args); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
-  def select(*args, block); end
+  def select(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
-  def order(*args, block); end
+  def order(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
-  def reorder(*args, block); end
+  def reorder(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
-  def group(*args, block); end
+  def group(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
-  def limit(*args, block); end
+  def limit(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
-  def offset(*args, block); end
+  def offset(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
-  def joins(*args, block); end
+  def joins(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
-  def left_joins(*args, block); end
+  def left_joins(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
-  def left_outer_joins(*args, block); end
+  def left_outer_joins(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
-  def where(*args, block); end
+  def where(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
-  def rewhere(*args, block); end
+  def rewhere(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
-  def preload(*args, block); end
+  def preload(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
-  def eager_load(*args, block); end
+  def eager_load(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
-  def includes(*args, block); end
+  def includes(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
-  def from(*args, block); end
+  def from(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
-  def lock(*args, block); end
+  def lock(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
-  def readonly(*args, block); end
+  def readonly(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
-  def or(*args, block); end
+  def or(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
-  def having(*args, block); end
+  def having(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
-  def create_with(*args, block); end
+  def create_with(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
-  def distinct(*args, block); end
+  def distinct(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
-  def references(*args, block); end
+  def references(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
-  def none(*args, block); end
+  def none(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
-  def unscope(*args, block); end
+  def unscope(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
-  def except(*args, block); end
+  def except(*args, &block); end
 
 end

--- a/spec/test_data/v5.0/expected_spell_book.rbi
+++ b/spec/test_data/v5.0/expected_spell_book.rbi
@@ -72,7 +72,7 @@ module SpellBook::ModelRelationShared
   sig { returns(SpellBook::Relation) }
   def all(); end
 
-  sig { params(block: T.nilable(T.proc.void)).returns(T.untyped) }
+  sig { params(block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
   def unscoped(block); end
 
   sig { params(args: T.untyped).returns(SpellBook::Relation) }

--- a/spec/test_data/v5.0/expected_wand.rbi
+++ b/spec/test_data/v5.0/expected_wand.rbi
@@ -168,6 +168,9 @@ module Wand::ModelRelationShared
   sig { returns(Wand::Relation) }
   def all(); end
 
+  sig { params(block: T.nilable(T.proc.void)).returns(T.untyped) }
+  def unscoped(block); end
+
   sig { params(args: T.untyped).returns(Wand::Relation) }
   def basilisk_horn(*args); end
 

--- a/spec/test_data/v5.0/expected_wand.rbi
+++ b/spec/test_data/v5.0/expected_wand.rbi
@@ -169,7 +169,7 @@ module Wand::ModelRelationShared
   def all(); end
 
   sig { params(block: T.nilable(T.proc.void)).returns(Wand::Relation) }
-  def unscoped(block); end
+  def unscoped(&block); end
 
   sig { params(args: T.untyped).returns(Wand::Relation) }
   def basilisk_horn(*args); end
@@ -187,78 +187,78 @@ module Wand::ModelRelationShared
   def unicorn_tail_hair(*args); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
-  def select(*args, block); end
+  def select(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
-  def order(*args, block); end
+  def order(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
-  def reorder(*args, block); end
+  def reorder(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
-  def group(*args, block); end
+  def group(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
-  def limit(*args, block); end
+  def limit(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
-  def offset(*args, block); end
+  def offset(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
-  def joins(*args, block); end
+  def joins(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
-  def left_joins(*args, block); end
+  def left_joins(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
-  def left_outer_joins(*args, block); end
+  def left_outer_joins(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
-  def where(*args, block); end
+  def where(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
-  def rewhere(*args, block); end
+  def rewhere(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
-  def preload(*args, block); end
+  def preload(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
-  def eager_load(*args, block); end
+  def eager_load(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
-  def includes(*args, block); end
+  def includes(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
-  def from(*args, block); end
+  def from(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
-  def lock(*args, block); end
+  def lock(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
-  def readonly(*args, block); end
+  def readonly(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
-  def or(*args, block); end
+  def or(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
-  def having(*args, block); end
+  def having(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
-  def create_with(*args, block); end
+  def create_with(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
-  def distinct(*args, block); end
+  def distinct(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
-  def references(*args, block); end
+  def references(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
-  def none(*args, block); end
+  def none(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
-  def unscope(*args, block); end
+  def unscope(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
-  def except(*args, block); end
+  def except(*args, &block); end
 
 end

--- a/spec/test_data/v5.0/expected_wand.rbi
+++ b/spec/test_data/v5.0/expected_wand.rbi
@@ -168,7 +168,7 @@ module Wand::ModelRelationShared
   sig { returns(Wand::Relation) }
   def all(); end
 
-  sig { params(block: T.nilable(T.proc.void)).returns(T.untyped) }
+  sig { params(block: T.nilable(T.proc.void)).returns(Wand::Relation) }
   def unscoped(block); end
 
   sig { params(args: T.untyped).returns(Wand::Relation) }

--- a/spec/test_data/v5.0/expected_wizard.rbi
+++ b/spec/test_data/v5.0/expected_wizard.rbi
@@ -130,7 +130,7 @@ module Wizard::ModelRelationShared
   def all(); end
 
   sig { params(block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def unscoped(block); end
+  def unscoped(&block); end
 
   sig { params(args: T.untyped).returns(Wizard::Relation) }
   def Gryffindor(*args); end
@@ -148,78 +148,78 @@ module Wizard::ModelRelationShared
   def recent(*args); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def select(*args, block); end
+  def select(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def order(*args, block); end
+  def order(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def reorder(*args, block); end
+  def reorder(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def group(*args, block); end
+  def group(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def limit(*args, block); end
+  def limit(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def offset(*args, block); end
+  def offset(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def joins(*args, block); end
+  def joins(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def left_joins(*args, block); end
+  def left_joins(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def left_outer_joins(*args, block); end
+  def left_outer_joins(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def where(*args, block); end
+  def where(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def rewhere(*args, block); end
+  def rewhere(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def preload(*args, block); end
+  def preload(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def eager_load(*args, block); end
+  def eager_load(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def includes(*args, block); end
+  def includes(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def from(*args, block); end
+  def from(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def lock(*args, block); end
+  def lock(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def readonly(*args, block); end
+  def readonly(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def or(*args, block); end
+  def or(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def having(*args, block); end
+  def having(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def create_with(*args, block); end
+  def create_with(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def distinct(*args, block); end
+  def distinct(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def references(*args, block); end
+  def references(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def none(*args, block); end
+  def none(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def unscope(*args, block); end
+  def unscope(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def except(*args, block); end
+  def except(*args, &block); end
 
 end

--- a/spec/test_data/v5.0/expected_wizard.rbi
+++ b/spec/test_data/v5.0/expected_wizard.rbi
@@ -129,7 +129,7 @@ module Wizard::ModelRelationShared
   sig { returns(Wizard::Relation) }
   def all(); end
 
-  sig { params(block: T.nilable(T.proc.void)).returns(T.untyped) }
+  sig { params(block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
   def unscoped(block); end
 
   sig { params(args: T.untyped).returns(Wizard::Relation) }

--- a/spec/test_data/v5.0/expected_wizard.rbi
+++ b/spec/test_data/v5.0/expected_wizard.rbi
@@ -129,6 +129,9 @@ module Wizard::ModelRelationShared
   sig { returns(Wizard::Relation) }
   def all(); end
 
+  sig { params(block: T.nilable(T.proc.void)).returns(T.untyped) }
+  def unscoped(block); end
+
   sig { params(args: T.untyped).returns(Wizard::Relation) }
   def Gryffindor(*args); end
 

--- a/spec/test_data/v5.0/expected_wizard_wo_spellbook.rbi
+++ b/spec/test_data/v5.0/expected_wizard_wo_spellbook.rbi
@@ -130,7 +130,7 @@ module Wizard::ModelRelationShared
   def all(); end
 
   sig { params(block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def unscoped(block); end
+  def unscoped(&block); end
 
   sig { params(args: T.untyped).returns(Wizard::Relation) }
   def Gryffindor(*args); end
@@ -148,78 +148,78 @@ module Wizard::ModelRelationShared
   def recent(*args); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def select(*args, block); end
+  def select(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def order(*args, block); end
+  def order(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def reorder(*args, block); end
+  def reorder(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def group(*args, block); end
+  def group(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def limit(*args, block); end
+  def limit(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def offset(*args, block); end
+  def offset(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def joins(*args, block); end
+  def joins(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def left_joins(*args, block); end
+  def left_joins(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def left_outer_joins(*args, block); end
+  def left_outer_joins(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def where(*args, block); end
+  def where(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def rewhere(*args, block); end
+  def rewhere(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def preload(*args, block); end
+  def preload(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def eager_load(*args, block); end
+  def eager_load(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def includes(*args, block); end
+  def includes(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def from(*args, block); end
+  def from(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def lock(*args, block); end
+  def lock(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def readonly(*args, block); end
+  def readonly(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def or(*args, block); end
+  def or(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def having(*args, block); end
+  def having(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def create_with(*args, block); end
+  def create_with(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def distinct(*args, block); end
+  def distinct(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def references(*args, block); end
+  def references(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def none(*args, block); end
+  def none(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def unscope(*args, block); end
+  def unscope(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def except(*args, block); end
+  def except(*args, &block); end
 
 end

--- a/spec/test_data/v5.0/expected_wizard_wo_spellbook.rbi
+++ b/spec/test_data/v5.0/expected_wizard_wo_spellbook.rbi
@@ -129,7 +129,7 @@ module Wizard::ModelRelationShared
   sig { returns(Wizard::Relation) }
   def all(); end
 
-  sig { params(block: T.nilable(T.proc.void)).returns(T.untyped) }
+  sig { params(block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
   def unscoped(block); end
 
   sig { params(args: T.untyped).returns(Wizard::Relation) }

--- a/spec/test_data/v5.0/expected_wizard_wo_spellbook.rbi
+++ b/spec/test_data/v5.0/expected_wizard_wo_spellbook.rbi
@@ -129,6 +129,9 @@ module Wizard::ModelRelationShared
   sig { returns(Wizard::Relation) }
   def all(); end
 
+  sig { params(block: T.nilable(T.proc.void)).returns(T.untyped) }
+  def unscoped(block); end
+
   sig { params(args: T.untyped).returns(Wizard::Relation) }
   def Gryffindor(*args); end
 

--- a/spec/test_data/v5.1/expected_potion.rbi
+++ b/spec/test_data/v5.1/expected_potion.rbi
@@ -40,90 +40,90 @@ module Potion::ModelRelationShared
   def all(); end
 
   sig { params(block: T.nilable(T.proc.void)).returns(Potion::Relation) }
-  def unscoped(block); end
+  def unscoped(&block); end
 
   sig { params(args: T.untyped).returns(Potion::Relation) }
   def recent(*args); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
-  def select(*args, block); end
+  def select(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
-  def order(*args, block); end
+  def order(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
-  def reorder(*args, block); end
+  def reorder(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
-  def group(*args, block); end
+  def group(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
-  def limit(*args, block); end
+  def limit(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
-  def offset(*args, block); end
+  def offset(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
-  def joins(*args, block); end
+  def joins(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
-  def left_joins(*args, block); end
+  def left_joins(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
-  def left_outer_joins(*args, block); end
+  def left_outer_joins(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
-  def where(*args, block); end
+  def where(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
-  def rewhere(*args, block); end
+  def rewhere(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
-  def preload(*args, block); end
+  def preload(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
-  def eager_load(*args, block); end
+  def eager_load(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
-  def includes(*args, block); end
+  def includes(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
-  def from(*args, block); end
+  def from(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
-  def lock(*args, block); end
+  def lock(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
-  def readonly(*args, block); end
+  def readonly(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
-  def extending(*args, block); end
+  def extending(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
-  def or(*args, block); end
+  def or(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
-  def having(*args, block); end
+  def having(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
-  def create_with(*args, block); end
+  def create_with(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
-  def distinct(*args, block); end
+  def distinct(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
-  def references(*args, block); end
+  def references(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
-  def none(*args, block); end
+  def none(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
-  def unscope(*args, block); end
+  def unscope(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
-  def merge(*args, block); end
+  def merge(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
-  def except(*args, block); end
+  def except(*args, &block); end
 
 end

--- a/spec/test_data/v5.1/expected_potion.rbi
+++ b/spec/test_data/v5.1/expected_potion.rbi
@@ -39,7 +39,7 @@ module Potion::ModelRelationShared
   sig { returns(Potion::Relation) }
   def all(); end
 
-  sig { params(block: T.nilable(T.proc.void)).returns(T.untyped) }
+  sig { params(block: T.nilable(T.proc.void)).returns(Potion::Relation) }
   def unscoped(block); end
 
   sig { params(args: T.untyped).returns(Potion::Relation) }

--- a/spec/test_data/v5.1/expected_potion.rbi
+++ b/spec/test_data/v5.1/expected_potion.rbi
@@ -39,6 +39,9 @@ module Potion::ModelRelationShared
   sig { returns(Potion::Relation) }
   def all(); end
 
+  sig { params(block: T.nilable(T.proc.void)).returns(T.untyped) }
+  def unscoped(block); end
+
   sig { params(args: T.untyped).returns(Potion::Relation) }
   def recent(*args); end
 

--- a/spec/test_data/v5.1/expected_spell_book.rbi
+++ b/spec/test_data/v5.1/expected_spell_book.rbi
@@ -72,6 +72,9 @@ module SpellBook::ModelRelationShared
   sig { returns(SpellBook::Relation) }
   def all(); end
 
+  sig { params(block: T.nilable(T.proc.void)).returns(T.untyped) }
+  def unscoped(block); end
+
   sig { params(args: T.untyped).returns(SpellBook::Relation) }
   def recent(*args); end
 

--- a/spec/test_data/v5.1/expected_spell_book.rbi
+++ b/spec/test_data/v5.1/expected_spell_book.rbi
@@ -72,7 +72,7 @@ module SpellBook::ModelRelationShared
   sig { returns(SpellBook::Relation) }
   def all(); end
 
-  sig { params(block: T.nilable(T.proc.void)).returns(T.untyped) }
+  sig { params(block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
   def unscoped(block); end
 
   sig { params(args: T.untyped).returns(SpellBook::Relation) }

--- a/spec/test_data/v5.1/expected_spell_book.rbi
+++ b/spec/test_data/v5.1/expected_spell_book.rbi
@@ -73,90 +73,90 @@ module SpellBook::ModelRelationShared
   def all(); end
 
   sig { params(block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
-  def unscoped(block); end
+  def unscoped(&block); end
 
   sig { params(args: T.untyped).returns(SpellBook::Relation) }
   def recent(*args); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
-  def select(*args, block); end
+  def select(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
-  def order(*args, block); end
+  def order(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
-  def reorder(*args, block); end
+  def reorder(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
-  def group(*args, block); end
+  def group(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
-  def limit(*args, block); end
+  def limit(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
-  def offset(*args, block); end
+  def offset(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
-  def joins(*args, block); end
+  def joins(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
-  def left_joins(*args, block); end
+  def left_joins(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
-  def left_outer_joins(*args, block); end
+  def left_outer_joins(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
-  def where(*args, block); end
+  def where(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
-  def rewhere(*args, block); end
+  def rewhere(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
-  def preload(*args, block); end
+  def preload(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
-  def eager_load(*args, block); end
+  def eager_load(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
-  def includes(*args, block); end
+  def includes(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
-  def from(*args, block); end
+  def from(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
-  def lock(*args, block); end
+  def lock(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
-  def readonly(*args, block); end
+  def readonly(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
-  def extending(*args, block); end
+  def extending(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
-  def or(*args, block); end
+  def or(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
-  def having(*args, block); end
+  def having(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
-  def create_with(*args, block); end
+  def create_with(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
-  def distinct(*args, block); end
+  def distinct(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
-  def references(*args, block); end
+  def references(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
-  def none(*args, block); end
+  def none(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
-  def unscope(*args, block); end
+  def unscope(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
-  def merge(*args, block); end
+  def merge(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
-  def except(*args, block); end
+  def except(*args, &block); end
 
 end

--- a/spec/test_data/v5.1/expected_wand.rbi
+++ b/spec/test_data/v5.1/expected_wand.rbi
@@ -168,6 +168,9 @@ module Wand::ModelRelationShared
   sig { returns(Wand::Relation) }
   def all(); end
 
+  sig { params(block: T.nilable(T.proc.void)).returns(T.untyped) }
+  def unscoped(block); end
+
   sig { params(args: T.untyped).returns(Wand::Relation) }
   def basilisk_horn(*args); end
 

--- a/spec/test_data/v5.1/expected_wand.rbi
+++ b/spec/test_data/v5.1/expected_wand.rbi
@@ -169,7 +169,7 @@ module Wand::ModelRelationShared
   def all(); end
 
   sig { params(block: T.nilable(T.proc.void)).returns(Wand::Relation) }
-  def unscoped(block); end
+  def unscoped(&block); end
 
   sig { params(args: T.untyped).returns(Wand::Relation) }
   def basilisk_horn(*args); end
@@ -187,84 +187,84 @@ module Wand::ModelRelationShared
   def unicorn_tail_hair(*args); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
-  def select(*args, block); end
+  def select(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
-  def order(*args, block); end
+  def order(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
-  def reorder(*args, block); end
+  def reorder(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
-  def group(*args, block); end
+  def group(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
-  def limit(*args, block); end
+  def limit(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
-  def offset(*args, block); end
+  def offset(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
-  def joins(*args, block); end
+  def joins(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
-  def left_joins(*args, block); end
+  def left_joins(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
-  def left_outer_joins(*args, block); end
+  def left_outer_joins(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
-  def where(*args, block); end
+  def where(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
-  def rewhere(*args, block); end
+  def rewhere(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
-  def preload(*args, block); end
+  def preload(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
-  def eager_load(*args, block); end
+  def eager_load(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
-  def includes(*args, block); end
+  def includes(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
-  def from(*args, block); end
+  def from(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
-  def lock(*args, block); end
+  def lock(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
-  def readonly(*args, block); end
+  def readonly(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
-  def extending(*args, block); end
+  def extending(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
-  def or(*args, block); end
+  def or(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
-  def having(*args, block); end
+  def having(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
-  def create_with(*args, block); end
+  def create_with(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
-  def distinct(*args, block); end
+  def distinct(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
-  def references(*args, block); end
+  def references(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
-  def none(*args, block); end
+  def none(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
-  def unscope(*args, block); end
+  def unscope(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
-  def merge(*args, block); end
+  def merge(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
-  def except(*args, block); end
+  def except(*args, &block); end
 
 end

--- a/spec/test_data/v5.1/expected_wand.rbi
+++ b/spec/test_data/v5.1/expected_wand.rbi
@@ -168,7 +168,7 @@ module Wand::ModelRelationShared
   sig { returns(Wand::Relation) }
   def all(); end
 
-  sig { params(block: T.nilable(T.proc.void)).returns(T.untyped) }
+  sig { params(block: T.nilable(T.proc.void)).returns(Wand::Relation) }
   def unscoped(block); end
 
   sig { params(args: T.untyped).returns(Wand::Relation) }

--- a/spec/test_data/v5.1/expected_wizard.rbi
+++ b/spec/test_data/v5.1/expected_wizard.rbi
@@ -129,7 +129,7 @@ module Wizard::ModelRelationShared
   sig { returns(Wizard::Relation) }
   def all(); end
 
-  sig { params(block: T.nilable(T.proc.void)).returns(T.untyped) }
+  sig { params(block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
   def unscoped(block); end
 
   sig { params(args: T.untyped).returns(Wizard::Relation) }

--- a/spec/test_data/v5.1/expected_wizard.rbi
+++ b/spec/test_data/v5.1/expected_wizard.rbi
@@ -129,6 +129,9 @@ module Wizard::ModelRelationShared
   sig { returns(Wizard::Relation) }
   def all(); end
 
+  sig { params(block: T.nilable(T.proc.void)).returns(T.untyped) }
+  def unscoped(block); end
+
   sig { params(args: T.untyped).returns(Wizard::Relation) }
   def Gryffindor(*args); end
 

--- a/spec/test_data/v5.1/expected_wizard.rbi
+++ b/spec/test_data/v5.1/expected_wizard.rbi
@@ -130,7 +130,7 @@ module Wizard::ModelRelationShared
   def all(); end
 
   sig { params(block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def unscoped(block); end
+  def unscoped(&block); end
 
   sig { params(args: T.untyped).returns(Wizard::Relation) }
   def Gryffindor(*args); end
@@ -148,84 +148,84 @@ module Wizard::ModelRelationShared
   def recent(*args); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def select(*args, block); end
+  def select(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def order(*args, block); end
+  def order(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def reorder(*args, block); end
+  def reorder(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def group(*args, block); end
+  def group(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def limit(*args, block); end
+  def limit(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def offset(*args, block); end
+  def offset(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def joins(*args, block); end
+  def joins(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def left_joins(*args, block); end
+  def left_joins(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def left_outer_joins(*args, block); end
+  def left_outer_joins(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def where(*args, block); end
+  def where(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def rewhere(*args, block); end
+  def rewhere(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def preload(*args, block); end
+  def preload(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def eager_load(*args, block); end
+  def eager_load(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def includes(*args, block); end
+  def includes(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def from(*args, block); end
+  def from(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def lock(*args, block); end
+  def lock(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def readonly(*args, block); end
+  def readonly(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def extending(*args, block); end
+  def extending(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def or(*args, block); end
+  def or(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def having(*args, block); end
+  def having(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def create_with(*args, block); end
+  def create_with(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def distinct(*args, block); end
+  def distinct(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def references(*args, block); end
+  def references(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def none(*args, block); end
+  def none(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def unscope(*args, block); end
+  def unscope(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def merge(*args, block); end
+  def merge(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def except(*args, block); end
+  def except(*args, &block); end
 
 end

--- a/spec/test_data/v5.1/expected_wizard_wo_spellbook.rbi
+++ b/spec/test_data/v5.1/expected_wizard_wo_spellbook.rbi
@@ -129,7 +129,7 @@ module Wizard::ModelRelationShared
   sig { returns(Wizard::Relation) }
   def all(); end
 
-  sig { params(block: T.nilable(T.proc.void)).returns(T.untyped) }
+  sig { params(block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
   def unscoped(block); end
 
   sig { params(args: T.untyped).returns(Wizard::Relation) }

--- a/spec/test_data/v5.1/expected_wizard_wo_spellbook.rbi
+++ b/spec/test_data/v5.1/expected_wizard_wo_spellbook.rbi
@@ -129,6 +129,9 @@ module Wizard::ModelRelationShared
   sig { returns(Wizard::Relation) }
   def all(); end
 
+  sig { params(block: T.nilable(T.proc.void)).returns(T.untyped) }
+  def unscoped(block); end
+
   sig { params(args: T.untyped).returns(Wizard::Relation) }
   def Gryffindor(*args); end
 

--- a/spec/test_data/v5.1/expected_wizard_wo_spellbook.rbi
+++ b/spec/test_data/v5.1/expected_wizard_wo_spellbook.rbi
@@ -130,7 +130,7 @@ module Wizard::ModelRelationShared
   def all(); end
 
   sig { params(block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def unscoped(block); end
+  def unscoped(&block); end
 
   sig { params(args: T.untyped).returns(Wizard::Relation) }
   def Gryffindor(*args); end
@@ -148,84 +148,84 @@ module Wizard::ModelRelationShared
   def recent(*args); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def select(*args, block); end
+  def select(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def order(*args, block); end
+  def order(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def reorder(*args, block); end
+  def reorder(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def group(*args, block); end
+  def group(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def limit(*args, block); end
+  def limit(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def offset(*args, block); end
+  def offset(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def joins(*args, block); end
+  def joins(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def left_joins(*args, block); end
+  def left_joins(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def left_outer_joins(*args, block); end
+  def left_outer_joins(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def where(*args, block); end
+  def where(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def rewhere(*args, block); end
+  def rewhere(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def preload(*args, block); end
+  def preload(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def eager_load(*args, block); end
+  def eager_load(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def includes(*args, block); end
+  def includes(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def from(*args, block); end
+  def from(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def lock(*args, block); end
+  def lock(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def readonly(*args, block); end
+  def readonly(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def extending(*args, block); end
+  def extending(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def or(*args, block); end
+  def or(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def having(*args, block); end
+  def having(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def create_with(*args, block); end
+  def create_with(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def distinct(*args, block); end
+  def distinct(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def references(*args, block); end
+  def references(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def none(*args, block); end
+  def none(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def unscope(*args, block); end
+  def unscope(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def merge(*args, block); end
+  def merge(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def except(*args, block); end
+  def except(*args, &block); end
 
 end

--- a/spec/test_data/v5.2/expected_potion.rbi
+++ b/spec/test_data/v5.2/expected_potion.rbi
@@ -40,90 +40,90 @@ module Potion::ModelRelationShared
   def all(); end
 
   sig { params(block: T.nilable(T.proc.void)).returns(Potion::Relation) }
-  def unscoped(block); end
+  def unscoped(&block); end
 
   sig { params(args: T.untyped).returns(Potion::Relation) }
   def recent(*args); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
-  def select(*args, block); end
+  def select(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
-  def order(*args, block); end
+  def order(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
-  def reorder(*args, block); end
+  def reorder(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
-  def group(*args, block); end
+  def group(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
-  def limit(*args, block); end
+  def limit(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
-  def offset(*args, block); end
+  def offset(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
-  def joins(*args, block); end
+  def joins(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
-  def left_joins(*args, block); end
+  def left_joins(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
-  def left_outer_joins(*args, block); end
+  def left_outer_joins(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
-  def where(*args, block); end
+  def where(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
-  def rewhere(*args, block); end
+  def rewhere(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
-  def preload(*args, block); end
+  def preload(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
-  def eager_load(*args, block); end
+  def eager_load(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
-  def includes(*args, block); end
+  def includes(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
-  def from(*args, block); end
+  def from(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
-  def lock(*args, block); end
+  def lock(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
-  def readonly(*args, block); end
+  def readonly(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
-  def extending(*args, block); end
+  def extending(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
-  def or(*args, block); end
+  def or(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
-  def having(*args, block); end
+  def having(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
-  def create_with(*args, block); end
+  def create_with(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
-  def distinct(*args, block); end
+  def distinct(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
-  def references(*args, block); end
+  def references(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
-  def none(*args, block); end
+  def none(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
-  def unscope(*args, block); end
+  def unscope(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
-  def merge(*args, block); end
+  def merge(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
-  def except(*args, block); end
+  def except(*args, &block); end
 
 end

--- a/spec/test_data/v5.2/expected_potion.rbi
+++ b/spec/test_data/v5.2/expected_potion.rbi
@@ -39,7 +39,7 @@ module Potion::ModelRelationShared
   sig { returns(Potion::Relation) }
   def all(); end
 
-  sig { params(block: T.nilable(T.proc.void)).returns(T.untyped) }
+  sig { params(block: T.nilable(T.proc.void)).returns(Potion::Relation) }
   def unscoped(block); end
 
   sig { params(args: T.untyped).returns(Potion::Relation) }

--- a/spec/test_data/v5.2/expected_potion.rbi
+++ b/spec/test_data/v5.2/expected_potion.rbi
@@ -39,6 +39,9 @@ module Potion::ModelRelationShared
   sig { returns(Potion::Relation) }
   def all(); end
 
+  sig { params(block: T.nilable(T.proc.void)).returns(T.untyped) }
+  def unscoped(block); end
+
   sig { params(args: T.untyped).returns(Potion::Relation) }
   def recent(*args); end
 

--- a/spec/test_data/v5.2/expected_spell_book.rbi
+++ b/spec/test_data/v5.2/expected_spell_book.rbi
@@ -72,6 +72,9 @@ module SpellBook::ModelRelationShared
   sig { returns(SpellBook::Relation) }
   def all(); end
 
+  sig { params(block: T.nilable(T.proc.void)).returns(T.untyped) }
+  def unscoped(block); end
+
   sig { params(args: T.untyped).returns(SpellBook::Relation) }
   def recent(*args); end
 

--- a/spec/test_data/v5.2/expected_spell_book.rbi
+++ b/spec/test_data/v5.2/expected_spell_book.rbi
@@ -72,7 +72,7 @@ module SpellBook::ModelRelationShared
   sig { returns(SpellBook::Relation) }
   def all(); end
 
-  sig { params(block: T.nilable(T.proc.void)).returns(T.untyped) }
+  sig { params(block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
   def unscoped(block); end
 
   sig { params(args: T.untyped).returns(SpellBook::Relation) }

--- a/spec/test_data/v5.2/expected_spell_book.rbi
+++ b/spec/test_data/v5.2/expected_spell_book.rbi
@@ -73,90 +73,90 @@ module SpellBook::ModelRelationShared
   def all(); end
 
   sig { params(block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
-  def unscoped(block); end
+  def unscoped(&block); end
 
   sig { params(args: T.untyped).returns(SpellBook::Relation) }
   def recent(*args); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
-  def select(*args, block); end
+  def select(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
-  def order(*args, block); end
+  def order(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
-  def reorder(*args, block); end
+  def reorder(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
-  def group(*args, block); end
+  def group(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
-  def limit(*args, block); end
+  def limit(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
-  def offset(*args, block); end
+  def offset(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
-  def joins(*args, block); end
+  def joins(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
-  def left_joins(*args, block); end
+  def left_joins(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
-  def left_outer_joins(*args, block); end
+  def left_outer_joins(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
-  def where(*args, block); end
+  def where(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
-  def rewhere(*args, block); end
+  def rewhere(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
-  def preload(*args, block); end
+  def preload(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
-  def eager_load(*args, block); end
+  def eager_load(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
-  def includes(*args, block); end
+  def includes(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
-  def from(*args, block); end
+  def from(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
-  def lock(*args, block); end
+  def lock(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
-  def readonly(*args, block); end
+  def readonly(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
-  def extending(*args, block); end
+  def extending(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
-  def or(*args, block); end
+  def or(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
-  def having(*args, block); end
+  def having(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
-  def create_with(*args, block); end
+  def create_with(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
-  def distinct(*args, block); end
+  def distinct(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
-  def references(*args, block); end
+  def references(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
-  def none(*args, block); end
+  def none(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
-  def unscope(*args, block); end
+  def unscope(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
-  def merge(*args, block); end
+  def merge(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
-  def except(*args, block); end
+  def except(*args, &block); end
 
 end

--- a/spec/test_data/v5.2/expected_wand.rbi
+++ b/spec/test_data/v5.2/expected_wand.rbi
@@ -186,7 +186,7 @@ module Wand::ModelRelationShared
   sig { returns(Wand::Relation) }
   def all(); end
 
-  sig { params(block: T.nilable(T.proc.void)).returns(T.untyped) }
+  sig { params(block: T.nilable(T.proc.void)).returns(Wand::Relation) }
   def unscoped(block); end
 
   sig { params(args: T.untyped).returns(Wand::Relation) }

--- a/spec/test_data/v5.2/expected_wand.rbi
+++ b/spec/test_data/v5.2/expected_wand.rbi
@@ -187,7 +187,7 @@ module Wand::ModelRelationShared
   def all(); end
 
   sig { params(block: T.nilable(T.proc.void)).returns(Wand::Relation) }
-  def unscoped(block); end
+  def unscoped(&block); end
 
   sig { params(args: T.untyped).returns(Wand::Relation) }
   def basilisk_horn(*args); end
@@ -205,84 +205,84 @@ module Wand::ModelRelationShared
   def unicorn_tail_hair(*args); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
-  def select(*args, block); end
+  def select(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
-  def order(*args, block); end
+  def order(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
-  def reorder(*args, block); end
+  def reorder(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
-  def group(*args, block); end
+  def group(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
-  def limit(*args, block); end
+  def limit(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
-  def offset(*args, block); end
+  def offset(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
-  def joins(*args, block); end
+  def joins(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
-  def left_joins(*args, block); end
+  def left_joins(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
-  def left_outer_joins(*args, block); end
+  def left_outer_joins(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
-  def where(*args, block); end
+  def where(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
-  def rewhere(*args, block); end
+  def rewhere(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
-  def preload(*args, block); end
+  def preload(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
-  def eager_load(*args, block); end
+  def eager_load(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
-  def includes(*args, block); end
+  def includes(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
-  def from(*args, block); end
+  def from(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
-  def lock(*args, block); end
+  def lock(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
-  def readonly(*args, block); end
+  def readonly(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
-  def extending(*args, block); end
+  def extending(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
-  def or(*args, block); end
+  def or(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
-  def having(*args, block); end
+  def having(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
-  def create_with(*args, block); end
+  def create_with(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
-  def distinct(*args, block); end
+  def distinct(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
-  def references(*args, block); end
+  def references(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
-  def none(*args, block); end
+  def none(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
-  def unscope(*args, block); end
+  def unscope(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
-  def merge(*args, block); end
+  def merge(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
-  def except(*args, block); end
+  def except(*args, &block); end
 
 end

--- a/spec/test_data/v5.2/expected_wand.rbi
+++ b/spec/test_data/v5.2/expected_wand.rbi
@@ -186,6 +186,9 @@ module Wand::ModelRelationShared
   sig { returns(Wand::Relation) }
   def all(); end
 
+  sig { params(block: T.nilable(T.proc.void)).returns(T.untyped) }
+  def unscoped(block); end
+
   sig { params(args: T.untyped).returns(Wand::Relation) }
   def basilisk_horn(*args); end
 

--- a/spec/test_data/v5.2/expected_wizard.rbi
+++ b/spec/test_data/v5.2/expected_wizard.rbi
@@ -129,7 +129,7 @@ module Wizard::ModelRelationShared
   sig { returns(Wizard::Relation) }
   def all(); end
 
-  sig { params(block: T.nilable(T.proc.void)).returns(T.untyped) }
+  sig { params(block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
   def unscoped(block); end
 
   sig { params(args: T.untyped).returns(Wizard::Relation) }

--- a/spec/test_data/v5.2/expected_wizard.rbi
+++ b/spec/test_data/v5.2/expected_wizard.rbi
@@ -129,6 +129,9 @@ module Wizard::ModelRelationShared
   sig { returns(Wizard::Relation) }
   def all(); end
 
+  sig { params(block: T.nilable(T.proc.void)).returns(T.untyped) }
+  def unscoped(block); end
+
   sig { params(args: T.untyped).returns(Wizard::Relation) }
   def Gryffindor(*args); end
 

--- a/spec/test_data/v5.2/expected_wizard.rbi
+++ b/spec/test_data/v5.2/expected_wizard.rbi
@@ -130,7 +130,7 @@ module Wizard::ModelRelationShared
   def all(); end
 
   sig { params(block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def unscoped(block); end
+  def unscoped(&block); end
 
   sig { params(args: T.untyped).returns(Wizard::Relation) }
   def Gryffindor(*args); end
@@ -148,84 +148,84 @@ module Wizard::ModelRelationShared
   def recent(*args); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def select(*args, block); end
+  def select(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def order(*args, block); end
+  def order(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def reorder(*args, block); end
+  def reorder(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def group(*args, block); end
+  def group(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def limit(*args, block); end
+  def limit(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def offset(*args, block); end
+  def offset(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def joins(*args, block); end
+  def joins(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def left_joins(*args, block); end
+  def left_joins(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def left_outer_joins(*args, block); end
+  def left_outer_joins(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def where(*args, block); end
+  def where(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def rewhere(*args, block); end
+  def rewhere(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def preload(*args, block); end
+  def preload(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def eager_load(*args, block); end
+  def eager_load(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def includes(*args, block); end
+  def includes(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def from(*args, block); end
+  def from(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def lock(*args, block); end
+  def lock(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def readonly(*args, block); end
+  def readonly(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def extending(*args, block); end
+  def extending(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def or(*args, block); end
+  def or(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def having(*args, block); end
+  def having(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def create_with(*args, block); end
+  def create_with(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def distinct(*args, block); end
+  def distinct(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def references(*args, block); end
+  def references(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def none(*args, block); end
+  def none(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def unscope(*args, block); end
+  def unscope(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def merge(*args, block); end
+  def merge(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def except(*args, block); end
+  def except(*args, &block); end
 
 end

--- a/spec/test_data/v5.2/expected_wizard_wo_spellbook.rbi
+++ b/spec/test_data/v5.2/expected_wizard_wo_spellbook.rbi
@@ -129,7 +129,7 @@ module Wizard::ModelRelationShared
   sig { returns(Wizard::Relation) }
   def all(); end
 
-  sig { params(block: T.nilable(T.proc.void)).returns(T.untyped) }
+  sig { params(block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
   def unscoped(block); end
 
   sig { params(args: T.untyped).returns(Wizard::Relation) }

--- a/spec/test_data/v5.2/expected_wizard_wo_spellbook.rbi
+++ b/spec/test_data/v5.2/expected_wizard_wo_spellbook.rbi
@@ -129,6 +129,9 @@ module Wizard::ModelRelationShared
   sig { returns(Wizard::Relation) }
   def all(); end
 
+  sig { params(block: T.nilable(T.proc.void)).returns(T.untyped) }
+  def unscoped(block); end
+
   sig { params(args: T.untyped).returns(Wizard::Relation) }
   def Gryffindor(*args); end
 

--- a/spec/test_data/v5.2/expected_wizard_wo_spellbook.rbi
+++ b/spec/test_data/v5.2/expected_wizard_wo_spellbook.rbi
@@ -130,7 +130,7 @@ module Wizard::ModelRelationShared
   def all(); end
 
   sig { params(block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def unscoped(block); end
+  def unscoped(&block); end
 
   sig { params(args: T.untyped).returns(Wizard::Relation) }
   def Gryffindor(*args); end
@@ -148,84 +148,84 @@ module Wizard::ModelRelationShared
   def recent(*args); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def select(*args, block); end
+  def select(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def order(*args, block); end
+  def order(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def reorder(*args, block); end
+  def reorder(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def group(*args, block); end
+  def group(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def limit(*args, block); end
+  def limit(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def offset(*args, block); end
+  def offset(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def joins(*args, block); end
+  def joins(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def left_joins(*args, block); end
+  def left_joins(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def left_outer_joins(*args, block); end
+  def left_outer_joins(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def where(*args, block); end
+  def where(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def rewhere(*args, block); end
+  def rewhere(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def preload(*args, block); end
+  def preload(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def eager_load(*args, block); end
+  def eager_load(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def includes(*args, block); end
+  def includes(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def from(*args, block); end
+  def from(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def lock(*args, block); end
+  def lock(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def readonly(*args, block); end
+  def readonly(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def extending(*args, block); end
+  def extending(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def or(*args, block); end
+  def or(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def having(*args, block); end
+  def having(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def create_with(*args, block); end
+  def create_with(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def distinct(*args, block); end
+  def distinct(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def references(*args, block); end
+  def references(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def none(*args, block); end
+  def none(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def unscope(*args, block); end
+  def unscope(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def merge(*args, block); end
+  def merge(*args, &block); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
-  def except(*args, block); end
+  def except(*args, &block); end
 
 end


### PR DESCRIPTION
Adds support for non-block `unscoped` method: https://apidock.com/rails/ActiveRecord/Scoping/Default/ClassMethods/unscoped

Unfortunately this method has also a less popular block option that has to be untyped as it can return anything so it has to be untyped.