### PR TITLE
Fixes for sorbet 0.4.4366

### DIFF
--- a/lib/sorbet-rails/tasks/rails_rbi.rake
+++ b/lib/sorbet-rails/tasks/rails_rbi.rake
@@ -54,7 +54,6 @@ namespace :rails_rbi do
 
   def blacklisted_models
     blacklisted_models = []
-    blacklisted_models << ActiveRecord::SchemaMigration if defined?(ActiveRecord::SchemaMigration)
     blacklisted_models << ApplicationRecord if defined?(ApplicationRecord)
     blacklisted_models
   end

--- a/rbi/activerecord.rbi
+++ b/rbi/activerecord.rbi
@@ -5,7 +5,7 @@ class ActiveRecord::Relation
   include Enumerable
   include ActiveRecord::Querying::Typed
 
-  Elem = type_member
+  Elem = type_member(fixed: ActiveRecord::Base)
 
   sig { params(block: T.proc.params(e: Elem).void).void }
   def each(&block); end
@@ -21,14 +21,14 @@ class ActiveRecord::Relation
   # TODO normally this method could return Elem or Array[Elem]
   # however, we think it's better to limit the interface to returning Elem only
   # Use `find_n` as a replacement if you want to get an array from `find`
-  sig { params(args: T.untyped).returns(Elem).soft }
+  sig { params(args: T.untyped).returns(Elem) }
   def find(*args); end
 end
 
 class ActiveRecord::Associations::CollectionProxy < ActiveRecord::Relation
   extend T::Generic
 
-  Elem = type_member
+  Elem = type_member(fixed: ActiveRecord::Base)
 
   # -- << and aliases
   sig { params(records: T.any(Elem, T::Array[Elem])).returns(T.self_type) }
@@ -45,7 +45,7 @@ end
 module ActiveRecord::Querying::Typed
   extend T::Sig
   extend T::Generic
-  Elem = type_member
+  Elem = type_member(fixed: ActiveRecord::Base)
 
   # -- Booleans
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(T::Boolean) }
@@ -94,13 +94,13 @@ module ActiveRecord::Querying::Typed
   # array of element when there is a limit passed in.
   # The more common use case is to find 1 object. We use that as the default sig
   # and add custom first_n, last_n method for the cases that return an array
-  sig { params(limit: T.nilable(Integer)).returns(T.nilable(Elem)).soft }
+  sig { params(limit: T.nilable(Integer)).returns(T.nilable(Elem)) }
   def first(limit = nil); end
-  sig { params(limit: T.nilable(Integer)).returns(T.nilable(Elem)).soft }
+  sig { params(limit: T.nilable(Integer)).returns(T.nilable(Elem)) }
   def last(limit = nil); end
   # Similar to first & last, normally this method could return Elem or Array[Elem]
   # But we enforce that `find` return Elem by default and provide find_n as an alternative
-  sig { params(args: T.any(Integer, String)).returns(Elem).soft }
+  sig { params(args: T.any(Integer, String)).returns(Elem) }
   def find(*args); end
   # These are custom finder methods to provide strong type for secondary use case of first, last & find
   # See sorbet_rails/custom_finder_methods

--- a/spec/test_data/v4.2/expected_potion.rbi
+++ b/spec/test_data/v4.2/expected_potion.rbi
@@ -2,13 +2,13 @@
 # Please rerun rake rails_rbi:models to regenerate.
 # typed: strong
 
-class Potion::Relation < ActiveRecord::Relation
+class Potion::ActiveRecord_Relation < ActiveRecord::Relation
   include Potion::ModelRelationShared
   extend T::Generic
   Elem = type_member(fixed: Potion)
 end
 
-class Potion::CollectionProxy < ActiveRecord::Associations::CollectionProxy
+class Potion::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include Potion::ModelRelationShared
   extend T::Generic
   Elem = type_member(fixed: Potion)
@@ -18,7 +18,6 @@ class Potion < ApplicationRecord
   extend T::Sig
   extend T::Generic
   extend Potion::ModelRelationShared
-  extend Potion::ClassMethods
   include Potion::InstanceMethods
   Elem = type_template(fixed: Potion)
 end
@@ -28,7 +27,7 @@ module Potion::InstanceMethods
 
 end
 
-module Potion::ClassMethods
+class Potion
   extend T::Sig
 
 end
@@ -36,79 +35,79 @@ end
 module Potion::ModelRelationShared
   extend T::Sig
 
-  sig { returns(Potion::Relation) }
+  sig { returns(Potion::ActiveRecord_Relation) }
   def all(); end
 
-  sig { params(block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def unscoped(&block); end
 
-  sig { params(args: T.untyped).returns(Potion::Relation) }
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
   def recent(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def select(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def order(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def reorder(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def group(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def limit(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def offset(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def joins(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def where(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def rewhere(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def preload(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def eager_load(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def includes(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def from(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def lock(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def readonly(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def having(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def create_with(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def distinct(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def references(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def none(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def unscope(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def except(*args, &block); end
 
 end

--- a/spec/test_data/v4.2/expected_spell_book.rbi
+++ b/spec/test_data/v4.2/expected_spell_book.rbi
@@ -2,13 +2,13 @@
 # Please rerun rake rails_rbi:models to regenerate.
 # typed: strong
 
-class SpellBook::Relation < ActiveRecord::Relation
+class SpellBook::ActiveRecord_Relation < ActiveRecord::Relation
   include SpellBook::ModelRelationShared
   extend T::Generic
   Elem = type_member(fixed: SpellBook)
 end
 
-class SpellBook::CollectionProxy < ActiveRecord::Associations::CollectionProxy
+class SpellBook::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include SpellBook::ModelRelationShared
   extend T::Generic
   Elem = type_member(fixed: SpellBook)
@@ -18,7 +18,6 @@ class SpellBook < ApplicationRecord
   extend T::Sig
   extend T::Generic
   extend SpellBook::ModelRelationShared
-  extend SpellBook::ClassMethods
   include SpellBook::InstanceMethods
   Elem = type_template(fixed: SpellBook)
 end
@@ -44,12 +43,6 @@ module SpellBook::InstanceMethods
   sig { params(args: T.untyped).returns(T::Boolean) }
   def name?(*args); end
 
-  sig { returns(T.nilable(Wizard)) }
-  def wizard(); end
-
-  sig { params(value: T.nilable(Wizard)).void }
-  def wizard=(value); end
-
   sig { returns(T.nilable(Integer)) }
   def wizard_id(); end
 
@@ -61,87 +54,93 @@ module SpellBook::InstanceMethods
 
 end
 
-module SpellBook::ClassMethods
+class SpellBook
   extend T::Sig
+
+  sig { returns(T.nilable(::Wizard)) }
+  def wizard(); end
+
+  sig { params(value: T.nilable(::Wizard)).void }
+  def wizard=(value); end
 
 end
 
 module SpellBook::ModelRelationShared
   extend T::Sig
 
-  sig { returns(SpellBook::Relation) }
+  sig { returns(SpellBook::ActiveRecord_Relation) }
   def all(); end
 
-  sig { params(block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def unscoped(&block); end
 
-  sig { params(args: T.untyped).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
   def recent(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def select(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def order(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def reorder(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def group(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def limit(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def offset(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def joins(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def where(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def rewhere(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def preload(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def eager_load(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def includes(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def from(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def lock(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def readonly(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def having(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def create_with(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def distinct(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def references(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def none(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def unscope(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def except(*args, &block); end
 
 end

--- a/spec/test_data/v4.2/expected_wand.rbi
+++ b/spec/test_data/v4.2/expected_wand.rbi
@@ -2,13 +2,13 @@
 # Please rerun rake rails_rbi:models to regenerate.
 # typed: strong
 
-class Wand::Relation < ActiveRecord::Relation
+class Wand::ActiveRecord_Relation < ActiveRecord::Relation
   include Wand::ModelRelationShared
   extend T::Generic
   Elem = type_member(fixed: Wand)
 end
 
-class Wand::CollectionProxy < ActiveRecord::Associations::CollectionProxy
+class Wand::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include Wand::ModelRelationShared
   extend T::Generic
   Elem = type_member(fixed: Wand)
@@ -18,7 +18,6 @@ class Wand < ApplicationRecord
   extend T::Sig
   extend T::Generic
   extend Wand::ModelRelationShared
-  extend Wand::ClassMethods
   include Wand::InstanceMethods
   Elem = type_template(fixed: Wand)
 end
@@ -128,12 +127,6 @@ module Wand::InstanceMethods
   sig { params(args: T.untyped).returns(T::Boolean) }
   def updated_at?(*args); end
 
-  sig { returns(Wizard) }
-  def wizard(); end
-
-  sig { params(value: Wizard).void }
-  def wizard=(value); end
-
   sig { returns(Integer) }
   def wizard_id(); end
 
@@ -154,102 +147,120 @@ module Wand::InstanceMethods
 
 end
 
-module Wand::ClassMethods
+class Wand
   extend T::Sig
 
+  sig { returns(::Wizard) }
+  def wizard(); end
+
+  sig { params(value: ::Wizard).void }
+  def wizard=(value); end
+
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.basilisk_horn(*args); end
+
   sig { returns(T::Hash[T.any(String, Symbol), Integer]) }
-  def core_types(); end
+  def self.core_types(); end
+
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.dragon_heartstring(*args); end
+
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.phoenix_feather(*args); end
+
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.unicorn_tail_hair(*args); end
 
 end
 
 module Wand::ModelRelationShared
   extend T::Sig
 
-  sig { returns(Wand::Relation) }
+  sig { returns(Wand::ActiveRecord_Relation) }
   def all(); end
 
-  sig { params(block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def unscoped(&block); end
 
-  sig { params(args: T.untyped).returns(Wand::Relation) }
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
   def basilisk_horn(*args); end
 
-  sig { params(args: T.untyped).returns(Wand::Relation) }
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
   def dragon_heartstring(*args); end
 
-  sig { params(args: T.untyped).returns(Wand::Relation) }
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
   def phoenix_feather(*args); end
 
-  sig { params(args: T.untyped).returns(Wand::Relation) }
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
   def recent(*args); end
 
-  sig { params(args: T.untyped).returns(Wand::Relation) }
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
   def unicorn_tail_hair(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def select(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def order(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def reorder(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def group(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def limit(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def offset(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def joins(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def where(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def rewhere(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def preload(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def eager_load(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def includes(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def from(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def lock(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def readonly(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def having(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def create_with(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def distinct(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def references(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def none(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def unscope(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def except(*args, &block); end
 
 end

--- a/spec/test_data/v4.2/expected_wizard.rbi
+++ b/spec/test_data/v4.2/expected_wizard.rbi
@@ -2,13 +2,13 @@
 # Please rerun rake rails_rbi:models to regenerate.
 # typed: strong
 
-class Wizard::Relation < ActiveRecord::Relation
+class Wizard::ActiveRecord_Relation < ActiveRecord::Relation
   include Wizard::ModelRelationShared
   extend T::Generic
   Elem = type_member(fixed: Wizard)
 end
 
-class Wizard::CollectionProxy < ActiveRecord::Associations::CollectionProxy
+class Wizard::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include Wizard::ModelRelationShared
   extend T::Generic
   Elem = type_member(fixed: Wizard)
@@ -18,7 +18,6 @@ class Wizard < ApplicationRecord
   extend T::Sig
   extend T::Generic
   extend Wizard::ModelRelationShared
-  extend Wizard::ClassMethods
   include Wizard::InstanceMethods
   Elem = type_template(fixed: Wizard)
 end
@@ -92,12 +91,6 @@ module Wizard::InstanceMethods
   sig { params(args: T.untyped).returns(T::Boolean) }
   def parent_email?(*args); end
 
-  sig { returns(SpellBook::CollectionProxy) }
-  def spell_books(); end
-
-  sig { params(value: T.any(T::Array[SpellBook], SpellBook::CollectionProxy)).void }
-  def spell_books=(value); end
-
   sig { returns(T.nilable(T.untyped)) }
   def updated_at(); end
 
@@ -107,110 +100,128 @@ module Wizard::InstanceMethods
   sig { params(args: T.untyped).returns(T::Boolean) }
   def updated_at?(*args); end
 
-  sig { returns(T.nilable(Wand)) }
-  def wand(); end
-
-  sig { params(value: T.nilable(Wand)).void }
-  def wand=(value); end
-
 end
 
-module Wizard::ClassMethods
+class Wizard
   extend T::Sig
 
+  sig { returns(::SpellBook::ActiveRecord_Associations_CollectionProxy) }
+  def spell_books(); end
+
+  sig { params(value: T.any(T::Array[::SpellBook], ::SpellBook::ActiveRecord_Associations_CollectionProxy)).void }
+  def spell_books=(value); end
+
+  sig { returns(T.nilable(::Wand)) }
+  def wand(); end
+
+  sig { params(value: T.nilable(::Wand)).void }
+  def wand=(value); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.Gryffindor(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.Hufflepuff(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.Ravenclaw(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.Slytherin(*args); end
+
   sig { returns(T::Hash[T.any(String, Symbol), Integer]) }
-  def houses(); end
+  def self.houses(); end
 
 end
 
 module Wizard::ModelRelationShared
   extend T::Sig
 
-  sig { returns(Wizard::Relation) }
+  sig { returns(Wizard::ActiveRecord_Relation) }
   def all(); end
 
-  sig { params(block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def unscoped(&block); end
 
-  sig { params(args: T.untyped).returns(Wizard::Relation) }
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
   def Gryffindor(*args); end
 
-  sig { params(args: T.untyped).returns(Wizard::Relation) }
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
   def Hufflepuff(*args); end
 
-  sig { params(args: T.untyped).returns(Wizard::Relation) }
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
   def Ravenclaw(*args); end
 
-  sig { params(args: T.untyped).returns(Wizard::Relation) }
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
   def Slytherin(*args); end
 
-  sig { params(args: T.untyped).returns(Wizard::Relation) }
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
   def recent(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def select(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def order(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def reorder(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def group(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def limit(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def offset(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def joins(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def where(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def rewhere(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def preload(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def eager_load(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def includes(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def from(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def lock(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def readonly(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def having(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def create_with(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def distinct(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def references(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def none(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def unscope(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def except(*args, &block); end
 
 end

--- a/spec/test_data/v4.2/expected_wizard_wo_spellbook.rbi
+++ b/spec/test_data/v4.2/expected_wizard_wo_spellbook.rbi
@@ -2,13 +2,13 @@
 # Please rerun rake rails_rbi:models to regenerate.
 # typed: strong
 
-class Wizard::Relation < ActiveRecord::Relation
+class Wizard::ActiveRecord_Relation < ActiveRecord::Relation
   include Wizard::ModelRelationShared
   extend T::Generic
   Elem = type_member(fixed: Wizard)
 end
 
-class Wizard::CollectionProxy < ActiveRecord::Associations::CollectionProxy
+class Wizard::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include Wizard::ModelRelationShared
   extend T::Generic
   Elem = type_member(fixed: Wizard)
@@ -18,7 +18,6 @@ class Wizard < ApplicationRecord
   extend T::Sig
   extend T::Generic
   extend Wizard::ModelRelationShared
-  extend Wizard::ClassMethods
   include Wizard::InstanceMethods
   Elem = type_template(fixed: Wizard)
 end
@@ -92,12 +91,6 @@ module Wizard::InstanceMethods
   sig { params(args: T.untyped).returns(T::Boolean) }
   def parent_email?(*args); end
 
-  sig { returns(ActiveRecord::Associations::CollectionProxy[T.untyped]) }
-  def spell_books(); end
-
-  sig { params(value: T.any(T::Array[SpellBook], ActiveRecord::Associations::CollectionProxy[T.untyped])).void }
-  def spell_books=(value); end
-
   sig { returns(T.nilable(T.untyped)) }
   def updated_at(); end
 
@@ -107,110 +100,128 @@ module Wizard::InstanceMethods
   sig { params(args: T.untyped).returns(T::Boolean) }
   def updated_at?(*args); end
 
-  sig { returns(T.nilable(Wand)) }
-  def wand(); end
-
-  sig { params(value: T.nilable(Wand)).void }
-  def wand=(value); end
-
 end
 
-module Wizard::ClassMethods
+class Wizard
   extend T::Sig
 
+  sig { returns(ActiveRecord::Associations::CollectionProxy) }
+  def spell_books(); end
+
+  sig { params(value: T.any(T::Array[::SpellBook], ActiveRecord::Associations::CollectionProxy)).void }
+  def spell_books=(value); end
+
+  sig { returns(T.nilable(::Wand)) }
+  def wand(); end
+
+  sig { params(value: T.nilable(::Wand)).void }
+  def wand=(value); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.Gryffindor(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.Hufflepuff(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.Ravenclaw(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.Slytherin(*args); end
+
   sig { returns(T::Hash[T.any(String, Symbol), Integer]) }
-  def houses(); end
+  def self.houses(); end
 
 end
 
 module Wizard::ModelRelationShared
   extend T::Sig
 
-  sig { returns(Wizard::Relation) }
+  sig { returns(Wizard::ActiveRecord_Relation) }
   def all(); end
 
-  sig { params(block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def unscoped(&block); end
 
-  sig { params(args: T.untyped).returns(Wizard::Relation) }
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
   def Gryffindor(*args); end
 
-  sig { params(args: T.untyped).returns(Wizard::Relation) }
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
   def Hufflepuff(*args); end
 
-  sig { params(args: T.untyped).returns(Wizard::Relation) }
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
   def Ravenclaw(*args); end
 
-  sig { params(args: T.untyped).returns(Wizard::Relation) }
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
   def Slytherin(*args); end
 
-  sig { params(args: T.untyped).returns(Wizard::Relation) }
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
   def recent(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def select(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def order(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def reorder(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def group(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def limit(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def offset(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def joins(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def where(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def rewhere(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def preload(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def eager_load(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def includes(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def from(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def lock(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def readonly(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def having(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def create_with(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def distinct(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def references(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def none(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def unscope(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def except(*args, &block); end
 
 end

--- a/spec/test_data/v5.0/expected_potion.rbi
+++ b/spec/test_data/v5.0/expected_potion.rbi
@@ -2,13 +2,13 @@
 # Please rerun rake rails_rbi:models to regenerate.
 # typed: strong
 
-class Potion::Relation < ActiveRecord::Relation
+class Potion::ActiveRecord_Relation < ActiveRecord::Relation
   include Potion::ModelRelationShared
   extend T::Generic
   Elem = type_member(fixed: Potion)
 end
 
-class Potion::CollectionProxy < ActiveRecord::Associations::CollectionProxy
+class Potion::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include Potion::ModelRelationShared
   extend T::Generic
   Elem = type_member(fixed: Potion)
@@ -18,7 +18,6 @@ class Potion < ApplicationRecord
   extend T::Sig
   extend T::Generic
   extend Potion::ModelRelationShared
-  extend Potion::ClassMethods
   include Potion::InstanceMethods
   Elem = type_template(fixed: Potion)
 end
@@ -28,7 +27,7 @@ module Potion::InstanceMethods
 
 end
 
-module Potion::ClassMethods
+class Potion
   extend T::Sig
 
 end
@@ -36,88 +35,88 @@ end
 module Potion::ModelRelationShared
   extend T::Sig
 
-  sig { returns(Potion::Relation) }
+  sig { returns(Potion::ActiveRecord_Relation) }
   def all(); end
 
-  sig { params(block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def unscoped(&block); end
 
-  sig { params(args: T.untyped).returns(Potion::Relation) }
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
   def recent(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def select(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def order(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def reorder(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def group(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def limit(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def offset(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def joins(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def left_joins(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def left_outer_joins(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def where(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def rewhere(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def preload(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def eager_load(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def includes(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def from(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def lock(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def readonly(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def or(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def having(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def create_with(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def distinct(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def references(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def none(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def unscope(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def except(*args, &block); end
 
 end

--- a/spec/test_data/v5.0/expected_spell_book.rbi
+++ b/spec/test_data/v5.0/expected_spell_book.rbi
@@ -2,13 +2,13 @@
 # Please rerun rake rails_rbi:models to regenerate.
 # typed: strong
 
-class SpellBook::Relation < ActiveRecord::Relation
+class SpellBook::ActiveRecord_Relation < ActiveRecord::Relation
   include SpellBook::ModelRelationShared
   extend T::Generic
   Elem = type_member(fixed: SpellBook)
 end
 
-class SpellBook::CollectionProxy < ActiveRecord::Associations::CollectionProxy
+class SpellBook::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include SpellBook::ModelRelationShared
   extend T::Generic
   Elem = type_member(fixed: SpellBook)
@@ -18,7 +18,6 @@ class SpellBook < ApplicationRecord
   extend T::Sig
   extend T::Generic
   extend SpellBook::ModelRelationShared
-  extend SpellBook::ClassMethods
   include SpellBook::InstanceMethods
   Elem = type_template(fixed: SpellBook)
 end
@@ -44,12 +43,6 @@ module SpellBook::InstanceMethods
   sig { params(args: T.untyped).returns(T::Boolean) }
   def name?(*args); end
 
-  sig { returns(T.nilable(Wizard)) }
-  def wizard(); end
-
-  sig { params(value: T.nilable(Wizard)).void }
-  def wizard=(value); end
-
   sig { returns(T.nilable(Integer)) }
   def wizard_id(); end
 
@@ -61,96 +54,102 @@ module SpellBook::InstanceMethods
 
 end
 
-module SpellBook::ClassMethods
+class SpellBook
   extend T::Sig
+
+  sig { returns(T.nilable(::Wizard)) }
+  def wizard(); end
+
+  sig { params(value: T.nilable(::Wizard)).void }
+  def wizard=(value); end
 
 end
 
 module SpellBook::ModelRelationShared
   extend T::Sig
 
-  sig { returns(SpellBook::Relation) }
+  sig { returns(SpellBook::ActiveRecord_Relation) }
   def all(); end
 
-  sig { params(block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def unscoped(&block); end
 
-  sig { params(args: T.untyped).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
   def recent(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def select(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def order(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def reorder(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def group(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def limit(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def offset(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def joins(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def left_joins(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def left_outer_joins(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def where(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def rewhere(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def preload(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def eager_load(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def includes(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def from(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def lock(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def readonly(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def or(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def having(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def create_with(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def distinct(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def references(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def none(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def unscope(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def except(*args, &block); end
 
 end

--- a/spec/test_data/v5.0/expected_wand.rbi
+++ b/spec/test_data/v5.0/expected_wand.rbi
@@ -2,13 +2,13 @@
 # Please rerun rake rails_rbi:models to regenerate.
 # typed: strong
 
-class Wand::Relation < ActiveRecord::Relation
+class Wand::ActiveRecord_Relation < ActiveRecord::Relation
   include Wand::ModelRelationShared
   extend T::Generic
   Elem = type_member(fixed: Wand)
 end
 
-class Wand::CollectionProxy < ActiveRecord::Associations::CollectionProxy
+class Wand::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include Wand::ModelRelationShared
   extend T::Generic
   Elem = type_member(fixed: Wand)
@@ -18,7 +18,6 @@ class Wand < ApplicationRecord
   extend T::Sig
   extend T::Generic
   extend Wand::ModelRelationShared
-  extend Wand::ClassMethods
   include Wand::InstanceMethods
   Elem = type_template(fixed: Wand)
 end
@@ -128,12 +127,6 @@ module Wand::InstanceMethods
   sig { params(args: T.untyped).returns(T::Boolean) }
   def updated_at?(*args); end
 
-  sig { returns(Wizard) }
-  def wizard(); end
-
-  sig { params(value: Wizard).void }
-  def wizard=(value); end
-
   sig { returns(Integer) }
   def wizard_id(); end
 
@@ -154,111 +147,129 @@ module Wand::InstanceMethods
 
 end
 
-module Wand::ClassMethods
+class Wand
   extend T::Sig
 
+  sig { returns(::Wizard) }
+  def wizard(); end
+
+  sig { params(value: ::Wizard).void }
+  def wizard=(value); end
+
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.basilisk_horn(*args); end
+
   sig { returns(T::Hash[T.any(String, Symbol), Integer]) }
-  def core_types(); end
+  def self.core_types(); end
+
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.dragon_heartstring(*args); end
+
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.phoenix_feather(*args); end
+
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.unicorn_tail_hair(*args); end
 
 end
 
 module Wand::ModelRelationShared
   extend T::Sig
 
-  sig { returns(Wand::Relation) }
+  sig { returns(Wand::ActiveRecord_Relation) }
   def all(); end
 
-  sig { params(block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def unscoped(&block); end
 
-  sig { params(args: T.untyped).returns(Wand::Relation) }
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
   def basilisk_horn(*args); end
 
-  sig { params(args: T.untyped).returns(Wand::Relation) }
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
   def dragon_heartstring(*args); end
 
-  sig { params(args: T.untyped).returns(Wand::Relation) }
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
   def phoenix_feather(*args); end
 
-  sig { params(args: T.untyped).returns(Wand::Relation) }
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
   def recent(*args); end
 
-  sig { params(args: T.untyped).returns(Wand::Relation) }
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
   def unicorn_tail_hair(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def select(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def order(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def reorder(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def group(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def limit(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def offset(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def joins(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def left_joins(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def left_outer_joins(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def where(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def rewhere(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def preload(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def eager_load(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def includes(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def from(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def lock(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def readonly(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def or(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def having(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def create_with(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def distinct(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def references(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def none(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def unscope(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def except(*args, &block); end
 
 end

--- a/spec/test_data/v5.0/expected_wizard.rbi
+++ b/spec/test_data/v5.0/expected_wizard.rbi
@@ -2,13 +2,13 @@
 # Please rerun rake rails_rbi:models to regenerate.
 # typed: strong
 
-class Wizard::Relation < ActiveRecord::Relation
+class Wizard::ActiveRecord_Relation < ActiveRecord::Relation
   include Wizard::ModelRelationShared
   extend T::Generic
   Elem = type_member(fixed: Wizard)
 end
 
-class Wizard::CollectionProxy < ActiveRecord::Associations::CollectionProxy
+class Wizard::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include Wizard::ModelRelationShared
   extend T::Generic
   Elem = type_member(fixed: Wizard)
@@ -18,7 +18,6 @@ class Wizard < ApplicationRecord
   extend T::Sig
   extend T::Generic
   extend Wizard::ModelRelationShared
-  extend Wizard::ClassMethods
   include Wizard::InstanceMethods
   Elem = type_template(fixed: Wizard)
 end
@@ -92,12 +91,6 @@ module Wizard::InstanceMethods
   sig { params(args: T.untyped).returns(T::Boolean) }
   def parent_email?(*args); end
 
-  sig { returns(SpellBook::CollectionProxy) }
-  def spell_books(); end
-
-  sig { params(value: T.any(T::Array[SpellBook], SpellBook::CollectionProxy)).void }
-  def spell_books=(value); end
-
   sig { returns(DateTime) }
   def updated_at(); end
 
@@ -107,119 +100,137 @@ module Wizard::InstanceMethods
   sig { params(args: T.untyped).returns(T::Boolean) }
   def updated_at?(*args); end
 
-  sig { returns(T.nilable(Wand)) }
-  def wand(); end
-
-  sig { params(value: T.nilable(Wand)).void }
-  def wand=(value); end
-
 end
 
-module Wizard::ClassMethods
+class Wizard
   extend T::Sig
 
+  sig { returns(::SpellBook::ActiveRecord_Associations_CollectionProxy) }
+  def spell_books(); end
+
+  sig { params(value: T.any(T::Array[::SpellBook], ::SpellBook::ActiveRecord_Associations_CollectionProxy)).void }
+  def spell_books=(value); end
+
+  sig { returns(T.nilable(::Wand)) }
+  def wand(); end
+
+  sig { params(value: T.nilable(::Wand)).void }
+  def wand=(value); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.Gryffindor(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.Hufflepuff(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.Ravenclaw(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.Slytherin(*args); end
+
   sig { returns(T::Hash[T.any(String, Symbol), Integer]) }
-  def houses(); end
+  def self.houses(); end
 
 end
 
 module Wizard::ModelRelationShared
   extend T::Sig
 
-  sig { returns(Wizard::Relation) }
+  sig { returns(Wizard::ActiveRecord_Relation) }
   def all(); end
 
-  sig { params(block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def unscoped(&block); end
 
-  sig { params(args: T.untyped).returns(Wizard::Relation) }
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
   def Gryffindor(*args); end
 
-  sig { params(args: T.untyped).returns(Wizard::Relation) }
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
   def Hufflepuff(*args); end
 
-  sig { params(args: T.untyped).returns(Wizard::Relation) }
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
   def Ravenclaw(*args); end
 
-  sig { params(args: T.untyped).returns(Wizard::Relation) }
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
   def Slytherin(*args); end
 
-  sig { params(args: T.untyped).returns(Wizard::Relation) }
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
   def recent(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def select(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def order(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def reorder(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def group(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def limit(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def offset(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def joins(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def left_joins(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def left_outer_joins(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def where(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def rewhere(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def preload(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def eager_load(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def includes(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def from(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def lock(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def readonly(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def or(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def having(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def create_with(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def distinct(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def references(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def none(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def unscope(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def except(*args, &block); end
 
 end

--- a/spec/test_data/v5.0/expected_wizard_wo_spellbook.rbi
+++ b/spec/test_data/v5.0/expected_wizard_wo_spellbook.rbi
@@ -2,13 +2,13 @@
 # Please rerun rake rails_rbi:models to regenerate.
 # typed: strong
 
-class Wizard::Relation < ActiveRecord::Relation
+class Wizard::ActiveRecord_Relation < ActiveRecord::Relation
   include Wizard::ModelRelationShared
   extend T::Generic
   Elem = type_member(fixed: Wizard)
 end
 
-class Wizard::CollectionProxy < ActiveRecord::Associations::CollectionProxy
+class Wizard::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include Wizard::ModelRelationShared
   extend T::Generic
   Elem = type_member(fixed: Wizard)
@@ -18,7 +18,6 @@ class Wizard < ApplicationRecord
   extend T::Sig
   extend T::Generic
   extend Wizard::ModelRelationShared
-  extend Wizard::ClassMethods
   include Wizard::InstanceMethods
   Elem = type_template(fixed: Wizard)
 end
@@ -92,12 +91,6 @@ module Wizard::InstanceMethods
   sig { params(args: T.untyped).returns(T::Boolean) }
   def parent_email?(*args); end
 
-  sig { returns(ActiveRecord::Associations::CollectionProxy[T.untyped]) }
-  def spell_books(); end
-
-  sig { params(value: T.any(T::Array[SpellBook], ActiveRecord::Associations::CollectionProxy[T.untyped])).void }
-  def spell_books=(value); end
-
   sig { returns(DateTime) }
   def updated_at(); end
 
@@ -107,119 +100,137 @@ module Wizard::InstanceMethods
   sig { params(args: T.untyped).returns(T::Boolean) }
   def updated_at?(*args); end
 
-  sig { returns(T.nilable(Wand)) }
-  def wand(); end
-
-  sig { params(value: T.nilable(Wand)).void }
-  def wand=(value); end
-
 end
 
-module Wizard::ClassMethods
+class Wizard
   extend T::Sig
 
+  sig { returns(ActiveRecord::Associations::CollectionProxy) }
+  def spell_books(); end
+
+  sig { params(value: T.any(T::Array[::SpellBook], ActiveRecord::Associations::CollectionProxy)).void }
+  def spell_books=(value); end
+
+  sig { returns(T.nilable(::Wand)) }
+  def wand(); end
+
+  sig { params(value: T.nilable(::Wand)).void }
+  def wand=(value); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.Gryffindor(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.Hufflepuff(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.Ravenclaw(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.Slytherin(*args); end
+
   sig { returns(T::Hash[T.any(String, Symbol), Integer]) }
-  def houses(); end
+  def self.houses(); end
 
 end
 
 module Wizard::ModelRelationShared
   extend T::Sig
 
-  sig { returns(Wizard::Relation) }
+  sig { returns(Wizard::ActiveRecord_Relation) }
   def all(); end
 
-  sig { params(block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def unscoped(&block); end
 
-  sig { params(args: T.untyped).returns(Wizard::Relation) }
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
   def Gryffindor(*args); end
 
-  sig { params(args: T.untyped).returns(Wizard::Relation) }
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
   def Hufflepuff(*args); end
 
-  sig { params(args: T.untyped).returns(Wizard::Relation) }
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
   def Ravenclaw(*args); end
 
-  sig { params(args: T.untyped).returns(Wizard::Relation) }
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
   def Slytherin(*args); end
 
-  sig { params(args: T.untyped).returns(Wizard::Relation) }
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
   def recent(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def select(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def order(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def reorder(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def group(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def limit(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def offset(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def joins(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def left_joins(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def left_outer_joins(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def where(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def rewhere(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def preload(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def eager_load(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def includes(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def from(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def lock(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def readonly(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def or(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def having(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def create_with(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def distinct(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def references(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def none(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def unscope(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def except(*args, &block); end
 
 end

--- a/spec/test_data/v5.1/expected_potion.rbi
+++ b/spec/test_data/v5.1/expected_potion.rbi
@@ -2,13 +2,13 @@
 # Please rerun rake rails_rbi:models to regenerate.
 # typed: strong
 
-class Potion::Relation < ActiveRecord::Relation
+class Potion::ActiveRecord_Relation < ActiveRecord::Relation
   include Potion::ModelRelationShared
   extend T::Generic
   Elem = type_member(fixed: Potion)
 end
 
-class Potion::CollectionProxy < ActiveRecord::Associations::CollectionProxy
+class Potion::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include Potion::ModelRelationShared
   extend T::Generic
   Elem = type_member(fixed: Potion)
@@ -18,7 +18,6 @@ class Potion < ApplicationRecord
   extend T::Sig
   extend T::Generic
   extend Potion::ModelRelationShared
-  extend Potion::ClassMethods
   include Potion::InstanceMethods
   Elem = type_template(fixed: Potion)
 end
@@ -28,7 +27,7 @@ module Potion::InstanceMethods
 
 end
 
-module Potion::ClassMethods
+class Potion
   extend T::Sig
 
 end
@@ -36,94 +35,94 @@ end
 module Potion::ModelRelationShared
   extend T::Sig
 
-  sig { returns(Potion::Relation) }
+  sig { returns(Potion::ActiveRecord_Relation) }
   def all(); end
 
-  sig { params(block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def unscoped(&block); end
 
-  sig { params(args: T.untyped).returns(Potion::Relation) }
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
   def recent(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def select(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def order(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def reorder(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def group(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def limit(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def offset(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def joins(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def left_joins(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def left_outer_joins(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def where(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def rewhere(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def preload(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def eager_load(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def includes(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def from(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def lock(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def readonly(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def extending(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def or(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def having(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def create_with(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def distinct(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def references(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def none(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def unscope(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def merge(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def except(*args, &block); end
 
 end

--- a/spec/test_data/v5.1/expected_spell_book.rbi
+++ b/spec/test_data/v5.1/expected_spell_book.rbi
@@ -2,13 +2,13 @@
 # Please rerun rake rails_rbi:models to regenerate.
 # typed: strong
 
-class SpellBook::Relation < ActiveRecord::Relation
+class SpellBook::ActiveRecord_Relation < ActiveRecord::Relation
   include SpellBook::ModelRelationShared
   extend T::Generic
   Elem = type_member(fixed: SpellBook)
 end
 
-class SpellBook::CollectionProxy < ActiveRecord::Associations::CollectionProxy
+class SpellBook::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include SpellBook::ModelRelationShared
   extend T::Generic
   Elem = type_member(fixed: SpellBook)
@@ -18,7 +18,6 @@ class SpellBook < ApplicationRecord
   extend T::Sig
   extend T::Generic
   extend SpellBook::ModelRelationShared
-  extend SpellBook::ClassMethods
   include SpellBook::InstanceMethods
   Elem = type_template(fixed: SpellBook)
 end
@@ -44,12 +43,6 @@ module SpellBook::InstanceMethods
   sig { params(args: T.untyped).returns(T::Boolean) }
   def name?(*args); end
 
-  sig { returns(T.nilable(Wizard)) }
-  def wizard(); end
-
-  sig { params(value: T.nilable(Wizard)).void }
-  def wizard=(value); end
-
   sig { returns(T.nilable(Integer)) }
   def wizard_id(); end
 
@@ -61,102 +54,108 @@ module SpellBook::InstanceMethods
 
 end
 
-module SpellBook::ClassMethods
+class SpellBook
   extend T::Sig
+
+  sig { returns(T.nilable(::Wizard)) }
+  def wizard(); end
+
+  sig { params(value: T.nilable(::Wizard)).void }
+  def wizard=(value); end
 
 end
 
 module SpellBook::ModelRelationShared
   extend T::Sig
 
-  sig { returns(SpellBook::Relation) }
+  sig { returns(SpellBook::ActiveRecord_Relation) }
   def all(); end
 
-  sig { params(block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def unscoped(&block); end
 
-  sig { params(args: T.untyped).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
   def recent(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def select(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def order(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def reorder(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def group(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def limit(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def offset(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def joins(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def left_joins(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def left_outer_joins(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def where(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def rewhere(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def preload(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def eager_load(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def includes(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def from(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def lock(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def readonly(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def extending(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def or(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def having(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def create_with(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def distinct(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def references(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def none(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def unscope(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def merge(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def except(*args, &block); end
 
 end

--- a/spec/test_data/v5.1/expected_wand.rbi
+++ b/spec/test_data/v5.1/expected_wand.rbi
@@ -2,13 +2,13 @@
 # Please rerun rake rails_rbi:models to regenerate.
 # typed: strong
 
-class Wand::Relation < ActiveRecord::Relation
+class Wand::ActiveRecord_Relation < ActiveRecord::Relation
   include Wand::ModelRelationShared
   extend T::Generic
   Elem = type_member(fixed: Wand)
 end
 
-class Wand::CollectionProxy < ActiveRecord::Associations::CollectionProxy
+class Wand::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include Wand::ModelRelationShared
   extend T::Generic
   Elem = type_member(fixed: Wand)
@@ -18,7 +18,6 @@ class Wand < ApplicationRecord
   extend T::Sig
   extend T::Generic
   extend Wand::ModelRelationShared
-  extend Wand::ClassMethods
   include Wand::InstanceMethods
   Elem = type_template(fixed: Wand)
 end
@@ -128,12 +127,6 @@ module Wand::InstanceMethods
   sig { params(args: T.untyped).returns(T::Boolean) }
   def updated_at?(*args); end
 
-  sig { returns(Wizard) }
-  def wizard(); end
-
-  sig { params(value: Wizard).void }
-  def wizard=(value); end
-
   sig { returns(Integer) }
   def wizard_id(); end
 
@@ -154,117 +147,135 @@ module Wand::InstanceMethods
 
 end
 
-module Wand::ClassMethods
+class Wand
   extend T::Sig
 
+  sig { returns(::Wizard) }
+  def wizard(); end
+
+  sig { params(value: ::Wizard).void }
+  def wizard=(value); end
+
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.basilisk_horn(*args); end
+
   sig { returns(T::Hash[T.any(String, Symbol), Integer]) }
-  def core_types(); end
+  def self.core_types(); end
+
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.dragon_heartstring(*args); end
+
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.phoenix_feather(*args); end
+
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.unicorn_tail_hair(*args); end
 
 end
 
 module Wand::ModelRelationShared
   extend T::Sig
 
-  sig { returns(Wand::Relation) }
+  sig { returns(Wand::ActiveRecord_Relation) }
   def all(); end
 
-  sig { params(block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def unscoped(&block); end
 
-  sig { params(args: T.untyped).returns(Wand::Relation) }
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
   def basilisk_horn(*args); end
 
-  sig { params(args: T.untyped).returns(Wand::Relation) }
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
   def dragon_heartstring(*args); end
 
-  sig { params(args: T.untyped).returns(Wand::Relation) }
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
   def phoenix_feather(*args); end
 
-  sig { params(args: T.untyped).returns(Wand::Relation) }
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
   def recent(*args); end
 
-  sig { params(args: T.untyped).returns(Wand::Relation) }
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
   def unicorn_tail_hair(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def select(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def order(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def reorder(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def group(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def limit(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def offset(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def joins(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def left_joins(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def left_outer_joins(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def where(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def rewhere(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def preload(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def eager_load(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def includes(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def from(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def lock(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def readonly(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def extending(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def or(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def having(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def create_with(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def distinct(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def references(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def none(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def unscope(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def merge(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def except(*args, &block); end
 
 end

--- a/spec/test_data/v5.1/expected_wizard.rbi
+++ b/spec/test_data/v5.1/expected_wizard.rbi
@@ -2,13 +2,13 @@
 # Please rerun rake rails_rbi:models to regenerate.
 # typed: strong
 
-class Wizard::Relation < ActiveRecord::Relation
+class Wizard::ActiveRecord_Relation < ActiveRecord::Relation
   include Wizard::ModelRelationShared
   extend T::Generic
   Elem = type_member(fixed: Wizard)
 end
 
-class Wizard::CollectionProxy < ActiveRecord::Associations::CollectionProxy
+class Wizard::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include Wizard::ModelRelationShared
   extend T::Generic
   Elem = type_member(fixed: Wizard)
@@ -18,7 +18,6 @@ class Wizard < ApplicationRecord
   extend T::Sig
   extend T::Generic
   extend Wizard::ModelRelationShared
-  extend Wizard::ClassMethods
   include Wizard::InstanceMethods
   Elem = type_template(fixed: Wizard)
 end
@@ -92,12 +91,6 @@ module Wizard::InstanceMethods
   sig { params(args: T.untyped).returns(T::Boolean) }
   def parent_email?(*args); end
 
-  sig { returns(SpellBook::CollectionProxy) }
-  def spell_books(); end
-
-  sig { params(value: T.any(T::Array[SpellBook], SpellBook::CollectionProxy)).void }
-  def spell_books=(value); end
-
   sig { returns(DateTime) }
   def updated_at(); end
 
@@ -107,125 +100,143 @@ module Wizard::InstanceMethods
   sig { params(args: T.untyped).returns(T::Boolean) }
   def updated_at?(*args); end
 
-  sig { returns(T.nilable(Wand)) }
-  def wand(); end
-
-  sig { params(value: T.nilable(Wand)).void }
-  def wand=(value); end
-
 end
 
-module Wizard::ClassMethods
+class Wizard
   extend T::Sig
 
+  sig { returns(::SpellBook::ActiveRecord_Associations_CollectionProxy) }
+  def spell_books(); end
+
+  sig { params(value: T.any(T::Array[::SpellBook], ::SpellBook::ActiveRecord_Associations_CollectionProxy)).void }
+  def spell_books=(value); end
+
+  sig { returns(T.nilable(::Wand)) }
+  def wand(); end
+
+  sig { params(value: T.nilable(::Wand)).void }
+  def wand=(value); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.Gryffindor(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.Hufflepuff(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.Ravenclaw(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.Slytherin(*args); end
+
   sig { returns(T::Hash[T.any(String, Symbol), Integer]) }
-  def houses(); end
+  def self.houses(); end
 
 end
 
 module Wizard::ModelRelationShared
   extend T::Sig
 
-  sig { returns(Wizard::Relation) }
+  sig { returns(Wizard::ActiveRecord_Relation) }
   def all(); end
 
-  sig { params(block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def unscoped(&block); end
 
-  sig { params(args: T.untyped).returns(Wizard::Relation) }
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
   def Gryffindor(*args); end
 
-  sig { params(args: T.untyped).returns(Wizard::Relation) }
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
   def Hufflepuff(*args); end
 
-  sig { params(args: T.untyped).returns(Wizard::Relation) }
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
   def Ravenclaw(*args); end
 
-  sig { params(args: T.untyped).returns(Wizard::Relation) }
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
   def Slytherin(*args); end
 
-  sig { params(args: T.untyped).returns(Wizard::Relation) }
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
   def recent(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def select(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def order(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def reorder(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def group(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def limit(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def offset(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def joins(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def left_joins(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def left_outer_joins(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def where(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def rewhere(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def preload(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def eager_load(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def includes(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def from(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def lock(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def readonly(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def extending(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def or(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def having(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def create_with(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def distinct(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def references(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def none(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def unscope(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def merge(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def except(*args, &block); end
 
 end

--- a/spec/test_data/v5.1/expected_wizard_wo_spellbook.rbi
+++ b/spec/test_data/v5.1/expected_wizard_wo_spellbook.rbi
@@ -2,13 +2,13 @@
 # Please rerun rake rails_rbi:models to regenerate.
 # typed: strong
 
-class Wizard::Relation < ActiveRecord::Relation
+class Wizard::ActiveRecord_Relation < ActiveRecord::Relation
   include Wizard::ModelRelationShared
   extend T::Generic
   Elem = type_member(fixed: Wizard)
 end
 
-class Wizard::CollectionProxy < ActiveRecord::Associations::CollectionProxy
+class Wizard::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include Wizard::ModelRelationShared
   extend T::Generic
   Elem = type_member(fixed: Wizard)
@@ -18,7 +18,6 @@ class Wizard < ApplicationRecord
   extend T::Sig
   extend T::Generic
   extend Wizard::ModelRelationShared
-  extend Wizard::ClassMethods
   include Wizard::InstanceMethods
   Elem = type_template(fixed: Wizard)
 end
@@ -92,12 +91,6 @@ module Wizard::InstanceMethods
   sig { params(args: T.untyped).returns(T::Boolean) }
   def parent_email?(*args); end
 
-  sig { returns(ActiveRecord::Associations::CollectionProxy[T.untyped]) }
-  def spell_books(); end
-
-  sig { params(value: T.any(T::Array[SpellBook], ActiveRecord::Associations::CollectionProxy[T.untyped])).void }
-  def spell_books=(value); end
-
   sig { returns(DateTime) }
   def updated_at(); end
 
@@ -107,125 +100,143 @@ module Wizard::InstanceMethods
   sig { params(args: T.untyped).returns(T::Boolean) }
   def updated_at?(*args); end
 
-  sig { returns(T.nilable(Wand)) }
-  def wand(); end
-
-  sig { params(value: T.nilable(Wand)).void }
-  def wand=(value); end
-
 end
 
-module Wizard::ClassMethods
+class Wizard
   extend T::Sig
 
+  sig { returns(ActiveRecord::Associations::CollectionProxy) }
+  def spell_books(); end
+
+  sig { params(value: T.any(T::Array[::SpellBook], ActiveRecord::Associations::CollectionProxy)).void }
+  def spell_books=(value); end
+
+  sig { returns(T.nilable(::Wand)) }
+  def wand(); end
+
+  sig { params(value: T.nilable(::Wand)).void }
+  def wand=(value); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.Gryffindor(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.Hufflepuff(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.Ravenclaw(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.Slytherin(*args); end
+
   sig { returns(T::Hash[T.any(String, Symbol), Integer]) }
-  def houses(); end
+  def self.houses(); end
 
 end
 
 module Wizard::ModelRelationShared
   extend T::Sig
 
-  sig { returns(Wizard::Relation) }
+  sig { returns(Wizard::ActiveRecord_Relation) }
   def all(); end
 
-  sig { params(block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def unscoped(&block); end
 
-  sig { params(args: T.untyped).returns(Wizard::Relation) }
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
   def Gryffindor(*args); end
 
-  sig { params(args: T.untyped).returns(Wizard::Relation) }
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
   def Hufflepuff(*args); end
 
-  sig { params(args: T.untyped).returns(Wizard::Relation) }
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
   def Ravenclaw(*args); end
 
-  sig { params(args: T.untyped).returns(Wizard::Relation) }
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
   def Slytherin(*args); end
 
-  sig { params(args: T.untyped).returns(Wizard::Relation) }
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
   def recent(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def select(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def order(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def reorder(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def group(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def limit(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def offset(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def joins(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def left_joins(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def left_outer_joins(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def where(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def rewhere(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def preload(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def eager_load(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def includes(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def from(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def lock(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def readonly(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def extending(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def or(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def having(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def create_with(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def distinct(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def references(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def none(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def unscope(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def merge(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def except(*args, &block); end
 
 end

--- a/spec/test_data/v5.2/expected_potion.rbi
+++ b/spec/test_data/v5.2/expected_potion.rbi
@@ -2,13 +2,13 @@
 # Please rerun rake rails_rbi:models to regenerate.
 # typed: strong
 
-class Potion::Relation < ActiveRecord::Relation
+class Potion::ActiveRecord_Relation < ActiveRecord::Relation
   include Potion::ModelRelationShared
   extend T::Generic
   Elem = type_member(fixed: Potion)
 end
 
-class Potion::CollectionProxy < ActiveRecord::Associations::CollectionProxy
+class Potion::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include Potion::ModelRelationShared
   extend T::Generic
   Elem = type_member(fixed: Potion)
@@ -18,7 +18,6 @@ class Potion < ApplicationRecord
   extend T::Sig
   extend T::Generic
   extend Potion::ModelRelationShared
-  extend Potion::ClassMethods
   include Potion::InstanceMethods
   Elem = type_template(fixed: Potion)
 end
@@ -28,7 +27,7 @@ module Potion::InstanceMethods
 
 end
 
-module Potion::ClassMethods
+class Potion
   extend T::Sig
 
 end
@@ -36,94 +35,94 @@ end
 module Potion::ModelRelationShared
   extend T::Sig
 
-  sig { returns(Potion::Relation) }
+  sig { returns(Potion::ActiveRecord_Relation) }
   def all(); end
 
-  sig { params(block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def unscoped(&block); end
 
-  sig { params(args: T.untyped).returns(Potion::Relation) }
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
   def recent(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def select(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def order(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def reorder(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def group(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def limit(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def offset(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def joins(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def left_joins(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def left_outer_joins(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def where(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def rewhere(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def preload(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def eager_load(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def includes(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def from(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def lock(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def readonly(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def extending(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def or(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def having(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def create_with(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def distinct(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def references(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def none(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def unscope(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def merge(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def except(*args, &block); end
 
 end

--- a/spec/test_data/v5.2/expected_spell_book.rbi
+++ b/spec/test_data/v5.2/expected_spell_book.rbi
@@ -2,13 +2,13 @@
 # Please rerun rake rails_rbi:models to regenerate.
 # typed: strong
 
-class SpellBook::Relation < ActiveRecord::Relation
+class SpellBook::ActiveRecord_Relation < ActiveRecord::Relation
   include SpellBook::ModelRelationShared
   extend T::Generic
   Elem = type_member(fixed: SpellBook)
 end
 
-class SpellBook::CollectionProxy < ActiveRecord::Associations::CollectionProxy
+class SpellBook::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include SpellBook::ModelRelationShared
   extend T::Generic
   Elem = type_member(fixed: SpellBook)
@@ -18,7 +18,6 @@ class SpellBook < ApplicationRecord
   extend T::Sig
   extend T::Generic
   extend SpellBook::ModelRelationShared
-  extend SpellBook::ClassMethods
   include SpellBook::InstanceMethods
   Elem = type_template(fixed: SpellBook)
 end
@@ -44,12 +43,6 @@ module SpellBook::InstanceMethods
   sig { params(args: T.untyped).returns(T::Boolean) }
   def name?(*args); end
 
-  sig { returns(T.nilable(Wizard)) }
-  def wizard(); end
-
-  sig { params(value: T.nilable(Wizard)).void }
-  def wizard=(value); end
-
   sig { returns(T.nilable(Integer)) }
   def wizard_id(); end
 
@@ -61,102 +54,108 @@ module SpellBook::InstanceMethods
 
 end
 
-module SpellBook::ClassMethods
+class SpellBook
   extend T::Sig
+
+  sig { returns(T.nilable(::Wizard)) }
+  def wizard(); end
+
+  sig { params(value: T.nilable(::Wizard)).void }
+  def wizard=(value); end
 
 end
 
 module SpellBook::ModelRelationShared
   extend T::Sig
 
-  sig { returns(SpellBook::Relation) }
+  sig { returns(SpellBook::ActiveRecord_Relation) }
   def all(); end
 
-  sig { params(block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def unscoped(&block); end
 
-  sig { params(args: T.untyped).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
   def recent(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def select(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def order(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def reorder(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def group(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def limit(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def offset(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def joins(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def left_joins(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def left_outer_joins(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def where(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def rewhere(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def preload(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def eager_load(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def includes(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def from(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def lock(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def readonly(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def extending(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def or(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def having(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def create_with(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def distinct(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def references(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def none(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def unscope(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def merge(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def except(*args, &block); end
 
 end

--- a/spec/test_data/v5.2/expected_wand.rbi
+++ b/spec/test_data/v5.2/expected_wand.rbi
@@ -2,13 +2,13 @@
 # Please rerun rake rails_rbi:models to regenerate.
 # typed: strong
 
-class Wand::Relation < ActiveRecord::Relation
+class Wand::ActiveRecord_Relation < ActiveRecord::Relation
   include Wand::ModelRelationShared
   extend T::Generic
   Elem = type_member(fixed: Wand)
 end
 
-class Wand::CollectionProxy < ActiveRecord::Associations::CollectionProxy
+class Wand::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include Wand::ModelRelationShared
   extend T::Generic
   Elem = type_member(fixed: Wand)
@@ -18,7 +18,6 @@ class Wand < ApplicationRecord
   extend T::Sig
   extend T::Generic
   extend Wand::ModelRelationShared
-  extend Wand::ClassMethods
   include Wand::InstanceMethods
   Elem = type_template(fixed: Wand)
 end
@@ -146,12 +145,6 @@ module Wand::InstanceMethods
   sig { params(args: T.untyped).returns(T::Boolean) }
   def updated_at?(*args); end
 
-  sig { returns(Wizard) }
-  def wizard(); end
-
-  sig { params(value: Wizard).void }
-  def wizard=(value); end
-
   sig { returns(Integer) }
   def wizard_id(); end
 
@@ -172,117 +165,135 @@ module Wand::InstanceMethods
 
 end
 
-module Wand::ClassMethods
+class Wand
   extend T::Sig
 
+  sig { returns(::Wizard) }
+  def wizard(); end
+
+  sig { params(value: ::Wizard).void }
+  def wizard=(value); end
+
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.basilisk_horn(*args); end
+
   sig { returns(T::Hash[T.any(String, Symbol), Integer]) }
-  def core_types(); end
+  def self.core_types(); end
+
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.dragon_heartstring(*args); end
+
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.phoenix_feather(*args); end
+
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.unicorn_tail_hair(*args); end
 
 end
 
 module Wand::ModelRelationShared
   extend T::Sig
 
-  sig { returns(Wand::Relation) }
+  sig { returns(Wand::ActiveRecord_Relation) }
   def all(); end
 
-  sig { params(block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def unscoped(&block); end
 
-  sig { params(args: T.untyped).returns(Wand::Relation) }
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
   def basilisk_horn(*args); end
 
-  sig { params(args: T.untyped).returns(Wand::Relation) }
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
   def dragon_heartstring(*args); end
 
-  sig { params(args: T.untyped).returns(Wand::Relation) }
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
   def phoenix_feather(*args); end
 
-  sig { params(args: T.untyped).returns(Wand::Relation) }
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
   def recent(*args); end
 
-  sig { params(args: T.untyped).returns(Wand::Relation) }
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
   def unicorn_tail_hair(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def select(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def order(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def reorder(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def group(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def limit(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def offset(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def joins(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def left_joins(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def left_outer_joins(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def where(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def rewhere(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def preload(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def eager_load(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def includes(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def from(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def lock(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def readonly(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def extending(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def or(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def having(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def create_with(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def distinct(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def references(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def none(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def unscope(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def merge(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def except(*args, &block); end
 
 end

--- a/spec/test_data/v5.2/expected_wizard.rbi
+++ b/spec/test_data/v5.2/expected_wizard.rbi
@@ -2,13 +2,13 @@
 # Please rerun rake rails_rbi:models to regenerate.
 # typed: strong
 
-class Wizard::Relation < ActiveRecord::Relation
+class Wizard::ActiveRecord_Relation < ActiveRecord::Relation
   include Wizard::ModelRelationShared
   extend T::Generic
   Elem = type_member(fixed: Wizard)
 end
 
-class Wizard::CollectionProxy < ActiveRecord::Associations::CollectionProxy
+class Wizard::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include Wizard::ModelRelationShared
   extend T::Generic
   Elem = type_member(fixed: Wizard)
@@ -18,7 +18,6 @@ class Wizard < ApplicationRecord
   extend T::Sig
   extend T::Generic
   extend Wizard::ModelRelationShared
-  extend Wizard::ClassMethods
   include Wizard::InstanceMethods
   Elem = type_template(fixed: Wizard)
 end
@@ -92,12 +91,6 @@ module Wizard::InstanceMethods
   sig { params(args: T.untyped).returns(T::Boolean) }
   def parent_email?(*args); end
 
-  sig { returns(SpellBook::CollectionProxy) }
-  def spell_books(); end
-
-  sig { params(value: T.any(T::Array[SpellBook], SpellBook::CollectionProxy)).void }
-  def spell_books=(value); end
-
   sig { returns(DateTime) }
   def updated_at(); end
 
@@ -107,125 +100,143 @@ module Wizard::InstanceMethods
   sig { params(args: T.untyped).returns(T::Boolean) }
   def updated_at?(*args); end
 
-  sig { returns(T.nilable(Wand)) }
-  def wand(); end
-
-  sig { params(value: T.nilable(Wand)).void }
-  def wand=(value); end
-
 end
 
-module Wizard::ClassMethods
+class Wizard
   extend T::Sig
 
+  sig { returns(::SpellBook::ActiveRecord_Associations_CollectionProxy) }
+  def spell_books(); end
+
+  sig { params(value: T.any(T::Array[::SpellBook], ::SpellBook::ActiveRecord_Associations_CollectionProxy)).void }
+  def spell_books=(value); end
+
+  sig { returns(T.nilable(::Wand)) }
+  def wand(); end
+
+  sig { params(value: T.nilable(::Wand)).void }
+  def wand=(value); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.Gryffindor(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.Hufflepuff(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.Ravenclaw(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.Slytherin(*args); end
+
   sig { returns(T::Hash[T.any(String, Symbol), Integer]) }
-  def houses(); end
+  def self.houses(); end
 
 end
 
 module Wizard::ModelRelationShared
   extend T::Sig
 
-  sig { returns(Wizard::Relation) }
+  sig { returns(Wizard::ActiveRecord_Relation) }
   def all(); end
 
-  sig { params(block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def unscoped(&block); end
 
-  sig { params(args: T.untyped).returns(Wizard::Relation) }
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
   def Gryffindor(*args); end
 
-  sig { params(args: T.untyped).returns(Wizard::Relation) }
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
   def Hufflepuff(*args); end
 
-  sig { params(args: T.untyped).returns(Wizard::Relation) }
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
   def Ravenclaw(*args); end
 
-  sig { params(args: T.untyped).returns(Wizard::Relation) }
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
   def Slytherin(*args); end
 
-  sig { params(args: T.untyped).returns(Wizard::Relation) }
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
   def recent(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def select(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def order(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def reorder(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def group(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def limit(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def offset(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def joins(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def left_joins(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def left_outer_joins(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def where(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def rewhere(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def preload(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def eager_load(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def includes(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def from(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def lock(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def readonly(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def extending(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def or(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def having(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def create_with(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def distinct(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def references(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def none(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def unscope(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def merge(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def except(*args, &block); end
 
 end

--- a/spec/test_data/v5.2/expected_wizard_wo_spellbook.rbi
+++ b/spec/test_data/v5.2/expected_wizard_wo_spellbook.rbi
@@ -2,13 +2,13 @@
 # Please rerun rake rails_rbi:models to regenerate.
 # typed: strong
 
-class Wizard::Relation < ActiveRecord::Relation
+class Wizard::ActiveRecord_Relation < ActiveRecord::Relation
   include Wizard::ModelRelationShared
   extend T::Generic
   Elem = type_member(fixed: Wizard)
 end
 
-class Wizard::CollectionProxy < ActiveRecord::Associations::CollectionProxy
+class Wizard::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include Wizard::ModelRelationShared
   extend T::Generic
   Elem = type_member(fixed: Wizard)
@@ -18,7 +18,6 @@ class Wizard < ApplicationRecord
   extend T::Sig
   extend T::Generic
   extend Wizard::ModelRelationShared
-  extend Wizard::ClassMethods
   include Wizard::InstanceMethods
   Elem = type_template(fixed: Wizard)
 end
@@ -92,12 +91,6 @@ module Wizard::InstanceMethods
   sig { params(args: T.untyped).returns(T::Boolean) }
   def parent_email?(*args); end
 
-  sig { returns(ActiveRecord::Associations::CollectionProxy[T.untyped]) }
-  def spell_books(); end
-
-  sig { params(value: T.any(T::Array[SpellBook], ActiveRecord::Associations::CollectionProxy[T.untyped])).void }
-  def spell_books=(value); end
-
   sig { returns(DateTime) }
   def updated_at(); end
 
@@ -107,125 +100,143 @@ module Wizard::InstanceMethods
   sig { params(args: T.untyped).returns(T::Boolean) }
   def updated_at?(*args); end
 
-  sig { returns(T.nilable(Wand)) }
-  def wand(); end
-
-  sig { params(value: T.nilable(Wand)).void }
-  def wand=(value); end
-
 end
 
-module Wizard::ClassMethods
+class Wizard
   extend T::Sig
 
+  sig { returns(ActiveRecord::Associations::CollectionProxy) }
+  def spell_books(); end
+
+  sig { params(value: T.any(T::Array[::SpellBook], ActiveRecord::Associations::CollectionProxy)).void }
+  def spell_books=(value); end
+
+  sig { returns(T.nilable(::Wand)) }
+  def wand(); end
+
+  sig { params(value: T.nilable(::Wand)).void }
+  def wand=(value); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.Gryffindor(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.Hufflepuff(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.Ravenclaw(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.Slytherin(*args); end
+
   sig { returns(T::Hash[T.any(String, Symbol), Integer]) }
-  def houses(); end
+  def self.houses(); end
 
 end
 
 module Wizard::ModelRelationShared
   extend T::Sig
 
-  sig { returns(Wizard::Relation) }
+  sig { returns(Wizard::ActiveRecord_Relation) }
   def all(); end
 
-  sig { params(block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def unscoped(&block); end
 
-  sig { params(args: T.untyped).returns(Wizard::Relation) }
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
   def Gryffindor(*args); end
 
-  sig { params(args: T.untyped).returns(Wizard::Relation) }
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
   def Hufflepuff(*args); end
 
-  sig { params(args: T.untyped).returns(Wizard::Relation) }
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
   def Ravenclaw(*args); end
 
-  sig { params(args: T.untyped).returns(Wizard::Relation) }
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
   def Slytherin(*args); end
 
-  sig { params(args: T.untyped).returns(Wizard::Relation) }
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
   def recent(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def select(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def order(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def reorder(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def group(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def limit(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def offset(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def joins(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def left_joins(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def left_outer_joins(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def where(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def rewhere(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def preload(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def eager_load(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def includes(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def from(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def lock(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def readonly(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def extending(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def or(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def having(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def create_with(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def distinct(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def references(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def none(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def unscope(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def merge(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def except(*args, &block); end
 
 end

--- a/spec/test_data/v6.0/expected_potion.rbi
+++ b/spec/test_data/v6.0/expected_potion.rbi
@@ -2,13 +2,13 @@
 # Please rerun rake rails_rbi:models to regenerate.
 # typed: strong
 
-class Potion::Relation < ActiveRecord::Relation
+class Potion::ActiveRecord_Relation < ActiveRecord::Relation
   include Potion::ModelRelationShared
   extend T::Generic
   Elem = type_member(fixed: Potion)
 end
 
-class Potion::CollectionProxy < ActiveRecord::Associations::CollectionProxy
+class Potion::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include Potion::ModelRelationShared
   extend T::Generic
   Elem = type_member(fixed: Potion)
@@ -18,7 +18,6 @@ class Potion < ApplicationRecord
   extend T::Sig
   extend T::Generic
   extend Potion::ModelRelationShared
-  extend Potion::ClassMethods
   include Potion::InstanceMethods
   Elem = type_template(fixed: Potion)
 end
@@ -28,7 +27,7 @@ module Potion::InstanceMethods
 
 end
 
-module Potion::ClassMethods
+class Potion
   extend T::Sig
 
 end
@@ -36,106 +35,106 @@ end
 module Potion::ModelRelationShared
   extend T::Sig
 
-  sig { returns(Potion::Relation) }
+  sig { returns(Potion::ActiveRecord_Relation) }
   def all(); end
 
-  sig { params(block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def unscoped(&block); end
 
-  sig { params(args: T.untyped).returns(Potion::Relation) }
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
   def recent(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def select(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def reselect(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def order(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def reorder(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def group(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def limit(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def offset(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def joins(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def left_joins(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def left_outer_joins(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def where(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def rewhere(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def preload(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def extract_associated(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def eager_load(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def includes(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def from(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def lock(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def readonly(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def extending(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def or(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def having(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def create_with(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def distinct(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def references(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def none(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def unscope(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def optimizer_hints(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def merge(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def except(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def only(*args, &block); end
 
 end

--- a/spec/test_data/v6.0/expected_spell_book.rbi
+++ b/spec/test_data/v6.0/expected_spell_book.rbi
@@ -2,13 +2,13 @@
 # Please rerun rake rails_rbi:models to regenerate.
 # typed: strong
 
-class SpellBook::Relation < ActiveRecord::Relation
+class SpellBook::ActiveRecord_Relation < ActiveRecord::Relation
   include SpellBook::ModelRelationShared
   extend T::Generic
   Elem = type_member(fixed: SpellBook)
 end
 
-class SpellBook::CollectionProxy < ActiveRecord::Associations::CollectionProxy
+class SpellBook::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include SpellBook::ModelRelationShared
   extend T::Generic
   Elem = type_member(fixed: SpellBook)
@@ -18,7 +18,6 @@ class SpellBook < ApplicationRecord
   extend T::Sig
   extend T::Generic
   extend SpellBook::ModelRelationShared
-  extend SpellBook::ClassMethods
   include SpellBook::InstanceMethods
   Elem = type_template(fixed: SpellBook)
 end
@@ -44,12 +43,6 @@ module SpellBook::InstanceMethods
   sig { params(args: T.untyped).returns(T::Boolean) }
   def name?(*args); end
 
-  sig { returns(T.nilable(Wizard)) }
-  def wizard(); end
-
-  sig { params(value: T.nilable(Wizard)).void }
-  def wizard=(value); end
-
   sig { returns(T.nilable(Integer)) }
   def wizard_id(); end
 
@@ -61,114 +54,120 @@ module SpellBook::InstanceMethods
 
 end
 
-module SpellBook::ClassMethods
+class SpellBook
   extend T::Sig
+
+  sig { returns(T.nilable(::Wizard)) }
+  def wizard(); end
+
+  sig { params(value: T.nilable(::Wizard)).void }
+  def wizard=(value); end
 
 end
 
 module SpellBook::ModelRelationShared
   extend T::Sig
 
-  sig { returns(SpellBook::Relation) }
+  sig { returns(SpellBook::ActiveRecord_Relation) }
   def all(); end
 
-  sig { params(block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def unscoped(&block); end
 
-  sig { params(args: T.untyped).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
   def recent(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def select(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def reselect(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def order(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def reorder(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def group(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def limit(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def offset(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def joins(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def left_joins(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def left_outer_joins(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def where(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def rewhere(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def preload(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def extract_associated(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def eager_load(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def includes(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def from(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def lock(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def readonly(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def extending(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def or(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def having(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def create_with(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def distinct(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def references(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def none(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def unscope(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def optimizer_hints(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def merge(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def except(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def only(*args, &block); end
 
 end

--- a/spec/test_data/v6.0/expected_wand.rbi
+++ b/spec/test_data/v6.0/expected_wand.rbi
@@ -2,13 +2,13 @@
 # Please rerun rake rails_rbi:models to regenerate.
 # typed: strong
 
-class Wand::Relation < ActiveRecord::Relation
+class Wand::ActiveRecord_Relation < ActiveRecord::Relation
   include Wand::ModelRelationShared
   extend T::Generic
   Elem = type_member(fixed: Wand)
 end
 
-class Wand::CollectionProxy < ActiveRecord::Associations::CollectionProxy
+class Wand::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include Wand::ModelRelationShared
   extend T::Generic
   Elem = type_member(fixed: Wand)
@@ -18,7 +18,6 @@ class Wand < ApplicationRecord
   extend T::Sig
   extend T::Generic
   extend Wand::ModelRelationShared
-  extend Wand::ClassMethods
   include Wand::InstanceMethods
   Elem = type_template(fixed: Wand)
 end
@@ -146,12 +145,6 @@ module Wand::InstanceMethods
   sig { params(args: T.untyped).returns(T::Boolean) }
   def updated_at?(*args); end
 
-  sig { returns(Wizard) }
-  def wizard(); end
-
-  sig { params(value: Wizard).void }
-  def wizard=(value); end
-
   sig { returns(Integer) }
   def wizard_id(); end
 
@@ -172,141 +165,159 @@ module Wand::InstanceMethods
 
 end
 
-module Wand::ClassMethods
+class Wand
   extend T::Sig
 
+  sig { returns(::Wizard) }
+  def wizard(); end
+
+  sig { params(value: ::Wizard).void }
+  def wizard=(value); end
+
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.basilisk_horn(*args); end
+
   sig { returns(T::Hash[T.any(String, Symbol), Integer]) }
-  def core_types(); end
+  def self.core_types(); end
+
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.dragon_heartstring(*args); end
+
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.phoenix_feather(*args); end
+
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.unicorn_tail_hair(*args); end
 
 end
 
 module Wand::ModelRelationShared
   extend T::Sig
 
-  sig { returns(Wand::Relation) }
+  sig { returns(Wand::ActiveRecord_Relation) }
   def all(); end
 
-  sig { params(block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def unscoped(&block); end
 
-  sig { params(args: T.untyped).returns(Wand::Relation) }
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
   def basilisk_horn(*args); end
 
-  sig { params(args: T.untyped).returns(Wand::Relation) }
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
   def dragon_heartstring(*args); end
 
-  sig { params(args: T.untyped).returns(Wand::Relation) }
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
   def not_basilisk_horn(*args); end
 
-  sig { params(args: T.untyped).returns(Wand::Relation) }
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
   def not_dragon_heartstring(*args); end
 
-  sig { params(args: T.untyped).returns(Wand::Relation) }
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
   def not_phoenix_feather(*args); end
 
-  sig { params(args: T.untyped).returns(Wand::Relation) }
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
   def not_unicorn_tail_hair(*args); end
 
-  sig { params(args: T.untyped).returns(Wand::Relation) }
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
   def phoenix_feather(*args); end
 
-  sig { params(args: T.untyped).returns(Wand::Relation) }
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
   def recent(*args); end
 
-  sig { params(args: T.untyped).returns(Wand::Relation) }
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
   def unicorn_tail_hair(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def select(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def reselect(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def order(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def reorder(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def group(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def limit(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def offset(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def joins(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def left_joins(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def left_outer_joins(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def where(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def rewhere(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def preload(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def extract_associated(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def eager_load(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def includes(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def from(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def lock(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def readonly(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def extending(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def or(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def having(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def create_with(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def distinct(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def references(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def none(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def unscope(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def optimizer_hints(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def merge(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def except(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def only(*args, &block); end
 
 end

--- a/spec/test_data/v6.0/expected_wizard.rbi
+++ b/spec/test_data/v6.0/expected_wizard.rbi
@@ -2,13 +2,13 @@
 # Please rerun rake rails_rbi:models to regenerate.
 # typed: strong
 
-class Wizard::Relation < ActiveRecord::Relation
+class Wizard::ActiveRecord_Relation < ActiveRecord::Relation
   include Wizard::ModelRelationShared
   extend T::Generic
   Elem = type_member(fixed: Wizard)
 end
 
-class Wizard::CollectionProxy < ActiveRecord::Associations::CollectionProxy
+class Wizard::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include Wizard::ModelRelationShared
   extend T::Generic
   Elem = type_member(fixed: Wizard)
@@ -18,7 +18,6 @@ class Wizard < ApplicationRecord
   extend T::Sig
   extend T::Generic
   extend Wizard::ModelRelationShared
-  extend Wizard::ClassMethods
   include Wizard::InstanceMethods
   Elem = type_template(fixed: Wizard)
 end
@@ -92,12 +91,6 @@ module Wizard::InstanceMethods
   sig { params(args: T.untyped).returns(T::Boolean) }
   def parent_email?(*args); end
 
-  sig { returns(SpellBook::CollectionProxy) }
-  def spell_books(); end
-
-  sig { params(value: T.any(T::Array[SpellBook], SpellBook::CollectionProxy)).void }
-  def spell_books=(value); end
-
   sig { returns(DateTime) }
   def updated_at(); end
 
@@ -107,149 +100,167 @@ module Wizard::InstanceMethods
   sig { params(args: T.untyped).returns(T::Boolean) }
   def updated_at?(*args); end
 
-  sig { returns(T.nilable(Wand)) }
-  def wand(); end
-
-  sig { params(value: T.nilable(Wand)).void }
-  def wand=(value); end
-
 end
 
-module Wizard::ClassMethods
+class Wizard
   extend T::Sig
 
+  sig { returns(::SpellBook::ActiveRecord_Associations_CollectionProxy) }
+  def spell_books(); end
+
+  sig { params(value: T.any(T::Array[::SpellBook], ::SpellBook::ActiveRecord_Associations_CollectionProxy)).void }
+  def spell_books=(value); end
+
+  sig { returns(T.nilable(::Wand)) }
+  def wand(); end
+
+  sig { params(value: T.nilable(::Wand)).void }
+  def wand=(value); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.Gryffindor(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.Hufflepuff(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.Ravenclaw(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.Slytherin(*args); end
+
   sig { returns(T::Hash[T.any(String, Symbol), Integer]) }
-  def houses(); end
+  def self.houses(); end
 
 end
 
 module Wizard::ModelRelationShared
   extend T::Sig
 
-  sig { returns(Wizard::Relation) }
+  sig { returns(Wizard::ActiveRecord_Relation) }
   def all(); end
 
-  sig { params(block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def unscoped(&block); end
 
-  sig { params(args: T.untyped).returns(Wizard::Relation) }
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
   def Gryffindor(*args); end
 
-  sig { params(args: T.untyped).returns(Wizard::Relation) }
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
   def Hufflepuff(*args); end
 
-  sig { params(args: T.untyped).returns(Wizard::Relation) }
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
   def Ravenclaw(*args); end
 
-  sig { params(args: T.untyped).returns(Wizard::Relation) }
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
   def Slytherin(*args); end
 
-  sig { params(args: T.untyped).returns(Wizard::Relation) }
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
   def not_Gryffindor(*args); end
 
-  sig { params(args: T.untyped).returns(Wizard::Relation) }
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
   def not_Hufflepuff(*args); end
 
-  sig { params(args: T.untyped).returns(Wizard::Relation) }
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
   def not_Ravenclaw(*args); end
 
-  sig { params(args: T.untyped).returns(Wizard::Relation) }
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
   def not_Slytherin(*args); end
 
-  sig { params(args: T.untyped).returns(Wizard::Relation) }
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
   def recent(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def select(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def reselect(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def order(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def reorder(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def group(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def limit(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def offset(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def joins(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def left_joins(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def left_outer_joins(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def where(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def rewhere(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def preload(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def extract_associated(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def eager_load(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def includes(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def from(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def lock(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def readonly(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def extending(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def or(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def having(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def create_with(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def distinct(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def references(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def none(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def unscope(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def optimizer_hints(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def merge(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def except(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def only(*args, &block); end
 
 end

--- a/spec/test_data/v6.0/expected_wizard_wo_spellbook.rbi
+++ b/spec/test_data/v6.0/expected_wizard_wo_spellbook.rbi
@@ -2,13 +2,13 @@
 # Please rerun rake rails_rbi:models to regenerate.
 # typed: strong
 
-class Wizard::Relation < ActiveRecord::Relation
+class Wizard::ActiveRecord_Relation < ActiveRecord::Relation
   include Wizard::ModelRelationShared
   extend T::Generic
   Elem = type_member(fixed: Wizard)
 end
 
-class Wizard::CollectionProxy < ActiveRecord::Associations::CollectionProxy
+class Wizard::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include Wizard::ModelRelationShared
   extend T::Generic
   Elem = type_member(fixed: Wizard)
@@ -18,7 +18,6 @@ class Wizard < ApplicationRecord
   extend T::Sig
   extend T::Generic
   extend Wizard::ModelRelationShared
-  extend Wizard::ClassMethods
   include Wizard::InstanceMethods
   Elem = type_template(fixed: Wizard)
 end
@@ -92,12 +91,6 @@ module Wizard::InstanceMethods
   sig { params(args: T.untyped).returns(T::Boolean) }
   def parent_email?(*args); end
 
-  sig { returns(ActiveRecord::Associations::CollectionProxy[T.untyped]) }
-  def spell_books(); end
-
-  sig { params(value: T.any(T::Array[SpellBook], ActiveRecord::Associations::CollectionProxy[T.untyped])).void }
-  def spell_books=(value); end
-
   sig { returns(DateTime) }
   def updated_at(); end
 
@@ -107,149 +100,167 @@ module Wizard::InstanceMethods
   sig { params(args: T.untyped).returns(T::Boolean) }
   def updated_at?(*args); end
 
-  sig { returns(T.nilable(Wand)) }
-  def wand(); end
-
-  sig { params(value: T.nilable(Wand)).void }
-  def wand=(value); end
-
 end
 
-module Wizard::ClassMethods
+class Wizard
   extend T::Sig
 
+  sig { returns(ActiveRecord::Associations::CollectionProxy) }
+  def spell_books(); end
+
+  sig { params(value: T.any(T::Array[::SpellBook], ActiveRecord::Associations::CollectionProxy)).void }
+  def spell_books=(value); end
+
+  sig { returns(T.nilable(::Wand)) }
+  def wand(); end
+
+  sig { params(value: T.nilable(::Wand)).void }
+  def wand=(value); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.Gryffindor(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.Hufflepuff(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.Ravenclaw(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.Slytherin(*args); end
+
   sig { returns(T::Hash[T.any(String, Symbol), Integer]) }
-  def houses(); end
+  def self.houses(); end
 
 end
 
 module Wizard::ModelRelationShared
   extend T::Sig
 
-  sig { returns(Wizard::Relation) }
+  sig { returns(Wizard::ActiveRecord_Relation) }
   def all(); end
 
-  sig { params(block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def unscoped(&block); end
 
-  sig { params(args: T.untyped).returns(Wizard::Relation) }
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
   def Gryffindor(*args); end
 
-  sig { params(args: T.untyped).returns(Wizard::Relation) }
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
   def Hufflepuff(*args); end
 
-  sig { params(args: T.untyped).returns(Wizard::Relation) }
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
   def Ravenclaw(*args); end
 
-  sig { params(args: T.untyped).returns(Wizard::Relation) }
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
   def Slytherin(*args); end
 
-  sig { params(args: T.untyped).returns(Wizard::Relation) }
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
   def not_Gryffindor(*args); end
 
-  sig { params(args: T.untyped).returns(Wizard::Relation) }
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
   def not_Hufflepuff(*args); end
 
-  sig { params(args: T.untyped).returns(Wizard::Relation) }
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
   def not_Ravenclaw(*args); end
 
-  sig { params(args: T.untyped).returns(Wizard::Relation) }
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
   def not_Slytherin(*args); end
 
-  sig { params(args: T.untyped).returns(Wizard::Relation) }
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
   def recent(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def select(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def reselect(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def order(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def reorder(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def group(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def limit(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def offset(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def joins(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def left_joins(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def left_outer_joins(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def where(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def rewhere(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def preload(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def extract_associated(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def eager_load(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def includes(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def from(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def lock(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def readonly(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def extending(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def or(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def having(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def create_with(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def distinct(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def references(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def none(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def unscope(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def optimizer_hints(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def merge(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def except(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::Relation) }
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def only(*args, &block); end
 
 end


### PR DESCRIPTION
    Fix model rbi generation to work with sorbet 0.4.4366

    Because sorbet generates hidden-definition.rbi file that contains the
    following types of methods, they need to be put at the class leve
    directly for sorbet to recognize the signature.
    - Put associations in a model class directly
    - Put enum-related methods in a model class directly
    Note: we keep column methods in a separate modules because we haven't
    supported serializer or attribute API. This allows people to override
    the generated RBI

    Fix using reflection.klass.name instead of reflection.class_name.
    reflection.class_name is a user-input value when they define an
    association, whereas reflection.klass.name reflects the ruby class that
    Rails thinks the association should be
    This also fix https://github.com/chanzuckerberg/sorbet-rails/issues/15

    Use ActiveRecord_Relation & ActiveRecord_Associations_CollectionPolicy
    to match what Sorbet generates in the hidden-definition file.

    Remove SchemaMetadata from blacklist because we need the generation code
    to define `Elem` for the class. (Every subclass of ActiveRecord::Base
    need to redefine this regardless)
   
    Remove .soft

I tested all the changes locally with a Rails codebase to make sure the generated code works with sorbet, and it works out of the box after set up (ie, people don't have to manually fix things).