### PR TITLE
More fixes to make sorbet-rails work out of the box

### DIFF
--- a/lib/sorbet-rails/model_rbi_formatter.rb
+++ b/lib/sorbet-rails/model_rbi_formatter.rb
@@ -232,7 +232,7 @@ class ModelRbiFormatter
   end
 
   def assoc_should_be_untyped?(reflection)
-    polymorphic_assoc?(reflection) || !Object.const_defined?(reflection.klass.name)
+    polymorphic_assoc?(reflection) || !@available_classes.include?(reflection.klass.name)
   end
 
   def relation_should_be_untyped?(reflection)

--- a/lib/sorbet-rails/model_rbi_formatter.rb
+++ b/lib/sorbet-rails/model_rbi_formatter.rb
@@ -218,6 +218,7 @@ class ModelRbiFormatter
       @generated_class_sigs["#{enum_name.pluralize}"] = { ret: "T::Hash[T.any(String, Symbol), Integer]"}
       enum_hash.keys.each do |enum_val|
         @generated_instance_module_sigs["#{enum_val}?"] = { ret: "T::Boolean" }
+        @generated_instance_module_sigs["#{enum_val}!"] = { ret: nil }
         @generated_scope_sigs["#{enum_val}"] = {
           args: [ name: :args, arg_type: :rest, value_type: 'T.untyped' ],
           ret: @model_relation_class_name,

--- a/lib/sorbet-rails/tasks/rails_rbi.rake
+++ b/lib/sorbet-rails/tasks/rails_rbi.rake
@@ -23,7 +23,7 @@ namespace :rails_rbi do
     # But this is not applied to Rails.application.eager_load! method
     Zeitwerk::Loader.eager_load_all if defined?(Zeitwerk)
 
-    all_models = ActiveRecord::Base.descendants - blacklisted_models
+    all_models = Set.new(ActiveRecord::Base.descendants + whitelisted_models - blacklisted_models)
 
     models_to_generate = args.extras.size > 0 ?
       args.extras.map { |m| Object.const_get(m) } :
@@ -56,5 +56,13 @@ namespace :rails_rbi do
     blacklisted_models = []
     blacklisted_models << ApplicationRecord if defined?(ApplicationRecord)
     blacklisted_models
+  end
+
+  def whitelisted_models
+    # force generating these models because they aren't loaded with eager_load!
+    whitelisted_models = []
+    whitelisted_models << ActiveRecord::InternalMetadata if Object.const_defined?('ActiveRecord::InternalMetadata')
+    whitelisted_models << ActiveRecord::SchemaMigration if Object.const_defined?('ActiveRecord::SchemaMigration')
+    whitelisted_models
   end
 end

--- a/spec/test_data/v4.2/expected_wand.rbi
+++ b/spec/test_data/v4.2/expected_wand.rbi
@@ -25,6 +25,9 @@ end
 module Wand::InstanceMethods
   extend T::Sig
 
+  sig { void }
+  def basilisk_horn!(); end
+
   sig { returns(T::Boolean) }
   def basilisk_horn?(); end
 
@@ -73,6 +76,9 @@ module Wand::InstanceMethods
   sig { params(args: T.untyped).returns(T::Boolean) }
   def created_at?(*args); end
 
+  sig { void }
+  def dragon_heartstring!(); end
+
   sig { returns(T::Boolean) }
   def dragon_heartstring?(); end
 
@@ -103,6 +109,9 @@ module Wand::InstanceMethods
   sig { params(args: T.untyped).returns(T::Boolean) }
   def id?(*args); end
 
+  sig { void }
+  def phoenix_feather!(); end
+
   sig { returns(T::Boolean) }
   def phoenix_feather?(); end
 
@@ -114,6 +123,9 @@ module Wand::InstanceMethods
 
   sig { params(args: T.untyped).returns(T::Boolean) }
   def reflectance?(*args); end
+
+  sig { void }
+  def unicorn_tail_hair!(); end
 
   sig { returns(T::Boolean) }
   def unicorn_tail_hair?(); end

--- a/spec/test_data/v4.2/expected_wizard.rbi
+++ b/spec/test_data/v4.2/expected_wizard.rbi
@@ -25,14 +25,26 @@ end
 module Wizard::InstanceMethods
   extend T::Sig
 
+  sig { void }
+  def Gryffindor!(); end
+
   sig { returns(T::Boolean) }
   def Gryffindor?(); end
+
+  sig { void }
+  def Hufflepuff!(); end
 
   sig { returns(T::Boolean) }
   def Hufflepuff?(); end
 
+  sig { void }
+  def Ravenclaw!(); end
+
   sig { returns(T::Boolean) }
   def Ravenclaw?(); end
+
+  sig { void }
+  def Slytherin!(); end
 
   sig { returns(T::Boolean) }
   def Slytherin?(); end

--- a/spec/test_data/v4.2/expected_wizard_wo_spellbook.rbi
+++ b/spec/test_data/v4.2/expected_wizard_wo_spellbook.rbi
@@ -25,14 +25,26 @@ end
 module Wizard::InstanceMethods
   extend T::Sig
 
+  sig { void }
+  def Gryffindor!(); end
+
   sig { returns(T::Boolean) }
   def Gryffindor?(); end
+
+  sig { void }
+  def Hufflepuff!(); end
 
   sig { returns(T::Boolean) }
   def Hufflepuff?(); end
 
+  sig { void }
+  def Ravenclaw!(); end
+
   sig { returns(T::Boolean) }
   def Ravenclaw?(); end
+
+  sig { void }
+  def Slytherin!(); end
 
   sig { returns(T::Boolean) }
   def Slytherin?(); end
@@ -108,7 +120,7 @@ class Wizard
   sig { returns(ActiveRecord::Associations::CollectionProxy) }
   def spell_books(); end
 
-  sig { params(value: T.any(T::Array[::SpellBook], ActiveRecord::Associations::CollectionProxy)).void }
+  sig { params(value: T.any(T::Array[T.untyped], ActiveRecord::Associations::CollectionProxy)).void }
   def spell_books=(value); end
 
   sig { returns(T.nilable(::Wand)) }

--- a/spec/test_data/v5.0/expected_wand.rbi
+++ b/spec/test_data/v5.0/expected_wand.rbi
@@ -25,6 +25,9 @@ end
 module Wand::InstanceMethods
   extend T::Sig
 
+  sig { void }
+  def basilisk_horn!(); end
+
   sig { returns(T::Boolean) }
   def basilisk_horn?(); end
 
@@ -73,6 +76,9 @@ module Wand::InstanceMethods
   sig { params(args: T.untyped).returns(T::Boolean) }
   def created_at?(*args); end
 
+  sig { void }
+  def dragon_heartstring!(); end
+
   sig { returns(T::Boolean) }
   def dragon_heartstring?(); end
 
@@ -103,6 +109,9 @@ module Wand::InstanceMethods
   sig { params(args: T.untyped).returns(T::Boolean) }
   def id?(*args); end
 
+  sig { void }
+  def phoenix_feather!(); end
+
   sig { returns(T::Boolean) }
   def phoenix_feather?(); end
 
@@ -114,6 +123,9 @@ module Wand::InstanceMethods
 
   sig { params(args: T.untyped).returns(T::Boolean) }
   def reflectance?(*args); end
+
+  sig { void }
+  def unicorn_tail_hair!(); end
 
   sig { returns(T::Boolean) }
   def unicorn_tail_hair?(); end

--- a/spec/test_data/v5.0/expected_wizard.rbi
+++ b/spec/test_data/v5.0/expected_wizard.rbi
@@ -25,14 +25,26 @@ end
 module Wizard::InstanceMethods
   extend T::Sig
 
+  sig { void }
+  def Gryffindor!(); end
+
   sig { returns(T::Boolean) }
   def Gryffindor?(); end
+
+  sig { void }
+  def Hufflepuff!(); end
 
   sig { returns(T::Boolean) }
   def Hufflepuff?(); end
 
+  sig { void }
+  def Ravenclaw!(); end
+
   sig { returns(T::Boolean) }
   def Ravenclaw?(); end
+
+  sig { void }
+  def Slytherin!(); end
 
   sig { returns(T::Boolean) }
   def Slytherin?(); end

--- a/spec/test_data/v5.0/expected_wizard_wo_spellbook.rbi
+++ b/spec/test_data/v5.0/expected_wizard_wo_spellbook.rbi
@@ -25,14 +25,26 @@ end
 module Wizard::InstanceMethods
   extend T::Sig
 
+  sig { void }
+  def Gryffindor!(); end
+
   sig { returns(T::Boolean) }
   def Gryffindor?(); end
+
+  sig { void }
+  def Hufflepuff!(); end
 
   sig { returns(T::Boolean) }
   def Hufflepuff?(); end
 
+  sig { void }
+  def Ravenclaw!(); end
+
   sig { returns(T::Boolean) }
   def Ravenclaw?(); end
+
+  sig { void }
+  def Slytherin!(); end
 
   sig { returns(T::Boolean) }
   def Slytherin?(); end
@@ -108,7 +120,7 @@ class Wizard
   sig { returns(ActiveRecord::Associations::CollectionProxy) }
   def spell_books(); end
 
-  sig { params(value: T.any(T::Array[::SpellBook], ActiveRecord::Associations::CollectionProxy)).void }
+  sig { params(value: T.any(T::Array[T.untyped], ActiveRecord::Associations::CollectionProxy)).void }
   def spell_books=(value); end
 
   sig { returns(T.nilable(::Wand)) }

--- a/spec/test_data/v5.1/expected_wand.rbi
+++ b/spec/test_data/v5.1/expected_wand.rbi
@@ -25,6 +25,9 @@ end
 module Wand::InstanceMethods
   extend T::Sig
 
+  sig { void }
+  def basilisk_horn!(); end
+
   sig { returns(T::Boolean) }
   def basilisk_horn?(); end
 
@@ -73,6 +76,9 @@ module Wand::InstanceMethods
   sig { params(args: T.untyped).returns(T::Boolean) }
   def created_at?(*args); end
 
+  sig { void }
+  def dragon_heartstring!(); end
+
   sig { returns(T::Boolean) }
   def dragon_heartstring?(); end
 
@@ -103,6 +109,9 @@ module Wand::InstanceMethods
   sig { params(args: T.untyped).returns(T::Boolean) }
   def id?(*args); end
 
+  sig { void }
+  def phoenix_feather!(); end
+
   sig { returns(T::Boolean) }
   def phoenix_feather?(); end
 
@@ -114,6 +123,9 @@ module Wand::InstanceMethods
 
   sig { params(args: T.untyped).returns(T::Boolean) }
   def reflectance?(*args); end
+
+  sig { void }
+  def unicorn_tail_hair!(); end
 
   sig { returns(T::Boolean) }
   def unicorn_tail_hair?(); end

--- a/spec/test_data/v5.1/expected_wizard.rbi
+++ b/spec/test_data/v5.1/expected_wizard.rbi
@@ -25,14 +25,26 @@ end
 module Wizard::InstanceMethods
   extend T::Sig
 
+  sig { void }
+  def Gryffindor!(); end
+
   sig { returns(T::Boolean) }
   def Gryffindor?(); end
+
+  sig { void }
+  def Hufflepuff!(); end
 
   sig { returns(T::Boolean) }
   def Hufflepuff?(); end
 
+  sig { void }
+  def Ravenclaw!(); end
+
   sig { returns(T::Boolean) }
   def Ravenclaw?(); end
+
+  sig { void }
+  def Slytherin!(); end
 
   sig { returns(T::Boolean) }
   def Slytherin?(); end

--- a/spec/test_data/v5.1/expected_wizard_wo_spellbook.rbi
+++ b/spec/test_data/v5.1/expected_wizard_wo_spellbook.rbi
@@ -25,14 +25,26 @@ end
 module Wizard::InstanceMethods
   extend T::Sig
 
+  sig { void }
+  def Gryffindor!(); end
+
   sig { returns(T::Boolean) }
   def Gryffindor?(); end
+
+  sig { void }
+  def Hufflepuff!(); end
 
   sig { returns(T::Boolean) }
   def Hufflepuff?(); end
 
+  sig { void }
+  def Ravenclaw!(); end
+
   sig { returns(T::Boolean) }
   def Ravenclaw?(); end
+
+  sig { void }
+  def Slytherin!(); end
 
   sig { returns(T::Boolean) }
   def Slytherin?(); end
@@ -108,7 +120,7 @@ class Wizard
   sig { returns(ActiveRecord::Associations::CollectionProxy) }
   def spell_books(); end
 
-  sig { params(value: T.any(T::Array[::SpellBook], ActiveRecord::Associations::CollectionProxy)).void }
+  sig { params(value: T.any(T::Array[T.untyped], ActiveRecord::Associations::CollectionProxy)).void }
   def spell_books=(value); end
 
   sig { returns(T.nilable(::Wand)) }

--- a/spec/test_data/v5.2/expected_wand.rbi
+++ b/spec/test_data/v5.2/expected_wand.rbi
@@ -25,6 +25,9 @@ end
 module Wand::InstanceMethods
   extend T::Sig
 
+  sig { void }
+  def basilisk_horn!(); end
+
   sig { returns(T::Boolean) }
   def basilisk_horn?(); end
 
@@ -73,6 +76,9 @@ module Wand::InstanceMethods
   sig { params(args: T.untyped).returns(T::Boolean) }
   def created_at?(*args); end
 
+  sig { void }
+  def dragon_heartstring!(); end
+
   sig { returns(T::Boolean) }
   def dragon_heartstring?(); end
 
@@ -112,6 +118,9 @@ module Wand::InstanceMethods
   sig { params(args: T.untyped).returns(T::Boolean) }
   def maker_info?(*args); end
 
+  sig { void }
+  def phoenix_feather!(); end
+
   sig { returns(T::Boolean) }
   def phoenix_feather?(); end
 
@@ -132,6 +141,9 @@ module Wand::InstanceMethods
 
   sig { params(args: T.untyped).returns(T::Boolean) }
   def spell_history?(*args); end
+
+  sig { void }
+  def unicorn_tail_hair!(); end
 
   sig { returns(T::Boolean) }
   def unicorn_tail_hair?(); end

--- a/spec/test_data/v5.2/expected_wizard.rbi
+++ b/spec/test_data/v5.2/expected_wizard.rbi
@@ -25,14 +25,26 @@ end
 module Wizard::InstanceMethods
   extend T::Sig
 
+  sig { void }
+  def Gryffindor!(); end
+
   sig { returns(T::Boolean) }
   def Gryffindor?(); end
+
+  sig { void }
+  def Hufflepuff!(); end
 
   sig { returns(T::Boolean) }
   def Hufflepuff?(); end
 
+  sig { void }
+  def Ravenclaw!(); end
+
   sig { returns(T::Boolean) }
   def Ravenclaw?(); end
+
+  sig { void }
+  def Slytherin!(); end
 
   sig { returns(T::Boolean) }
   def Slytherin?(); end

--- a/spec/test_data/v5.2/expected_wizard_wo_spellbook.rbi
+++ b/spec/test_data/v5.2/expected_wizard_wo_spellbook.rbi
@@ -25,14 +25,26 @@ end
 module Wizard::InstanceMethods
   extend T::Sig
 
+  sig { void }
+  def Gryffindor!(); end
+
   sig { returns(T::Boolean) }
   def Gryffindor?(); end
+
+  sig { void }
+  def Hufflepuff!(); end
 
   sig { returns(T::Boolean) }
   def Hufflepuff?(); end
 
+  sig { void }
+  def Ravenclaw!(); end
+
   sig { returns(T::Boolean) }
   def Ravenclaw?(); end
+
+  sig { void }
+  def Slytherin!(); end
 
   sig { returns(T::Boolean) }
   def Slytherin?(); end
@@ -108,7 +120,7 @@ class Wizard
   sig { returns(ActiveRecord::Associations::CollectionProxy) }
   def spell_books(); end
 
-  sig { params(value: T.any(T::Array[::SpellBook], ActiveRecord::Associations::CollectionProxy)).void }
+  sig { params(value: T.any(T::Array[T.untyped], ActiveRecord::Associations::CollectionProxy)).void }
   def spell_books=(value); end
 
   sig { returns(T.nilable(::Wand)) }

--- a/spec/test_data/v6.0/expected_wand.rbi
+++ b/spec/test_data/v6.0/expected_wand.rbi
@@ -25,6 +25,9 @@ end
 module Wand::InstanceMethods
   extend T::Sig
 
+  sig { void }
+  def basilisk_horn!(); end
+
   sig { returns(T::Boolean) }
   def basilisk_horn?(); end
 
@@ -73,6 +76,9 @@ module Wand::InstanceMethods
   sig { params(args: T.untyped).returns(T::Boolean) }
   def created_at?(*args); end
 
+  sig { void }
+  def dragon_heartstring!(); end
+
   sig { returns(T::Boolean) }
   def dragon_heartstring?(); end
 
@@ -112,6 +118,9 @@ module Wand::InstanceMethods
   sig { params(args: T.untyped).returns(T::Boolean) }
   def maker_info?(*args); end
 
+  sig { void }
+  def phoenix_feather!(); end
+
   sig { returns(T::Boolean) }
   def phoenix_feather?(); end
 
@@ -132,6 +141,9 @@ module Wand::InstanceMethods
 
   sig { params(args: T.untyped).returns(T::Boolean) }
   def spell_history?(*args); end
+
+  sig { void }
+  def unicorn_tail_hair!(); end
 
   sig { returns(T::Boolean) }
   def unicorn_tail_hair?(); end

--- a/spec/test_data/v6.0/expected_wizard.rbi
+++ b/spec/test_data/v6.0/expected_wizard.rbi
@@ -25,14 +25,26 @@ end
 module Wizard::InstanceMethods
   extend T::Sig
 
+  sig { void }
+  def Gryffindor!(); end
+
   sig { returns(T::Boolean) }
   def Gryffindor?(); end
+
+  sig { void }
+  def Hufflepuff!(); end
 
   sig { returns(T::Boolean) }
   def Hufflepuff?(); end
 
+  sig { void }
+  def Ravenclaw!(); end
+
   sig { returns(T::Boolean) }
   def Ravenclaw?(); end
+
+  sig { void }
+  def Slytherin!(); end
 
   sig { returns(T::Boolean) }
   def Slytherin?(); end

--- a/spec/test_data/v6.0/expected_wizard_wo_spellbook.rbi
+++ b/spec/test_data/v6.0/expected_wizard_wo_spellbook.rbi
@@ -25,14 +25,26 @@ end
 module Wizard::InstanceMethods
   extend T::Sig
 
+  sig { void }
+  def Gryffindor!(); end
+
   sig { returns(T::Boolean) }
   def Gryffindor?(); end
+
+  sig { void }
+  def Hufflepuff!(); end
 
   sig { returns(T::Boolean) }
   def Hufflepuff?(); end
 
+  sig { void }
+  def Ravenclaw!(); end
+
   sig { returns(T::Boolean) }
   def Ravenclaw?(); end
+
+  sig { void }
+  def Slytherin!(); end
 
   sig { returns(T::Boolean) }
   def Slytherin?(); end
@@ -108,7 +120,7 @@ class Wizard
   sig { returns(ActiveRecord::Associations::CollectionProxy) }
   def spell_books(); end
 
-  sig { params(value: T.any(T::Array[::SpellBook], ActiveRecord::Associations::CollectionProxy)).void }
+  sig { params(value: T.any(T::Array[T.untyped], ActiveRecord::Associations::CollectionProxy)).void }
   def spell_books=(value); end
 
   sig { returns(T.nilable(::Wand)) }


### PR DESCRIPTION
- Only uses models based on available classes. There was an instance of a model existed in the Const list, but `srb tc` doesn't see it. Better to keep the system correct internally.
- Force generating ActiveRecord::InternalMetadata and ActiveRecord::SchemaMigration because Sorbet starts generating those classes. If we don't generate those classes, `srb tc` will complain that they don't have `Elem` defined. `Rails.application.eager_load!` doesn't load them & I haven't found a way to load them reliably yet
- Generate ! method for enum values