### PR TITLE
Remove instructions about adding sorbet-rails

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,6 @@ This gem adds a few Rake tasks to generate Ruby Interface (RBI) files for dynami
 
 1. Follow the steps [here](https://sorbet.org/docs/adopting) to set up the latest version of Sorbet, up to being able to run `srb tc`.
 
-Note: Do not add `sorbet-rails` to your Gemfile until after you've set up Sorbet. `sorbet-rails` adds RBI files that may [break](https://github.com/sorbet/sorbet/issues/1158) `srb init`.
-
 2. Add `sorbet-rails` to your Gemfile and install them with Bundler.
 
 ```


### PR DESCRIPTION
`srb init` now works with  when `sorbet-rails` is  in the gem file.