### PR TITLE
Regenerate descendants of specific models

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ This Rake task generates RBI files for all models in the Rails application (all 
 ```sh
 ❯ rake rails_rbi:models
 ```
-You can also regenerate RBI files for specific models:
+You can also regenerate RBI files for specific models. To accommodate for STI, this will generate rbi for all the subclasses of the models included.
 ```sh
 ❯ rake rails_rbi:models[ModelName,AnotherOne,...]
 ```

--- a/lib/sorbet-rails/tasks/rails_rbi.rake
+++ b/lib/sorbet-rails/tasks/rails_rbi.rake
@@ -43,14 +43,15 @@ namespace :rails_rbi do
 
     all_models = Set.new(ActiveRecord::Base.descendants + whitelisted_models - blacklisted_models)
 
-    models_to_generate = args.extras.size > 0 ?
-      args.extras.map { |m| Object.const_get(m) } :
-      all_models
-
-    models_to_generate = models_to_generate.
+    models_to_generate = all_models
+    if args.extras.size > 0
+      models_to_generate = args.extras.map { |m| Object.const_get(m) }
+      # also generate descendants of a model
+      models_to_generate = models_to_generate.
       map { |m| [m, m.descendants] }.
       flatten.
       uniq
+    end
 
     generated_rbis = generate_rbis_for_models(models_to_generate, all_models)
     generated_rbis.each do |model_name, contents|

--- a/lib/sorbet-rails/tasks/rails_rbi.rake
+++ b/lib/sorbet-rails/tasks/rails_rbi.rake
@@ -48,9 +48,11 @@ namespace :rails_rbi do
       models_to_generate = args.extras.map { |m| Object.const_get(m) }
       # also generate descendants of a model
       models_to_generate = models_to_generate.
-      map { |m| [m, m.descendants] }.
-      flatten.
-      uniq
+        map { |m| [m, m.descendants] }.
+        flatten.
+        uniq
+      # be safe about ignoring blacklisted models
+      models_to_generate = models_to_generate - blacklisted_models
     end
 
     generated_rbis = generate_rbis_for_models(models_to_generate, all_models)

--- a/lib/sorbet-rails/tasks/rails_rbi.rake
+++ b/lib/sorbet-rails/tasks/rails_rbi.rake
@@ -47,6 +47,11 @@ namespace :rails_rbi do
       args.extras.map { |m| Object.const_get(m) } :
       all_models
 
+    models_to_generate = models_to_generate.
+      map { |m| [m, m.descendants] }.
+      flatten.
+      uniq
+
     generated_rbis = generate_rbis_for_models(models_to_generate, all_models)
     generated_rbis.each do |model_name, contents|
       file_path = Rails.root.join("sorbet", "rails-rbi", "models", "#{model_name.underscore}.rbi")

--- a/spec/rake_rails_rbi_models_spec.rb
+++ b/spec/rake_rails_rbi_models_spec.rb
@@ -44,6 +44,7 @@ RSpec.describe 'rake rails_rbi:models', type: :task do
     expect_files(
       base_dir: generated_dir_path,
       files: [
+        'squib.rbi',
         'wizard.rbi',
       ]
     )
@@ -55,6 +56,7 @@ RSpec.describe 'rake rails_rbi:models', type: :task do
       base_dir: generated_dir_path,
       files: [
         'spell_book.rbi',
+        'squib.rbi',
         'wizard.rbi',
       ]
     )


### PR DESCRIPTION
When using STI in rails with a large number of descendant models, it's frustrating when I update the parent class because I have two options:

1. Re-run the entire `rake rails:models_rbi` script, which is slow.
2. Enumerate all child models manually and make a really long command like `rake rails:models_rbi[Foo,Bar,Bax,Asdf,Etc]`

This changes the default to *include* descendants of a model when its specified as a specific argument. Then I only need to do `rake rails:models_rbi[Parent]` to regenerate all children.

I think this makes sense because I can't really imagine a scenario where the parent changes but we would not want to also be safe and regenerate the children.