### PR TITLE
Include ActionView::Helpers in helpers.rbi

### DIFF
--- a/lib/sorbet-rails/helper_rbi_formatter.rb
+++ b/lib/sorbet-rails/helper_rbi_formatter.rb
@@ -23,6 +23,7 @@ class HelperRbiFormatter
       rbi += <<~RBI
         module #{helper}
           include Kernel
+          include ActionView::Helpers
         end
 
       RBI

--- a/spec/test_data/v4.2/expected_helpers.rbi
+++ b/spec/test_data/v4.2/expected_helpers.rbi
@@ -4,13 +4,16 @@
 
 module BarHelper
   include Kernel
+  include ActionView::Helpers
 end
 
 module BazHelper
   include Kernel
+  include ActionView::Helpers
 end
 
 module FooHelper
   include Kernel
+  include ActionView::Helpers
 end
 

--- a/spec/test_data/v5.0/expected_helpers.rbi
+++ b/spec/test_data/v5.0/expected_helpers.rbi
@@ -4,13 +4,16 @@
 
 module BarHelper
   include Kernel
+  include ActionView::Helpers
 end
 
 module BazHelper
   include Kernel
+  include ActionView::Helpers
 end
 
 module FooHelper
   include Kernel
+  include ActionView::Helpers
 end
 

--- a/spec/test_data/v5.1/expected_helpers.rbi
+++ b/spec/test_data/v5.1/expected_helpers.rbi
@@ -4,13 +4,16 @@
 
 module BarHelper
   include Kernel
+  include ActionView::Helpers
 end
 
 module BazHelper
   include Kernel
+  include ActionView::Helpers
 end
 
 module FooHelper
   include Kernel
+  include ActionView::Helpers
 end
 

--- a/spec/test_data/v5.2-no-sorbet/expected_helpers.rbi
+++ b/spec/test_data/v5.2-no-sorbet/expected_helpers.rbi
@@ -4,13 +4,16 @@
 
 module BarHelper
   include Kernel
+  include ActionView::Helpers
 end
 
 module BazHelper
   include Kernel
+  include ActionView::Helpers
 end
 
 module FooHelper
   include Kernel
+  include ActionView::Helpers
 end
 

--- a/spec/test_data/v5.2/expected_helpers.rbi
+++ b/spec/test_data/v5.2/expected_helpers.rbi
@@ -4,13 +4,16 @@
 
 module BarHelper
   include Kernel
+  include ActionView::Helpers
 end
 
 module BazHelper
   include Kernel
+  include ActionView::Helpers
 end
 
 module FooHelper
   include Kernel
+  include ActionView::Helpers
 end
 

--- a/spec/test_data/v6.0/expected_helpers.rbi
+++ b/spec/test_data/v6.0/expected_helpers.rbi
@@ -4,13 +4,16 @@
 
 module BarHelper
   include Kernel
+  include ActionView::Helpers
 end
 
 module BazHelper
   include Kernel
+  include ActionView::Helpers
 end
 
 module FooHelper
   include Kernel
+  include ActionView::Helpers
 end
 


### PR DESCRIPTION
`ActionView::Helpers` provides methods like `link_to` in Helpers, e.g. I have a helper like this:

```ruby
# typed: true
module GamesHelper
  def sort_dropdown_link(sort, humanized_name)
    link_to(humanized_name, request.params.merge(order_by: nil), class: "dropdown-item#{params[:order_by].nil? ? ' has-text-weight-bold' : ''}")
  end
end
```

Previously, the `link_to` and `request` methods were undefined according to Sorbet. With this change, this code no longer throws Sorbet errors :)

I had hoped to also figure out how to include the URL methods (e.g. `user_url`) in Helpers, but I think the way sorbet-rails currently implements those methods is somewhat flawed (or perhaps I'm misunderstanding how it actually works in Rails?), since I haven't been able to figure out a way to include those methods as part of the helper modules. If I'm missing something, I'd appreciate any help figuring this out :)