### PR TITLE
Fix primary::SchemaMigration in Rails 6.0 & sorbet version upgrade

### DIFF
--- a/lib/sorbet-rails/tasks/rails_rbi.rake
+++ b/lib/sorbet-rails/tasks/rails_rbi.rake
@@ -44,7 +44,7 @@ namespace :rails_rbi do
   task helpers: :environment do |t, args|
     SorbetRails::Utils.rails_eager_load_all!
 
-    if ApplicationController.methods.include?(:modules_for_helpers) 
+    if ApplicationController.methods.include?(:modules_for_helpers)
       helpers = ApplicationController.modules_for_helpers([:all])
     end
 
@@ -85,6 +85,13 @@ namespace :rails_rbi do
   def blacklisted_models
     blacklisted_models = []
     blacklisted_models << ApplicationRecord if defined?(ApplicationRecord)
+    if Object.const_defined?('ActiveRecord::SchemaMigration')
+      # In Rails 6.0, there are dynamically created SchemaMigration classes like primary::SchemaMigration, etc.
+      # We ignore them because Sorbet cannot typecheck those classes and it's unlikely anyone use
+      # them in code.
+      # https://github.com/rails/rails/blob/7cc27d749c3563e6b278ad01d233cb92ea3b7935/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb#L170
+      blacklisted_models.concat(ActiveRecord::SchemaMigration.descendants)
+    end
     blacklisted_models
   end
 

--- a/spec/support/v4.2/sorbet/rbi/hidden-definitions/hidden.rbi
+++ b/spec/support/v4.2/sorbet/rbi/hidden-definitions/hidden.rbi
@@ -17765,8 +17765,6 @@ module OptionParser::Completion
   def candidate(key, icase=T.unsafe(nil), pat=T.unsafe(nil)); end
 
   def complete(key, icase=T.unsafe(nil), pat=T.unsafe(nil)); end
-
-  def convert(opt=T.unsafe(nil), val=T.unsafe(nil), *_); end
 end
 
 module OptionParser::Completion
@@ -17898,7 +17896,6 @@ class OptionParser::Switch::NoArgument
 end
 
 class OptionParser::Switch::NoArgument
-  def self.incompatible_argument_styles(*_); end
 end
 
 class OptionParser::Switch::OptionalArgument

--- a/spec/support/v5.0/sorbet/rbi/hidden-definitions/hidden.rbi
+++ b/spec/support/v5.0/sorbet/rbi/hidden-definitions/hidden.rbi
@@ -18052,8 +18052,6 @@ module OptionParser::Completion
   def candidate(key, icase=T.unsafe(nil), pat=T.unsafe(nil)); end
 
   def complete(key, icase=T.unsafe(nil), pat=T.unsafe(nil)); end
-
-  def convert(opt=T.unsafe(nil), val=T.unsafe(nil), *_); end
 end
 
 module OptionParser::Completion
@@ -18185,7 +18183,6 @@ class OptionParser::Switch::NoArgument
 end
 
 class OptionParser::Switch::NoArgument
-  def self.incompatible_argument_styles(*_); end
 end
 
 class OptionParser::Switch::OptionalArgument

--- a/spec/support/v5.1/sorbet/rbi/hidden-definitions/hidden.rbi
+++ b/spec/support/v5.1/sorbet/rbi/hidden-definitions/hidden.rbi
@@ -17862,8 +17862,6 @@ module OptionParser::Completion
   def candidate(key, icase=T.unsafe(nil), pat=T.unsafe(nil)); end
 
   def complete(key, icase=T.unsafe(nil), pat=T.unsafe(nil)); end
-
-  def convert(opt=T.unsafe(nil), val=T.unsafe(nil), *_); end
 end
 
 module OptionParser::Completion
@@ -17995,7 +17993,6 @@ class OptionParser::Switch::NoArgument
 end
 
 class OptionParser::Switch::NoArgument
-  def self.incompatible_argument_styles(*_); end
 end
 
 class OptionParser::Switch::OptionalArgument

--- a/spec/support/v5.2/sorbet/rbi/hidden-definitions/hidden.rbi
+++ b/spec/support/v5.2/sorbet/rbi/hidden-definitions/hidden.rbi
@@ -17651,8 +17651,6 @@ module OptionParser::Completion
   def candidate(key, icase=T.unsafe(nil), pat=T.unsafe(nil)); end
 
   def complete(key, icase=T.unsafe(nil), pat=T.unsafe(nil)); end
-
-  def convert(opt=T.unsafe(nil), val=T.unsafe(nil), *_); end
 end
 
 module OptionParser::Completion
@@ -17784,7 +17782,6 @@ class OptionParser::Switch::NoArgument
 end
 
 class OptionParser::Switch::NoArgument
-  def self.incompatible_argument_styles(*_); end
 end
 
 class OptionParser::Switch::OptionalArgument

--- a/spec/support/v6.0/sorbet/rbi/hidden-definitions/hidden.rbi
+++ b/spec/support/v6.0/sorbet/rbi/hidden-definitions/hidden.rbi
@@ -21328,8 +21328,6 @@ module OptionParser::Completion
   def candidate(key, icase=T.unsafe(nil), pat=T.unsafe(nil)); end
 
   def complete(key, icase=T.unsafe(nil), pat=T.unsafe(nil)); end
-
-  def convert(opt=T.unsafe(nil), val=T.unsafe(nil), *_); end
 end
 
 module OptionParser::Completion
@@ -21461,7 +21459,6 @@ class OptionParser::Switch::NoArgument
 end
 
 class OptionParser::Switch::NoArgument
-  def self.incompatible_argument_styles(*_); end
 end
 
 class OptionParser::Switch::OptionalArgument


### PR DESCRIPTION
- In Rails 6.0, there are dynamic classes like "primary::SchemaMigration". When we try to generate rbi for this class, sorbet will complain that we shouldn't use dynamic class. We ignore them because it's unlikely anyone will use them.
- Update hidden-definition to avoid conflict with newer version of Sorbet.