### PR TITLE
err.inspect gives more information than err.class

### DIFF
--- a/lib/sorbet-rails/model_rbi_formatter.rb
+++ b/lib/sorbet-rails/model_rbi_formatter.rb
@@ -28,7 +28,7 @@ class SorbetRails::ModelRbiFormatter
       # Load all dynamic instance methods of this model by instantiating a fake model
       @model_class.new unless @model_class.abstract_class?
     rescue StandardError => err
-      puts "#{err.inspect}: Note: Unable to create new instance of #{model_class.name}"
+      puts "Note: Unable to create new instance of #{model_class.name}. Error: #{err.inspect}"
     end
   end
 

--- a/lib/sorbet-rails/model_rbi_formatter.rb
+++ b/lib/sorbet-rails/model_rbi_formatter.rb
@@ -28,7 +28,7 @@ class SorbetRails::ModelRbiFormatter
       # Load all dynamic instance methods of this model by instantiating a fake model
       @model_class.new unless @model_class.abstract_class?
     rescue StandardError => err
-      puts "#{err.class}: Note: Unable to create new instance of #{model_class.name}"
+      puts "#{err.inspect}: Note: Unable to create new instance of #{model_class.name}"
     end
   end
 


### PR DESCRIPTION
Change "err.class" to "err.inspect" because it give more information regarding the error.