### PR TITLE
Add ActiveStorage attachment methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,4 @@ build-iPhoneSimulator/
 *.swk
 
 lib/sorbet/rbi/hidden-definitions/errors.txt
+.vscode

--- a/lib/sorbet-rails/activerecord.rbi
+++ b/lib/sorbet-rails/activerecord.rbi
@@ -20,6 +20,9 @@ class ActiveRecord::Base < Object
 
   sig { returns(T::Boolean) }
   def self.abstract_class?; end
+
+  sig { returns(T::Hash[String, T.untyped]) }
+  def self.attachment_reflections; end
 end
 
 class ActiveRecord::AttributeMethods::TimeZoneConversion::TimeZoneConverter;

--- a/lib/sorbet-rails/config.rb
+++ b/lib/sorbet-rails/config.rb
@@ -49,8 +49,7 @@ module SorbetRails
         :enumerable_collections,
       ]
 
-      # TODO: Replace this with something sensible.
-      @enabled_model_plugins << :active_storage_methods if ['5.2', '6.0'].include?(ENV['RAILS_VERSION'])
+      @enabled_model_plugins << :active_storage_methods if defined?(T.unsafe(ActiveStorage))
     end
 
     sig { returns(T::Array[Symbol]) }

--- a/lib/sorbet-rails/config.rb
+++ b/lib/sorbet-rails/config.rb
@@ -48,6 +48,9 @@ module SorbetRails
         :custom_finder_methods,
         :enumerable_collections,
       ]
+
+      # TODO: Replace this with something sensible.
+      @enabled_model_plugins << :active_storage_methods if ['5.2', '6.0'].include?(ENV['RAILS_VERSION'])
     end
 
     sig { returns(T::Array[Symbol]) }

--- a/lib/sorbet-rails/model_plugins/active_record_assoc.rb
+++ b/lib/sorbet-rails/model_plugins/active_record_assoc.rb
@@ -1,7 +1,7 @@
 # typed: true
 require ('sorbet-rails/model_plugins/base')
 class SorbetRails::ModelPlugins::ActiveRecordAssoc < SorbetRails::ModelPlugins::Base
-  sig {params(model_class: T.class_of(ActiveRecord::Base), available_classes: T::Set[String]).void}
+  sig { params(model_class: T.class_of(ActiveRecord::Base), available_classes: T::Set[String]).void }
   def initialize(model_class, available_classes)
     super
     @columns_hash = @model_class.table_exists? ? @model_class.columns_hash : {}
@@ -25,6 +25,13 @@ class SorbetRails::ModelPlugins::ActiveRecordAssoc < SorbetRails::ModelPlugins::
     end
   end
 
+  sig do
+    params(
+      assoc_module_rbi: T.untyped,
+      assoc_name: T.untyped,
+      reflection: T.untyped
+    ).void
+  end
   def populate_single_assoc_getter_setter(assoc_module_rbi, assoc_name, reflection)
     # TODO allow people to specify the possible values of polymorphic associations
     assoc_class = assoc_should_be_untyped?(reflection) ? "T.untyped" : "::#{reflection.klass.name}"
@@ -57,6 +64,13 @@ class SorbetRails::ModelPlugins::ActiveRecordAssoc < SorbetRails::ModelPlugins::
     )
   end
 
+  sig do
+    params(
+      assoc_module_rbi: T.untyped,
+      assoc_name: T.untyped,
+      reflection: T.untyped
+    ).void
+  end
   def populate_collection_assoc_getter_setter(assoc_module_rbi, assoc_name, reflection)
     # TODO allow people to specify the possible values of polymorphic associations
     assoc_class = assoc_should_be_untyped?(reflection) ? "T.untyped" : "::#{reflection.klass.name}"

--- a/lib/sorbet-rails/model_plugins/active_record_attribute.rb
+++ b/lib/sorbet-rails/model_plugins/active_record_attribute.rb
@@ -55,7 +55,7 @@ class SorbetRails::ModelPlugins::ActiveRecordAttribute < SorbetRails::ModelPlugi
     end
   end
 
-  sig {params(column_def: T.untyped).returns(T.any(String, Class))}
+  sig { params(column_def: T.untyped).returns(T.any(String, Class)) }
   def type_for_column_def(column_def)
     cast_type = ActiveRecord::Base.connection.respond_to?(:lookup_cast_type_from_column) ?
       ActiveRecord::Base.connection.lookup_cast_type_from_column(column_def) :
@@ -69,13 +69,12 @@ class SorbetRails::ModelPlugins::ActiveRecordAttribute < SorbetRails::ModelPlugi
     column_def.null ? "T.nilable(#{strict_type})" : strict_type
   end
 
-  sig {
+  sig do
     params(
       # in v4.2, datetime can be TimeZoneConverter
       klass: T.any(Object, ActiveRecord::AttributeMethods::TimeZoneConversion::TimeZoneConverter)
-    ).
-    returns(T.any(String, Class))
-  }
+    ).returns(T.any(String, Class))
+  end
   def active_record_type_to_sorbet_type(klass)
     case klass
     when ActiveRecord::Type::Boolean

--- a/lib/sorbet-rails/model_plugins/active_storage_methods.rb
+++ b/lib/sorbet-rails/model_plugins/active_storage_methods.rb
@@ -8,7 +8,9 @@ class SorbetRails::ModelPlugins::ActiveStorageMethods < SorbetRails::ModelPlugin
 
   sig { implementation.params(root: Parlour::RbiGenerator::Namespace).void }
   def generate(root)
-    return unless @model_class.attachment_reflections.length > 0
+    # Check that ActiveStorage the attachment_reflections method exists
+    # It was added in 6.0, so it isn't available for 5.2.
+    return unless defined?(@model_class.attachment_reflections) && @model_class.attachment_reflections.length > 0
 
     assoc_module_name = self.model_module_name("GeneratedAssociationMethods")
     assoc_module_rbi = root.create_module(assoc_module_name)

--- a/lib/sorbet-rails/model_plugins/active_storage_methods.rb
+++ b/lib/sorbet-rails/model_plugins/active_storage_methods.rb
@@ -1,0 +1,58 @@
+# typed: true
+require ('sorbet-rails/model_plugins/base')
+class SorbetRails::ModelPlugins::ActiveStorageMethods < SorbetRails::ModelPlugins::Base
+  sig { params(model_class: T.class_of(ActiveRecord::Base), available_classes: T::Set[String]).void }
+  def initialize(model_class, available_classes)
+    super
+  end
+
+  sig { implementation.params(root: Parlour::RbiGenerator::Namespace).void }
+  def generate(root)
+    return unless @model_class.attachment_reflections.length > 0
+
+    assoc_module_name = self.model_module_name("GeneratedAssociationMethods")
+    assoc_module_rbi = root.create_module(assoc_module_name)
+
+    attachment_reflections = @model_class.attachment_reflections.transform_values { |attachment| attachment.class }
+
+    attachment_reflections.each do |assoc_name, attachment_type|
+      if attachment_type.to_s == 'ActiveStorage::Reflection::HasOneAttachedReflection'
+        create_has_one_methods(assoc_name, assoc_module_rbi)
+      elsif attachment_type.to_s == 'ActiveStorage::Reflection::HasManyAttachedReflection'
+        create_has_many_methods(assoc_name, assoc_module_rbi)
+      end
+    end
+  end
+
+  sig { params(assoc_name: String, mod: Parlour::RbiGenerator::Namespace).void }
+  def create_has_one_methods(assoc_name, mod)
+    mod.create_method(
+      assoc_name,
+      return_type: 'T.nilable(ActiveStorage::Attached::One)'
+    )
+
+    mod.create_method(
+      "#{assoc_name}=",
+      parameters: [
+        Parameter.new('attachable', type: 'T.untyped')
+      ],
+      return_type: 'T.untyped'
+    )
+  end
+
+  sig { params(assoc_name: String, mod: Parlour::RbiGenerator::Namespace).void }
+  def create_has_many_methods(assoc_name, mod)
+    mod.create_method(
+      assoc_name,
+      return_type: 'T.nilable(ActiveStorage::Attached::Many)'
+    )
+
+    mod.create_method(
+      "#{assoc_name}=",
+      parameters: [
+        Parameter.new('*attachables', type: 'T.untyped')
+      ],
+      return_type: 'T.untyped'
+    )
+  end
+end

--- a/lib/sorbet-rails/model_plugins/plugins.rb
+++ b/lib/sorbet-rails/model_plugins/plugins.rb
@@ -10,6 +10,7 @@ require('sorbet-rails/model_plugins/active_record_finder_methods')
 require('sorbet-rails/model_plugins/custom_finder_methods')
 require('sorbet-rails/model_plugins/enumerable_collections')
 require('sorbet-rails/model_plugins/active_record_overrides')
+require('sorbet-rails/model_plugins/active_storage_methods')
 
 module SorbetRails::ModelPlugins
   extend T::Sig
@@ -58,6 +59,8 @@ module SorbetRails::ModelPlugins
       CustomFinderMethods
     when :enumerable_collections
       EnumerableCollections
+    when :active_storage_methods
+      ActiveStorageMethods
     when :kaminari
       require('sorbet-rails/gem_plugins/kaminari_plugin')
       KaminariPlugin

--- a/spec/generators/rails-template.rb
+++ b/spec/generators/rails-template.rb
@@ -114,6 +114,12 @@ def create_models
     end
   RUBY
 
+  # A nasty hack to add has_one_attached and has_many_attached to the models/wizard.rb file.
+  attachments = nil
+  if ['5.2', '6.0'].include?(ENV["RAILS_VERSION"])
+    attachments = "has_one_attached :school_photo\n  has_many_attached :hats"
+  end
+
   if ENV["RAILS_VERSION"] == "4.2"
     file "app/models/wizard.rb", <<~RUBY
       class Wizard < ApplicationRecord
@@ -124,7 +130,7 @@ def create_models
           Hufflepuff: 1,
           Ravenclaw: 2,
           Slytherin: 3,
-	}
+        }
 
         enum professor: {
           "Severus Snape": 0,
@@ -193,6 +199,7 @@ def create_models
         has_many :spell_books
 
         scope :recent, -> { where('created_at > ?', 1.month.ago) }
+        #{attachments}
       end
     RUBY
   end

--- a/spec/model_rbi_formatter_spec.rb
+++ b/spec/model_rbi_formatter_spec.rb
@@ -12,7 +12,12 @@ RSpec.describe SorbetRails::ModelRbiFormatter do
   end
 
   it 'generates correct rbi file for Wizard' do
-    formatter = SorbetRails::ModelRbiFormatter.new(Wizard, Set.new(['Wizard', 'Wand', 'SpellBook']))
+    class_set = Set.new(['Wizard', 'Wand', 'SpellBook'])
+    if ['5.2', '6.0'].include?(ENV['RAILS_VERSION'])
+      class_set << 'ActiveStorage::Attachment'
+      class_set << 'ActiveStorage::Blob'
+    end
+    formatter = SorbetRails::ModelRbiFormatter.new(Wizard, class_set)
     expect_match_file(
       formatter.generate_rbi,
       'expected_wizard.rbi',
@@ -29,7 +34,12 @@ RSpec.describe SorbetRails::ModelRbiFormatter do
 
   context 'there is a hidden model' do
     it 'fallbacks to use ActiveRecord::Relation' do
-      formatter = SorbetRails::ModelRbiFormatter.new(Wizard, Set.new(['Wizard', 'Wand']))
+      class_set = Set.new(['Wizard', 'Wand'])
+      if ['5.2', '6.0'].include?(ENV['RAILS_VERSION'])
+        class_set << 'ActiveStorage::Attachment'
+        class_set << 'ActiveStorage::Blob'
+      end
+      formatter = SorbetRails::ModelRbiFormatter.new(Wizard, class_set)
       expect_match_file(
         formatter.generate_rbi,
         'expected_wizard_wo_spellbook.rbi',

--- a/spec/support/v4.2/app/models/wizard.rb
+++ b/spec/support/v4.2/app/models/wizard.rb
@@ -26,4 +26,5 @@ class Wizard < ApplicationRecord
   has_many :spell_books
 
   scope :recent, -> { where('created_at > ?', 1.month.ago) }
+  
 end

--- a/spec/support/v5.0/app/models/wizard.rb
+++ b/spec/support/v5.0/app/models/wizard.rb
@@ -45,4 +45,5 @@ class Wizard < ApplicationRecord
   has_many :spell_books
 
   scope :recent, -> { where('created_at > ?', 1.month.ago) }
+  
 end

--- a/spec/support/v5.1/app/models/wizard.rb
+++ b/spec/support/v5.1/app/models/wizard.rb
@@ -45,4 +45,5 @@ class Wizard < ApplicationRecord
   has_many :spell_books
 
   scope :recent, -> { where('created_at > ?', 1.month.ago) }
+  
 end

--- a/spec/support/v5.2/app/models/wizard.rb
+++ b/spec/support/v5.2/app/models/wizard.rb
@@ -45,4 +45,6 @@ class Wizard < ApplicationRecord
   has_many :spell_books
 
   scope :recent, -> { where('created_at > ?', 1.month.ago) }
+  has_one_attached :school_photo
+  has_many_attached :hats
 end

--- a/spec/support/v6.0/app/models/wizard.rb
+++ b/spec/support/v6.0/app/models/wizard.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: false
 class Wizard < ApplicationRecord
   validates :name, length: { minimum: 5 }, presence: true
 

--- a/spec/support/v6.0/app/models/wizard.rb
+++ b/spec/support/v6.0/app/models/wizard.rb
@@ -45,4 +45,6 @@ class Wizard < ApplicationRecord
   has_many :spell_books
 
   scope :recent, -> { where('created_at > ?', 1.month.ago) }
+  has_one_attached :school_photo
+  has_many_attached :hats
 end

--- a/spec/test_data/v5.2/expected_wizard.rbi
+++ b/spec/test_data/v5.2/expected_wizard.rbi
@@ -228,6 +228,30 @@ end
 module Wizard::GeneratedAssociationMethods
   extend T::Sig
 
+  sig { returns(::ActiveStorage::Attachment::ActiveRecord_Associations_CollectionProxy) }
+  def hats_attachments; end
+
+  sig { params(value: T.any(T::Array[::ActiveStorage::Attachment], ::ActiveStorage::Attachment::ActiveRecord_Associations_CollectionProxy)).void }
+  def hats_attachments=(value); end
+
+  sig { returns(::ActiveStorage::Blob::ActiveRecord_Associations_CollectionProxy) }
+  def hats_blobs; end
+
+  sig { params(value: T.any(T::Array[::ActiveStorage::Blob], ::ActiveStorage::Blob::ActiveRecord_Associations_CollectionProxy)).void }
+  def hats_blobs=(value); end
+
+  sig { returns(T.nilable(::ActiveStorage::Attachment)) }
+  def school_photo_attachment; end
+
+  sig { params(value: T.nilable(::ActiveStorage::Attachment)).void }
+  def school_photo_attachment=(value); end
+
+  sig { returns(T.nilable(::ActiveStorage::Blob)) }
+  def school_photo_blob; end
+
+  sig { params(value: T.nilable(::ActiveStorage::Blob)).void }
+  def school_photo_blob=(value); end
+
   sig { returns(::SpellBook::ActiveRecord_Associations_CollectionProxy) }
   def spell_books; end
 
@@ -337,6 +361,12 @@ class Wizard < ApplicationRecord
 
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
   def self.recent(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.with_attached_hats(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.with_attached_school_photo(*args); end
 
   sig { returns(Wizard::ActiveRecord_Relation) }
   def self.all; end
@@ -547,6 +577,12 @@ class Wizard::ActiveRecord_Relation < ActiveRecord::Relation
 
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
   def recent(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def with_attached_hats(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def with_attached_school_photo(*args); end
 
   sig { returns(Wizard::ActiveRecord_Relation) }
   def all; end
@@ -775,6 +811,12 @@ class Wizard::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelati
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
   def recent(*args); end
 
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def with_attached_hats(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def with_attached_school_photo(*args); end
+
   sig { returns(Wizard::ActiveRecord_AssociationRelation) }
   def all; end
 
@@ -1000,6 +1042,12 @@ class Wizard::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associat
 
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
   def recent(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def with_attached_hats(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def with_attached_school_photo(*args); end
 
   sig { returns(Wizard::ActiveRecord_AssociationRelation) }
   def all; end

--- a/spec/test_data/v5.2/expected_wizard_wo_spellbook.rbi
+++ b/spec/test_data/v5.2/expected_wizard_wo_spellbook.rbi
@@ -229,6 +229,30 @@ module Wizard::GeneratedAssociationMethods
   extend T::Sig
 
   sig { returns(ActiveRecord::Associations::CollectionProxy) }
+  def hats_attachments; end
+
+  sig { params(value: T.any(T::Array[T.untyped], ActiveRecord::Associations::CollectionProxy)).void }
+  def hats_attachments=(value); end
+
+  sig { returns(ActiveRecord::Associations::CollectionProxy) }
+  def hats_blobs; end
+
+  sig { params(value: T.any(T::Array[T.untyped], ActiveRecord::Associations::CollectionProxy)).void }
+  def hats_blobs=(value); end
+
+  sig { returns(T.nilable(T.untyped)) }
+  def school_photo_attachment; end
+
+  sig { params(value: T.nilable(T.untyped)).void }
+  def school_photo_attachment=(value); end
+
+  sig { returns(T.nilable(T.untyped)) }
+  def school_photo_blob; end
+
+  sig { params(value: T.nilable(T.untyped)).void }
+  def school_photo_blob=(value); end
+
+  sig { returns(ActiveRecord::Associations::CollectionProxy) }
   def spell_books; end
 
   sig { params(value: T.any(T::Array[T.untyped], ActiveRecord::Associations::CollectionProxy)).void }
@@ -337,6 +361,12 @@ class Wizard < ApplicationRecord
 
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
   def self.recent(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.with_attached_hats(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.with_attached_school_photo(*args); end
 
   sig { returns(Wizard::ActiveRecord_Relation) }
   def self.all; end
@@ -547,6 +577,12 @@ class Wizard::ActiveRecord_Relation < ActiveRecord::Relation
 
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
   def recent(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def with_attached_hats(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def with_attached_school_photo(*args); end
 
   sig { returns(Wizard::ActiveRecord_Relation) }
   def all; end
@@ -775,6 +811,12 @@ class Wizard::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelati
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
   def recent(*args); end
 
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def with_attached_hats(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def with_attached_school_photo(*args); end
+
   sig { returns(Wizard::ActiveRecord_AssociationRelation) }
   def all; end
 
@@ -1000,6 +1042,12 @@ class Wizard::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associat
 
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
   def recent(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def with_attached_hats(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def with_attached_school_photo(*args); end
 
   sig { returns(Wizard::ActiveRecord_AssociationRelation) }
   def all; end

--- a/spec/test_data/v5.2/expected_wizard_wo_spellbook.rbi
+++ b/spec/test_data/v5.2/expected_wizard_wo_spellbook.rbi
@@ -228,28 +228,28 @@ end
 module Wizard::GeneratedAssociationMethods
   extend T::Sig
 
-  sig { returns(ActiveRecord::Associations::CollectionProxy) }
+  sig { returns(::ActiveStorage::Attachment::ActiveRecord_Associations_CollectionProxy) }
   def hats_attachments; end
 
-  sig { params(value: T.any(T::Array[T.untyped], ActiveRecord::Associations::CollectionProxy)).void }
+  sig { params(value: T.any(T::Array[::ActiveStorage::Attachment], ::ActiveStorage::Attachment::ActiveRecord_Associations_CollectionProxy)).void }
   def hats_attachments=(value); end
 
-  sig { returns(ActiveRecord::Associations::CollectionProxy) }
+  sig { returns(::ActiveStorage::Blob::ActiveRecord_Associations_CollectionProxy) }
   def hats_blobs; end
 
-  sig { params(value: T.any(T::Array[T.untyped], ActiveRecord::Associations::CollectionProxy)).void }
+  sig { params(value: T.any(T::Array[::ActiveStorage::Blob], ::ActiveStorage::Blob::ActiveRecord_Associations_CollectionProxy)).void }
   def hats_blobs=(value); end
 
-  sig { returns(T.nilable(T.untyped)) }
+  sig { returns(T.nilable(::ActiveStorage::Attachment)) }
   def school_photo_attachment; end
 
-  sig { params(value: T.nilable(T.untyped)).void }
+  sig { params(value: T.nilable(::ActiveStorage::Attachment)).void }
   def school_photo_attachment=(value); end
 
-  sig { returns(T.nilable(T.untyped)) }
+  sig { returns(T.nilable(::ActiveStorage::Blob)) }
   def school_photo_blob; end
 
-  sig { params(value: T.nilable(T.untyped)).void }
+  sig { params(value: T.nilable(::ActiveStorage::Blob)).void }
   def school_photo_blob=(value); end
 
   sig { returns(ActiveRecord::Associations::CollectionProxy) }

--- a/spec/test_data/v6.0/expected_blob.rbi
+++ b/spec/test_data/v6.0/expected_blob.rbi
@@ -7,28 +7,6 @@ module ActiveStorage::Blob::ActiveRelation_WhereNot
   def not(opts, *rest); end
 end
 
-module ActiveStorage::Blob::GeneratedAssociationMethods
-  extend T::Sig
-
-  sig { returns(::ActiveStorage::Attachment::ActiveRecord_Associations_CollectionProxy) }
-  def attachments; end
-
-  sig { params(value: T.any(T::Array[::ActiveStorage::Attachment], ::ActiveStorage::Attachment::ActiveRecord_Associations_CollectionProxy)).void }
-  def attachments=(value); end
-
-  sig { returns(T.nilable(::ActiveStorage::Attachment)) }
-  def preview_image_attachment; end
-
-  sig { params(value: T.nilable(::ActiveStorage::Attachment)).void }
-  def preview_image_attachment=(value); end
-
-  sig { returns(T.nilable(::ActiveStorage::Blob)) }
-  def preview_image_blob; end
-
-  sig { params(value: T.nilable(::ActiveStorage::Blob)).void }
-  def preview_image_blob=(value); end
-end
-
 module ActiveStorage::Blob::CustomFinderMethods
   sig { params(limit: Integer).returns(T::Array[ActiveStorage::Blob]) }
   def first_n(limit); end
@@ -800,4 +778,32 @@ class ActiveStorage::Blob::ActiveRecord_Associations_CollectionProxy < ActiveRec
 
   sig { params(records: T.any(ActiveStorage::Blob, T::Array[ActiveStorage::Blob])).returns(T.self_type) }
   def concat(*records); end
+end
+
+module ActiveStorage::Blob::GeneratedAssociationMethods
+  extend T::Sig
+
+  sig { returns(::ActiveStorage::Attachment::ActiveRecord_Associations_CollectionProxy) }
+  def attachments; end
+
+  sig { params(value: T.any(T::Array[::ActiveStorage::Attachment], ::ActiveStorage::Attachment::ActiveRecord_Associations_CollectionProxy)).void }
+  def attachments=(value); end
+
+  sig { returns(T.nilable(::ActiveStorage::Attachment)) }
+  def preview_image_attachment; end
+
+  sig { params(value: T.nilable(::ActiveStorage::Attachment)).void }
+  def preview_image_attachment=(value); end
+
+  sig { returns(T.nilable(::ActiveStorage::Blob)) }
+  def preview_image_blob; end
+
+  sig { params(value: T.nilable(::ActiveStorage::Blob)).void }
+  def preview_image_blob=(value); end
+
+  sig { returns(T.nilable(ActiveStorage::Attached::One)) }
+  def preview_image; end
+
+  sig { params(attachable: T.untyped).returns(T.untyped) }
+  def preview_image=(attachable); end
 end

--- a/spec/test_data/v6.0/expected_wizard.rbi
+++ b/spec/test_data/v6.0/expected_wizard.rbi
@@ -225,22 +225,6 @@ module Wizard::GeneratedAttributeMethods
   def updated_at?; end
 end
 
-module Wizard::GeneratedAssociationMethods
-  extend T::Sig
-
-  sig { returns(::SpellBook::ActiveRecord_Associations_CollectionProxy) }
-  def spell_books; end
-
-  sig { params(value: T.any(T::Array[::SpellBook], ::SpellBook::ActiveRecord_Associations_CollectionProxy)).void }
-  def spell_books=(value); end
-
-  sig { returns(T.nilable(::Wand)) }
-  def wand; end
-
-  sig { params(value: T.nilable(::Wand)).void }
-  def wand=(value); end
-end
-
 module Wizard::CustomFinderMethods
   sig { params(limit: Integer).returns(T::Array[Wizard]) }
   def first_n(limit); end
@@ -388,6 +372,12 @@ class Wizard < ApplicationRecord
 
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
   def self.recent(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.with_attached_hats(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.with_attached_school_photo(*args); end
 
   sig { returns(Wizard::ActiveRecord_Relation) }
   def self.all; end
@@ -661,6 +651,12 @@ class Wizard::ActiveRecord_Relation < ActiveRecord::Relation
 
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
   def recent(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def with_attached_hats(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def with_attached_school_photo(*args); end
 
   sig { returns(Wizard::ActiveRecord_Relation) }
   def all; end
@@ -952,6 +948,12 @@ class Wizard::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelati
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
   def recent(*args); end
 
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def with_attached_hats(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def with_attached_school_photo(*args); end
+
   sig { returns(Wizard::ActiveRecord_AssociationRelation) }
   def all; end
 
@@ -1241,6 +1243,12 @@ class Wizard::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associat
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
   def recent(*args); end
 
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def with_attached_hats(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def with_attached_school_photo(*args); end
+
   sig { returns(Wizard::ActiveRecord_AssociationRelation) }
   def all; end
 
@@ -1428,4 +1436,56 @@ class Wizard::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associat
 
   sig { params(records: T.any(Wizard, T::Array[Wizard])).returns(T.self_type) }
   def concat(*records); end
+end
+
+module Wizard::GeneratedAssociationMethods
+  extend T::Sig
+
+  sig { returns(::ActiveStorage::Attachment::ActiveRecord_Associations_CollectionProxy) }
+  def hats_attachments; end
+
+  sig { params(value: T.any(T::Array[::ActiveStorage::Attachment], ::ActiveStorage::Attachment::ActiveRecord_Associations_CollectionProxy)).void }
+  def hats_attachments=(value); end
+
+  sig { returns(::ActiveStorage::Blob::ActiveRecord_Associations_CollectionProxy) }
+  def hats_blobs; end
+
+  sig { params(value: T.any(T::Array[::ActiveStorage::Blob], ::ActiveStorage::Blob::ActiveRecord_Associations_CollectionProxy)).void }
+  def hats_blobs=(value); end
+
+  sig { returns(T.nilable(::ActiveStorage::Attachment)) }
+  def school_photo_attachment; end
+
+  sig { params(value: T.nilable(::ActiveStorage::Attachment)).void }
+  def school_photo_attachment=(value); end
+
+  sig { returns(T.nilable(::ActiveStorage::Blob)) }
+  def school_photo_blob; end
+
+  sig { params(value: T.nilable(::ActiveStorage::Blob)).void }
+  def school_photo_blob=(value); end
+
+  sig { returns(::SpellBook::ActiveRecord_Associations_CollectionProxy) }
+  def spell_books; end
+
+  sig { params(value: T.any(T::Array[::SpellBook], ::SpellBook::ActiveRecord_Associations_CollectionProxy)).void }
+  def spell_books=(value); end
+
+  sig { returns(T.nilable(::Wand)) }
+  def wand; end
+
+  sig { params(value: T.nilable(::Wand)).void }
+  def wand=(value); end
+
+  sig { returns(T.nilable(ActiveStorage::Attached::One)) }
+  def school_photo; end
+
+  sig { params(attachable: T.untyped).returns(T.untyped) }
+  def school_photo=(attachable); end
+
+  sig { returns(T.nilable(ActiveStorage::Attached::Many)) }
+  def hats; end
+
+  sig { params(attachables: T.untyped).returns(T.untyped) }
+  def hats=(*attachables); end
 end

--- a/spec/test_data/v6.0/expected_wizard_wo_spellbook.rbi
+++ b/spec/test_data/v6.0/expected_wizard_wo_spellbook.rbi
@@ -225,22 +225,6 @@ module Wizard::GeneratedAttributeMethods
   def updated_at?; end
 end
 
-module Wizard::GeneratedAssociationMethods
-  extend T::Sig
-
-  sig { returns(ActiveRecord::Associations::CollectionProxy) }
-  def spell_books; end
-
-  sig { params(value: T.any(T::Array[T.untyped], ActiveRecord::Associations::CollectionProxy)).void }
-  def spell_books=(value); end
-
-  sig { returns(T.nilable(::Wand)) }
-  def wand; end
-
-  sig { params(value: T.nilable(::Wand)).void }
-  def wand=(value); end
-end
-
 module Wizard::CustomFinderMethods
   sig { params(limit: Integer).returns(T::Array[Wizard]) }
   def first_n(limit); end
@@ -388,6 +372,12 @@ class Wizard < ApplicationRecord
 
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
   def self.recent(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.with_attached_hats(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.with_attached_school_photo(*args); end
 
   sig { returns(Wizard::ActiveRecord_Relation) }
   def self.all; end
@@ -661,6 +651,12 @@ class Wizard::ActiveRecord_Relation < ActiveRecord::Relation
 
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
   def recent(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def with_attached_hats(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def with_attached_school_photo(*args); end
 
   sig { returns(Wizard::ActiveRecord_Relation) }
   def all; end
@@ -952,6 +948,12 @@ class Wizard::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelati
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
   def recent(*args); end
 
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def with_attached_hats(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def with_attached_school_photo(*args); end
+
   sig { returns(Wizard::ActiveRecord_AssociationRelation) }
   def all; end
 
@@ -1241,6 +1243,12 @@ class Wizard::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associat
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
   def recent(*args); end
 
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def with_attached_hats(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def with_attached_school_photo(*args); end
+
   sig { returns(Wizard::ActiveRecord_AssociationRelation) }
   def all; end
 
@@ -1428,4 +1436,56 @@ class Wizard::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associat
 
   sig { params(records: T.any(Wizard, T::Array[Wizard])).returns(T.self_type) }
   def concat(*records); end
+end
+
+module Wizard::GeneratedAssociationMethods
+  extend T::Sig
+
+  sig { returns(::ActiveStorage::Attachment::ActiveRecord_Associations_CollectionProxy) }
+  def hats_attachments; end
+
+  sig { params(value: T.any(T::Array[::ActiveStorage::Attachment], ::ActiveStorage::Attachment::ActiveRecord_Associations_CollectionProxy)).void }
+  def hats_attachments=(value); end
+
+  sig { returns(::ActiveStorage::Blob::ActiveRecord_Associations_CollectionProxy) }
+  def hats_blobs; end
+
+  sig { params(value: T.any(T::Array[::ActiveStorage::Blob], ::ActiveStorage::Blob::ActiveRecord_Associations_CollectionProxy)).void }
+  def hats_blobs=(value); end
+
+  sig { returns(T.nilable(::ActiveStorage::Attachment)) }
+  def school_photo_attachment; end
+
+  sig { params(value: T.nilable(::ActiveStorage::Attachment)).void }
+  def school_photo_attachment=(value); end
+
+  sig { returns(T.nilable(::ActiveStorage::Blob)) }
+  def school_photo_blob; end
+
+  sig { params(value: T.nilable(::ActiveStorage::Blob)).void }
+  def school_photo_blob=(value); end
+
+  sig { returns(ActiveRecord::Associations::CollectionProxy) }
+  def spell_books; end
+
+  sig { params(value: T.any(T::Array[T.untyped], ActiveRecord::Associations::CollectionProxy)).void }
+  def spell_books=(value); end
+
+  sig { returns(T.nilable(::Wand)) }
+  def wand; end
+
+  sig { params(value: T.nilable(::Wand)).void }
+  def wand=(value); end
+
+  sig { returns(T.nilable(ActiveStorage::Attached::One)) }
+  def school_photo; end
+
+  sig { params(attachable: T.untyped).returns(T.untyped) }
+  def school_photo=(attachable); end
+
+  sig { returns(T.nilable(ActiveStorage::Attached::Many)) }
+  def hats; end
+
+  sig { params(attachables: T.untyped).returns(T.untyped) }
+  def hats=(*attachables); end
 end


### PR DESCRIPTION
Also made some small formatting changes in a few places.

Fixes #148.

`attachment_reflections` wasn't added until 6.0, with https://github.com/rails/rails/pull/33018

So this doesn't support 5.2, and I'm not sure of a good way to get it to work. We can do something like `User.reflect_on_all_associations.filter { |x| x.name.to_s.end_with?('attachment') }`, but that's _really_ gross so I don't want to.

Are we fine just having this only support 6.0?