### PR TITLE
Introduce IntegerString & BooleanString class to typecheck input params

### DIFF
--- a/lib/sorbet-rails.rb
+++ b/lib/sorbet-rails.rb
@@ -4,5 +4,6 @@ module SorbetRails
     require 'sorbet-rails/railtie'
     require 'sorbet-rails/model_rbi_formatter'
     require 'sorbet-rails/type_assert/type_assert'
+    require 'sorbet-rails/custom_types/integer_string'
   end
 end

--- a/lib/sorbet-rails.rb
+++ b/lib/sorbet-rails.rb
@@ -5,5 +5,6 @@ module SorbetRails
     require 'sorbet-rails/model_rbi_formatter'
     require 'sorbet-rails/type_assert/type_assert'
     require 'sorbet-rails/custom_types/integer_string'
+    require 'sorbet-rails/custom_types/boolean_string'
   end
 end

--- a/lib/sorbet-rails/custom_types/boolean_string.rb
+++ b/lib/sorbet-rails/custom_types/boolean_string.rb
@@ -1,0 +1,32 @@
+# typed: false
+module BooleanStringImpl
+  def is_a?(type)
+    return super unless type == BooleanString
+    _is_a_boolean_string?
+  end
+
+  def kind_of?(type)
+    return super unless type == BooleanString
+    _is_a_boolean_string?
+  end
+
+  def instance_of?(type)
+    return super unless type == BooleanString
+    _is_a_boolean_string?
+  end
+
+  def _is_a_boolean_string?
+    return @cached_is_a unless @cached_is_a.nil?
+    @cached_is_a = (self =~ /^(true|false)$/i) == 0
+  end
+end
+
+class String
+  include BooleanStringImpl
+end
+
+class BooleanString < String
+  def self.===(other)
+    other.is_a?(BooleanString)
+  end
+end

--- a/lib/sorbet-rails/custom_types/integer_string.rb
+++ b/lib/sorbet-rails/custom_types/integer_string.rb
@@ -1,0 +1,35 @@
+# typed: false
+module IntegerStringImpl
+  def is_a?(type)
+    return super unless type == IntegerString
+    _is_a_integer_string?
+  end
+
+  def kind_of?(type)
+    return super unless type == IntegerString
+    _is_a_integer_string?
+  end
+
+  def instance_of?(type)
+    return super unless type == IntegerString
+    _is_a_integer_string?
+  end
+
+  def _is_a_integer_string?
+    return @cached_is_a unless @cached_is_a.nil?
+    Integer(self, 10)
+    @cached_is_a = true
+  rescue ArgumentError => err
+    @cached_is_a = false
+  end
+end
+
+class String
+  include IntegerStringImpl
+end
+
+class IntegerString < String
+  def self.===(other)
+    other.is_a?(IntegerString)
+  end
+end

--- a/spec/boolean_string_spec.rb
+++ b/spec/boolean_string_spec.rb
@@ -1,0 +1,59 @@
+require 'rails_helper'
+require 'sorbet-rails/custom_types/boolean_string'
+require 'sorbet-runtime'
+
+RSpec.describe BooleanString do
+  shared_examples 'boolean string' do |str|
+    it 'acts as BooleanString perfectly' do
+      expect(str.is_a?(BooleanString)).to be(true)
+      expect(str.kind_of?(BooleanString)).to be(true)
+      expect(str.instance_of?(BooleanString)).to be(true)
+      expect(BooleanString === str).to be(true)
+    end
+  end
+
+  include_examples 'boolean string', 'true'
+  include_examples 'boolean string', 'false'
+  include_examples 'boolean string', 'True'
+  include_examples 'boolean string', 'False'
+
+  shared_examples 'non boolean string' do |str|
+    it 'does not acts as BooleanString' do
+      expect(str.is_a?(BooleanString)).to be(false)
+      expect(str.kind_of?(BooleanString)).to be(false)
+      expect(str.instance_of?(BooleanString)).to be(false)
+      expect(BooleanString === str).to be(false)
+    end
+  end
+
+  include_examples 'non boolean string', 'yes'
+  include_examples 'non boolean string', 'no'
+  include_examples 'non boolean string', 'alala'
+
+  context 'sorbet recognizes it at runtime' do
+    it 'lets boolean string pass runtime check' do
+      expect(T.let('true', BooleanString)).to eql('true')
+    end
+
+    it 'doesnt let normal string pass runtime typecheck' do
+      expect {
+        T.let('yes', BooleanString)
+      }.to raise_error(TypeError)
+    end
+  end
+
+  context 'using with TypeAssert' do
+    let!(:ta) { TA[BooleanString].new }
+
+    it 'lets boolean string pass runtime typecheck' do
+      expect(ta.assert('true')).to eql('true')
+    end
+
+    it 'doesnt let normal string pass runtime typecheck' do
+      expect {
+        ta.assert('yes')
+      }.to raise_error(TypeError)
+    end
+  end
+end
+

--- a/spec/integer_string_spec.rb
+++ b/spec/integer_string_spec.rb
@@ -1,0 +1,46 @@
+require 'rails_helper'
+require 'sorbet-rails/custom_types/integer_string'
+require 'sorbet-runtime'
+
+RSpec.describe IntegerString do
+  it 'lets integer string acts as IntegerString perfectly' do
+    expect('1'.is_a?(IntegerString)).to be(true)
+    expect('12'.kind_of?(IntegerString)).to be(true)
+    expect('123'.instance_of?(IntegerString)).to be(true)
+    expect(IntegerString === '1234').to be(true)
+  end
+
+  it 'does not let other string acts as IntegerString' do
+    expect('a1'.is_a?(IntegerString)).to be(false)
+    expect('a12'.kind_of?(IntegerString)).to be(false)
+    expect('a123'.instance_of?(IntegerString)).to be(false)
+    expect(IntegerString === 'a1234').to be(false)
+  end
+
+  context 'sorbet recognizes it at runtime' do
+    it 'lets integer string pass runtime check' do
+      expect(T.let('123', IntegerString)).to eql('123')
+    end
+
+    it 'doesnt let normal string pass runtime typecheck' do
+      expect {
+        T.let('a123', IntegerString)
+      }.to raise_error(TypeError)
+    end
+  end
+
+  context 'using with TypeAssert' do
+    let!(:ta) { TA[IntegerString].new }
+
+    it 'lets integer string pass runtime typecheck' do
+      expect(ta.assert('123')).to eql('123')
+    end
+
+    it 'doesnt let normal string pass runtime typecheck' do
+      expect {
+        ta.assert('a123')
+      }.to raise_error(TypeError)
+    end
+  end
+end
+


### PR DESCRIPTION
It's common in Rails to have IntegerString passed in from the client side. It may be convenient to be able to check that a string is an IntegerString, but not a random string. Idea suggested by @twhitnah :-)