### PR TITLE
Check enum_call nil before proceeding

### DIFF
--- a/lib/sorbet-rails/model_plugins/active_record_enum.rb
+++ b/lib/sorbet-rails/model_plugins/active_record_enum.rb
@@ -32,7 +32,11 @@ class SorbetRails::ModelPlugins::ActiveRecordEnum < SorbetRails::ModelPlugins::B
         class_method: true,
       )
 
-      enum_call = enum_calls.find {|call| call.has_key?(enum_name.to_sym)}
+      enum_call = enum_calls.find { |call| call.has_key?(enum_name.to_sym) }
+      if enum_call.nil?
+        puts "Error: unable to find enum call for enum #{enum_name}, model #{self.model_class_name}"
+        next
+      end
 
       enum_prefix = enum_call[:_prefix]
       prefix =


### PR DESCRIPTION
@wpride reported that sometimes `enum_call` could be nil for models. I'm unable to reproduce it but it's a good idea to be defensive around accessing nilable object.
cc @deecewan 