### PR TITLE
Add helpers method

### DIFF
--- a/lib/sorbet-rails/helper_rbi_formatter.rb
+++ b/lib/sorbet-rails/helper_rbi_formatter.rb
@@ -31,6 +31,16 @@ class SorbetRails::HelperRbiFormatter
       end
     end
 
+    # Adds the `helpers` method that provides access to all methods within the
+    # application's helpers.
+    # https://api.rubyonrails.org/classes/ActionController/Helpers/ClassMethods.html#method-i-helpers
+    @parlour.root.create_module('ActionController::Helpers') do |mod|
+      mod.create_method(
+        'helpers',
+        return_type: "T.all(#{@helpers.join(', ')})"
+      )
+    end
+
     return @parlour.rbi
   end
 end

--- a/lib/sorbet-rails/helper_rbi_formatter.rb
+++ b/lib/sorbet-rails/helper_rbi_formatter.rb
@@ -31,14 +31,16 @@ class SorbetRails::HelperRbiFormatter
       end
     end
 
-    # Adds the `helpers` method that provides access to all methods within the
-    # application's helpers.
-    # https://api.rubyonrails.org/classes/ActionController/Helpers/ClassMethods.html#method-i-helpers
-    @parlour.root.create_module('ActionController::Helpers') do |mod|
-      mod.create_method(
-        'helpers',
-        return_type: "T.all(#{@helpers.join(', ')})"
-      )
+    if ActionController::Helpers.method_defined?(:helpers)
+      # Adds the `helpers` method that provides access to all methods within the
+      # application's helpers.
+      # https://api.rubyonrails.org/classes/ActionController/Helpers/ClassMethods.html#method-i-helpers
+      @parlour.root.create_module('ActionController::Helpers') do |mod|
+        mod.create_method(
+          'helpers',
+          return_type: "T.all(#{@helpers.join(', ')})"
+        )
+      end
     end
 
     return @parlour.rbi

--- a/lib/sorbet/rbi/todo.rbi
+++ b/lib/sorbet/rbi/todo.rbi
@@ -6,6 +6,7 @@ module ::FriendlyId; end
 module ::Kaminari; end
 module ::Kaminari::ActiveRecordModelExtension; end
 module ::PgSearch::Model; end
+module ActionController::Helpers; end
 module ActionMailer::Base::Mail::Message; end
 module ActiveModel::AttributeMethods; end
 module ActiveModel::Conversion; end
@@ -30,7 +31,6 @@ module ActiveRecord::CounterCache; end
 module ActiveRecord::DefineCallbacks; end
 module ActiveRecord::Delegation::DelegateCache; end
 module ActiveRecord::DynamicMatchers; end
-module ActiveRecord::Enum; end
 module ActiveRecord::Enum::EnumType; end
 module ActiveRecord::Explain; end
 module ActiveRecord::Integration; end
@@ -127,4 +127,3 @@ module T::Private::Methods::SingletonMethodHooks; end
 module T::Private::Methods::SingletonMethodHooks; end
 module T::Private::Methods::SingletonMethodHooks; end
 module T::Private::Methods::SingletonMethodHooks; end
-module TA::TypeAssertImpl; end

--- a/spec/support/v4.2/Gemfile.lock
+++ b/spec/support/v4.2/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../..
   specs:
-    sorbet-rails (0.5.5)
+    sorbet-rails (0.5.5.1)
       parlour (~> 0.8.0)
 
 GEM

--- a/spec/support/v5.0/Gemfile.lock
+++ b/spec/support/v5.0/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../..
   specs:
-    sorbet-rails (0.5.5)
+    sorbet-rails (0.5.5.1)
       parlour (~> 0.8.0)
 
 GEM

--- a/spec/support/v5.1/Gemfile.lock
+++ b/spec/support/v5.1/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../..
   specs:
-    sorbet-rails (0.5.5)
+    sorbet-rails (0.5.5.1)
       parlour (~> 0.8.0)
 
 GEM

--- a/spec/test_data/v5.0/expected_helpers.rbi
+++ b/spec/test_data/v5.0/expected_helpers.rbi
@@ -20,3 +20,8 @@ module FooHelper
   include Kernel
   include ActionView::Helpers
 end
+
+module ActionController::Helpers
+  sig { returns(T.all(ApplicationHelper, BarHelper, BazHelper, FooHelper)) }
+  def helpers; end
+end

--- a/spec/test_data/v5.0/expected_helpers_with_application_and_devise_helpers.rbi
+++ b/spec/test_data/v5.0/expected_helpers_with_application_and_devise_helpers.rbi
@@ -27,3 +27,8 @@ module FooHelper
   include ApplicationHelper
   include DeviseHelper
 end
+
+module ActionController::Helpers
+  sig { returns(T.all(ApplicationHelper, BarHelper, BazHelper, FooHelper)) }
+  def helpers; end
+end

--- a/spec/test_data/v5.1/expected_helpers.rbi
+++ b/spec/test_data/v5.1/expected_helpers.rbi
@@ -20,3 +20,8 @@ module FooHelper
   include Kernel
   include ActionView::Helpers
 end
+
+module ActionController::Helpers
+  sig { returns(T.all(ApplicationHelper, BarHelper, BazHelper, FooHelper)) }
+  def helpers; end
+end

--- a/spec/test_data/v5.1/expected_helpers_with_application_and_devise_helpers.rbi
+++ b/spec/test_data/v5.1/expected_helpers_with_application_and_devise_helpers.rbi
@@ -27,3 +27,8 @@ module FooHelper
   include ApplicationHelper
   include DeviseHelper
 end
+
+module ActionController::Helpers
+  sig { returns(T.all(ApplicationHelper, BarHelper, BazHelper, FooHelper)) }
+  def helpers; end
+end

--- a/spec/test_data/v5.2/expected_helpers.rbi
+++ b/spec/test_data/v5.2/expected_helpers.rbi
@@ -20,3 +20,8 @@ module FooHelper
   include Kernel
   include ActionView::Helpers
 end
+
+module ActionController::Helpers
+  sig { returns(T.all(ApplicationHelper, BarHelper, BazHelper, FooHelper)) }
+  def helpers; end
+end

--- a/spec/test_data/v5.2/expected_helpers_with_application_and_devise_helpers.rbi
+++ b/spec/test_data/v5.2/expected_helpers_with_application_and_devise_helpers.rbi
@@ -27,3 +27,8 @@ module FooHelper
   include ApplicationHelper
   include DeviseHelper
 end
+
+module ActionController::Helpers
+  sig { returns(T.all(ApplicationHelper, BarHelper, BazHelper, FooHelper)) }
+  def helpers; end
+end

--- a/spec/test_data/v6.0/expected_helpers.rbi
+++ b/spec/test_data/v6.0/expected_helpers.rbi
@@ -20,3 +20,8 @@ module FooHelper
   include Kernel
   include ActionView::Helpers
 end
+
+module ActionController::Helpers
+  sig { returns(T.all(ApplicationHelper, BarHelper, BazHelper, FooHelper)) }
+  def helpers; end
+end

--- a/spec/test_data/v6.0/expected_helpers_with_application_and_devise_helpers.rbi
+++ b/spec/test_data/v6.0/expected_helpers_with_application_and_devise_helpers.rbi
@@ -27,3 +27,8 @@ module FooHelper
   include ApplicationHelper
   include DeviseHelper
 end
+
+module ActionController::Helpers
+  sig { returns(T.all(ApplicationHelper, BarHelper, BazHelper, FooHelper)) }
+  def helpers; end
+end


### PR DESCRIPTION
Resolves #156.

This intentionally does not include DeviseHelper because you can pass any kind of module into the `includes` config, and I don't think the Devise helpers are included in `helpers` anyway.

It checks for the existence of the `helpers` method because the method doesn't exist on 4.2.