### PR TITLE
`each` should return an array, not void

### DIFF
--- a/lib/sorbet-rails/model_plugins/enumerable_collections.rb
+++ b/lib/sorbet-rails/model_plugins/enumerable_collections.rb
@@ -36,6 +36,7 @@ class SorbetRails::ModelPlugins::EnumerableCollections < SorbetRails::ModelPlugi
       parameters: [
         Parameter.new("&block", type: "T.proc.params(e: #{self.model_class_name}).void")
       ],
+      return_type: "T::Array[#{self.model_class_name}]",
       implementation: true,
     )
     class_rbi.create_method(

--- a/spec/test_data/v4.2/expected_potion.rbi
+++ b/spec/test_data/v4.2/expected_potion.rbi
@@ -302,7 +302,7 @@ class Potion::ActiveRecord_Relation < ActiveRecord::Relation
   sig { params(args: T.untyped).returns(T::Boolean) }
   def one?(*args); end
 
-  sig { override.params(block: T.proc.params(e: Potion).void).void }
+  sig { override.params(block: T.proc.params(e: Potion).void).returns(T::Array[Potion]) }
   def each(&block); end
 
   sig { params(level: T.nilable(Integer)).returns(T::Array[Potion]) }
@@ -460,7 +460,7 @@ class Potion::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelati
   sig { params(args: T.untyped).returns(T::Boolean) }
   def one?(*args); end
 
-  sig { override.params(block: T.proc.params(e: Potion).void).void }
+  sig { override.params(block: T.proc.params(e: Potion).void).returns(T::Array[Potion]) }
   def each(&block); end
 
   sig { params(level: T.nilable(Integer)).returns(T::Array[Potion]) }
@@ -617,7 +617,7 @@ class Potion::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associat
   sig { params(args: T.untyped).returns(T::Boolean) }
   def one?(*args); end
 
-  sig { override.params(block: T.proc.params(e: Potion).void).void }
+  sig { override.params(block: T.proc.params(e: Potion).void).returns(T::Array[Potion]) }
   def each(&block); end
 
   sig { params(level: T.nilable(Integer)).returns(T::Array[Potion]) }

--- a/spec/test_data/v4.2/expected_spell_book.rbi
+++ b/spec/test_data/v4.2/expected_spell_book.rbi
@@ -398,7 +398,7 @@ class SpellBook::ActiveRecord_Relation < ActiveRecord::Relation
   sig { params(args: T.untyped).returns(T::Boolean) }
   def one?(*args); end
 
-  sig { override.params(block: T.proc.params(e: SpellBook).void).void }
+  sig { override.params(block: T.proc.params(e: SpellBook).void).returns(T::Array[SpellBook]) }
   def each(&block); end
 
   sig { params(level: T.nilable(Integer)).returns(T::Array[SpellBook]) }
@@ -565,7 +565,7 @@ class SpellBook::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRel
   sig { params(args: T.untyped).returns(T::Boolean) }
   def one?(*args); end
 
-  sig { override.params(block: T.proc.params(e: SpellBook).void).void }
+  sig { override.params(block: T.proc.params(e: SpellBook).void).returns(T::Array[SpellBook]) }
   def each(&block); end
 
   sig { params(level: T.nilable(Integer)).returns(T::Array[SpellBook]) }
@@ -731,7 +731,7 @@ class SpellBook::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Assoc
   sig { params(args: T.untyped).returns(T::Boolean) }
   def one?(*args); end
 
-  sig { override.params(block: T.proc.params(e: SpellBook).void).void }
+  sig { override.params(block: T.proc.params(e: SpellBook).void).returns(T::Array[SpellBook]) }
   def each(&block); end
 
   sig { params(level: T.nilable(Integer)).returns(T::Array[SpellBook]) }

--- a/spec/test_data/v4.2/expected_squib.rbi
+++ b/spec/test_data/v4.2/expected_squib.rbi
@@ -509,7 +509,7 @@ class Squib::ActiveRecord_Relation < ActiveRecord::Relation
   sig { params(args: T.untyped).returns(T::Boolean) }
   def one?(*args); end
 
-  sig { override.params(block: T.proc.params(e: Squib).void).void }
+  sig { override.params(block: T.proc.params(e: Squib).void).returns(T::Array[Squib]) }
   def each(&block); end
 
   sig { params(level: T.nilable(Integer)).returns(T::Array[Squib]) }
@@ -691,7 +691,7 @@ class Squib::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelatio
   sig { params(args: T.untyped).returns(T::Boolean) }
   def one?(*args); end
 
-  sig { override.params(block: T.proc.params(e: Squib).void).void }
+  sig { override.params(block: T.proc.params(e: Squib).void).returns(T::Array[Squib]) }
   def each(&block); end
 
   sig { params(level: T.nilable(Integer)).returns(T::Array[Squib]) }
@@ -872,7 +872,7 @@ class Squib::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associati
   sig { params(args: T.untyped).returns(T::Boolean) }
   def one?(*args); end
 
-  sig { override.params(block: T.proc.params(e: Squib).void).void }
+  sig { override.params(block: T.proc.params(e: Squib).void).returns(T::Array[Squib]) }
   def each(&block); end
 
   sig { params(level: T.nilable(Integer)).returns(T::Array[Squib]) }

--- a/spec/test_data/v4.2/expected_wand.rbi
+++ b/spec/test_data/v4.2/expected_wand.rbi
@@ -485,7 +485,7 @@ class Wand::ActiveRecord_Relation < ActiveRecord::Relation
   sig { params(args: T.untyped).returns(T::Boolean) }
   def one?(*args); end
 
-  sig { override.params(block: T.proc.params(e: Wand).void).void }
+  sig { override.params(block: T.proc.params(e: Wand).void).returns(T::Array[Wand]) }
   def each(&block); end
 
   sig { params(level: T.nilable(Integer)).returns(T::Array[Wand]) }
@@ -655,7 +655,7 @@ class Wand::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
   sig { params(args: T.untyped).returns(T::Boolean) }
   def one?(*args); end
 
-  sig { override.params(block: T.proc.params(e: Wand).void).void }
+  sig { override.params(block: T.proc.params(e: Wand).void).returns(T::Array[Wand]) }
   def each(&block); end
 
   sig { params(level: T.nilable(Integer)).returns(T::Array[Wand]) }
@@ -824,7 +824,7 @@ class Wand::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associatio
   sig { params(args: T.untyped).returns(T::Boolean) }
   def one?(*args); end
 
-  sig { override.params(block: T.proc.params(e: Wand).void).void }
+  sig { override.params(block: T.proc.params(e: Wand).void).returns(T::Array[Wand]) }
   def each(&block); end
 
   sig { params(level: T.nilable(Integer)).returns(T::Array[Wand]) }

--- a/spec/test_data/v4.2/expected_wizard.rbi
+++ b/spec/test_data/v4.2/expected_wizard.rbi
@@ -509,7 +509,7 @@ class Wizard::ActiveRecord_Relation < ActiveRecord::Relation
   sig { params(args: T.untyped).returns(T::Boolean) }
   def one?(*args); end
 
-  sig { override.params(block: T.proc.params(e: Wizard).void).void }
+  sig { override.params(block: T.proc.params(e: Wizard).void).returns(T::Array[Wizard]) }
   def each(&block); end
 
   sig { params(level: T.nilable(Integer)).returns(T::Array[Wizard]) }
@@ -691,7 +691,7 @@ class Wizard::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelati
   sig { params(args: T.untyped).returns(T::Boolean) }
   def one?(*args); end
 
-  sig { override.params(block: T.proc.params(e: Wizard).void).void }
+  sig { override.params(block: T.proc.params(e: Wizard).void).returns(T::Array[Wizard]) }
   def each(&block); end
 
   sig { params(level: T.nilable(Integer)).returns(T::Array[Wizard]) }
@@ -872,7 +872,7 @@ class Wizard::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associat
   sig { params(args: T.untyped).returns(T::Boolean) }
   def one?(*args); end
 
-  sig { override.params(block: T.proc.params(e: Wizard).void).void }
+  sig { override.params(block: T.proc.params(e: Wizard).void).returns(T::Array[Wizard]) }
   def each(&block); end
 
   sig { params(level: T.nilable(Integer)).returns(T::Array[Wizard]) }

--- a/spec/test_data/v4.2/expected_wizard_wo_spellbook.rbi
+++ b/spec/test_data/v4.2/expected_wizard_wo_spellbook.rbi
@@ -509,7 +509,7 @@ class Wizard::ActiveRecord_Relation < ActiveRecord::Relation
   sig { params(args: T.untyped).returns(T::Boolean) }
   def one?(*args); end
 
-  sig { override.params(block: T.proc.params(e: Wizard).void).void }
+  sig { override.params(block: T.proc.params(e: Wizard).void).returns(T::Array[Wizard]) }
   def each(&block); end
 
   sig { params(level: T.nilable(Integer)).returns(T::Array[Wizard]) }
@@ -691,7 +691,7 @@ class Wizard::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelati
   sig { params(args: T.untyped).returns(T::Boolean) }
   def one?(*args); end
 
-  sig { override.params(block: T.proc.params(e: Wizard).void).void }
+  sig { override.params(block: T.proc.params(e: Wizard).void).returns(T::Array[Wizard]) }
   def each(&block); end
 
   sig { params(level: T.nilable(Integer)).returns(T::Array[Wizard]) }
@@ -872,7 +872,7 @@ class Wizard::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associat
   sig { params(args: T.untyped).returns(T::Boolean) }
   def one?(*args); end
 
-  sig { override.params(block: T.proc.params(e: Wizard).void).void }
+  sig { override.params(block: T.proc.params(e: Wizard).void).returns(T::Array[Wizard]) }
   def each(&block); end
 
   sig { params(level: T.nilable(Integer)).returns(T::Array[Wizard]) }

--- a/spec/test_data/v5.0/expected_internal_metadata.rbi
+++ b/spec/test_data/v5.0/expected_internal_metadata.rbi
@@ -361,7 +361,7 @@ class ActiveRecord::InternalMetadata::ActiveRecord_Relation < ActiveRecord::Rela
   sig { params(args: T.untyped).returns(T::Boolean) }
   def one?(*args); end
 
-  sig { override.params(block: T.proc.params(e: ActiveRecord::InternalMetadata).void).void }
+  sig { override.params(block: T.proc.params(e: ActiveRecord::InternalMetadata).void).returns(T::Array[ActiveRecord::InternalMetadata]) }
   def each(&block); end
 
   sig { params(level: T.nilable(Integer)).returns(T::Array[ActiveRecord::InternalMetadata]) }
@@ -528,7 +528,7 @@ class ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation < ActiveR
   sig { params(args: T.untyped).returns(T::Boolean) }
   def one?(*args); end
 
-  sig { override.params(block: T.proc.params(e: ActiveRecord::InternalMetadata).void).void }
+  sig { override.params(block: T.proc.params(e: ActiveRecord::InternalMetadata).void).returns(T::Array[ActiveRecord::InternalMetadata]) }
   def each(&block); end
 
   sig { params(level: T.nilable(Integer)).returns(T::Array[ActiveRecord::InternalMetadata]) }
@@ -694,7 +694,7 @@ class ActiveRecord::InternalMetadata::ActiveRecord_Associations_CollectionProxy 
   sig { params(args: T.untyped).returns(T::Boolean) }
   def one?(*args); end
 
-  sig { override.params(block: T.proc.params(e: ActiveRecord::InternalMetadata).void).void }
+  sig { override.params(block: T.proc.params(e: ActiveRecord::InternalMetadata).void).returns(T::Array[ActiveRecord::InternalMetadata]) }
   def each(&block); end
 
   sig { params(level: T.nilable(Integer)).returns(T::Array[ActiveRecord::InternalMetadata]) }

--- a/spec/test_data/v5.0/expected_potion.rbi
+++ b/spec/test_data/v5.0/expected_potion.rbi
@@ -320,7 +320,7 @@ class Potion::ActiveRecord_Relation < ActiveRecord::Relation
   sig { params(args: T.untyped).returns(T::Boolean) }
   def one?(*args); end
 
-  sig { override.params(block: T.proc.params(e: Potion).void).void }
+  sig { override.params(block: T.proc.params(e: Potion).void).returns(T::Array[Potion]) }
   def each(&block); end
 
   sig { params(level: T.nilable(Integer)).returns(T::Array[Potion]) }
@@ -487,7 +487,7 @@ class Potion::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelati
   sig { params(args: T.untyped).returns(T::Boolean) }
   def one?(*args); end
 
-  sig { override.params(block: T.proc.params(e: Potion).void).void }
+  sig { override.params(block: T.proc.params(e: Potion).void).returns(T::Array[Potion]) }
   def each(&block); end
 
   sig { params(level: T.nilable(Integer)).returns(T::Array[Potion]) }
@@ -653,7 +653,7 @@ class Potion::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associat
   sig { params(args: T.untyped).returns(T::Boolean) }
   def one?(*args); end
 
-  sig { override.params(block: T.proc.params(e: Potion).void).void }
+  sig { override.params(block: T.proc.params(e: Potion).void).returns(T::Array[Potion]) }
   def each(&block); end
 
   sig { params(level: T.nilable(Integer)).returns(T::Array[Potion]) }

--- a/spec/test_data/v5.0/expected_schema_migration.rbi
+++ b/spec/test_data/v5.0/expected_schema_migration.rbi
@@ -334,7 +334,7 @@ class ActiveRecord::SchemaMigration::ActiveRecord_Relation < ActiveRecord::Relat
   sig { params(args: T.untyped).returns(T::Boolean) }
   def one?(*args); end
 
-  sig { override.params(block: T.proc.params(e: ActiveRecord::SchemaMigration).void).void }
+  sig { override.params(block: T.proc.params(e: ActiveRecord::SchemaMigration).void).returns(T::Array[ActiveRecord::SchemaMigration]) }
   def each(&block); end
 
   sig { params(level: T.nilable(Integer)).returns(T::Array[ActiveRecord::SchemaMigration]) }
@@ -501,7 +501,7 @@ class ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation < ActiveRe
   sig { params(args: T.untyped).returns(T::Boolean) }
   def one?(*args); end
 
-  sig { override.params(block: T.proc.params(e: ActiveRecord::SchemaMigration).void).void }
+  sig { override.params(block: T.proc.params(e: ActiveRecord::SchemaMigration).void).returns(T::Array[ActiveRecord::SchemaMigration]) }
   def each(&block); end
 
   sig { params(level: T.nilable(Integer)).returns(T::Array[ActiveRecord::SchemaMigration]) }
@@ -667,7 +667,7 @@ class ActiveRecord::SchemaMigration::ActiveRecord_Associations_CollectionProxy <
   sig { params(args: T.untyped).returns(T::Boolean) }
   def one?(*args); end
 
-  sig { override.params(block: T.proc.params(e: ActiveRecord::SchemaMigration).void).void }
+  sig { override.params(block: T.proc.params(e: ActiveRecord::SchemaMigration).void).returns(T::Array[ActiveRecord::SchemaMigration]) }
   def each(&block); end
 
   sig { params(level: T.nilable(Integer)).returns(T::Array[ActiveRecord::SchemaMigration]) }

--- a/spec/test_data/v5.0/expected_spell_book.rbi
+++ b/spec/test_data/v5.0/expected_spell_book.rbi
@@ -416,7 +416,7 @@ class SpellBook::ActiveRecord_Relation < ActiveRecord::Relation
   sig { params(args: T.untyped).returns(T::Boolean) }
   def one?(*args); end
 
-  sig { override.params(block: T.proc.params(e: SpellBook).void).void }
+  sig { override.params(block: T.proc.params(e: SpellBook).void).returns(T::Array[SpellBook]) }
   def each(&block); end
 
   sig { params(level: T.nilable(Integer)).returns(T::Array[SpellBook]) }
@@ -592,7 +592,7 @@ class SpellBook::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRel
   sig { params(args: T.untyped).returns(T::Boolean) }
   def one?(*args); end
 
-  sig { override.params(block: T.proc.params(e: SpellBook).void).void }
+  sig { override.params(block: T.proc.params(e: SpellBook).void).returns(T::Array[SpellBook]) }
   def each(&block); end
 
   sig { params(level: T.nilable(Integer)).returns(T::Array[SpellBook]) }
@@ -767,7 +767,7 @@ class SpellBook::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Assoc
   sig { params(args: T.untyped).returns(T::Boolean) }
   def one?(*args); end
 
-  sig { override.params(block: T.proc.params(e: SpellBook).void).void }
+  sig { override.params(block: T.proc.params(e: SpellBook).void).returns(T::Array[SpellBook]) }
   def each(&block); end
 
   sig { params(level: T.nilable(Integer)).returns(T::Array[SpellBook]) }

--- a/spec/test_data/v5.0/expected_squib.rbi
+++ b/spec/test_data/v5.0/expected_squib.rbi
@@ -692,7 +692,7 @@ class Squib::ActiveRecord_Relation < ActiveRecord::Relation
   sig { params(args: T.untyped).returns(T::Boolean) }
   def one?(*args); end
 
-  sig { override.params(block: T.proc.params(e: Squib).void).void }
+  sig { override.params(block: T.proc.params(e: Squib).void).returns(T::Array[Squib]) }
   def each(&block); end
 
   sig { params(level: T.nilable(Integer)).returns(T::Array[Squib]) }
@@ -913,7 +913,7 @@ class Squib::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelatio
   sig { params(args: T.untyped).returns(T::Boolean) }
   def one?(*args); end
 
-  sig { override.params(block: T.proc.params(e: Squib).void).void }
+  sig { override.params(block: T.proc.params(e: Squib).void).returns(T::Array[Squib]) }
   def each(&block); end
 
   sig { params(level: T.nilable(Integer)).returns(T::Array[Squib]) }
@@ -1133,7 +1133,7 @@ class Squib::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associati
   sig { params(args: T.untyped).returns(T::Boolean) }
   def one?(*args); end
 
-  sig { override.params(block: T.proc.params(e: Squib).void).void }
+  sig { override.params(block: T.proc.params(e: Squib).void).returns(T::Array[Squib]) }
   def each(&block); end
 
   sig { params(level: T.nilable(Integer)).returns(T::Array[Squib]) }

--- a/spec/test_data/v5.0/expected_wand.rbi
+++ b/spec/test_data/v5.0/expected_wand.rbi
@@ -503,7 +503,7 @@ class Wand::ActiveRecord_Relation < ActiveRecord::Relation
   sig { params(args: T.untyped).returns(T::Boolean) }
   def one?(*args); end
 
-  sig { override.params(block: T.proc.params(e: Wand).void).void }
+  sig { override.params(block: T.proc.params(e: Wand).void).returns(T::Array[Wand]) }
   def each(&block); end
 
   sig { params(level: T.nilable(Integer)).returns(T::Array[Wand]) }
@@ -682,7 +682,7 @@ class Wand::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
   sig { params(args: T.untyped).returns(T::Boolean) }
   def one?(*args); end
 
-  sig { override.params(block: T.proc.params(e: Wand).void).void }
+  sig { override.params(block: T.proc.params(e: Wand).void).returns(T::Array[Wand]) }
   def each(&block); end
 
   sig { params(level: T.nilable(Integer)).returns(T::Array[Wand]) }
@@ -860,7 +860,7 @@ class Wand::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associatio
   sig { params(args: T.untyped).returns(T::Boolean) }
   def one?(*args); end
 
-  sig { override.params(block: T.proc.params(e: Wand).void).void }
+  sig { override.params(block: T.proc.params(e: Wand).void).returns(T::Array[Wand]) }
   def each(&block); end
 
   sig { params(level: T.nilable(Integer)).returns(T::Array[Wand]) }

--- a/spec/test_data/v5.0/expected_wizard.rbi
+++ b/spec/test_data/v5.0/expected_wizard.rbi
@@ -692,7 +692,7 @@ class Wizard::ActiveRecord_Relation < ActiveRecord::Relation
   sig { params(args: T.untyped).returns(T::Boolean) }
   def one?(*args); end
 
-  sig { override.params(block: T.proc.params(e: Wizard).void).void }
+  sig { override.params(block: T.proc.params(e: Wizard).void).returns(T::Array[Wizard]) }
   def each(&block); end
 
   sig { params(level: T.nilable(Integer)).returns(T::Array[Wizard]) }
@@ -913,7 +913,7 @@ class Wizard::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelati
   sig { params(args: T.untyped).returns(T::Boolean) }
   def one?(*args); end
 
-  sig { override.params(block: T.proc.params(e: Wizard).void).void }
+  sig { override.params(block: T.proc.params(e: Wizard).void).returns(T::Array[Wizard]) }
   def each(&block); end
 
   sig { params(level: T.nilable(Integer)).returns(T::Array[Wizard]) }
@@ -1133,7 +1133,7 @@ class Wizard::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associat
   sig { params(args: T.untyped).returns(T::Boolean) }
   def one?(*args); end
 
-  sig { override.params(block: T.proc.params(e: Wizard).void).void }
+  sig { override.params(block: T.proc.params(e: Wizard).void).returns(T::Array[Wizard]) }
   def each(&block); end
 
   sig { params(level: T.nilable(Integer)).returns(T::Array[Wizard]) }

--- a/spec/test_data/v5.0/expected_wizard_wo_spellbook.rbi
+++ b/spec/test_data/v5.0/expected_wizard_wo_spellbook.rbi
@@ -692,7 +692,7 @@ class Wizard::ActiveRecord_Relation < ActiveRecord::Relation
   sig { params(args: T.untyped).returns(T::Boolean) }
   def one?(*args); end
 
-  sig { override.params(block: T.proc.params(e: Wizard).void).void }
+  sig { override.params(block: T.proc.params(e: Wizard).void).returns(T::Array[Wizard]) }
   def each(&block); end
 
   sig { params(level: T.nilable(Integer)).returns(T::Array[Wizard]) }
@@ -913,7 +913,7 @@ class Wizard::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelati
   sig { params(args: T.untyped).returns(T::Boolean) }
   def one?(*args); end
 
-  sig { override.params(block: T.proc.params(e: Wizard).void).void }
+  sig { override.params(block: T.proc.params(e: Wizard).void).returns(T::Array[Wizard]) }
   def each(&block); end
 
   sig { params(level: T.nilable(Integer)).returns(T::Array[Wizard]) }
@@ -1133,7 +1133,7 @@ class Wizard::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associat
   sig { params(args: T.untyped).returns(T::Boolean) }
   def one?(*args); end
 
-  sig { override.params(block: T.proc.params(e: Wizard).void).void }
+  sig { override.params(block: T.proc.params(e: Wizard).void).returns(T::Array[Wizard]) }
   def each(&block); end
 
   sig { params(level: T.nilable(Integer)).returns(T::Array[Wizard]) }

--- a/spec/test_data/v5.1/expected_internal_metadata.rbi
+++ b/spec/test_data/v5.1/expected_internal_metadata.rbi
@@ -373,7 +373,7 @@ class ActiveRecord::InternalMetadata::ActiveRecord_Relation < ActiveRecord::Rela
   sig { params(args: T.untyped).returns(T::Boolean) }
   def one?(*args); end
 
-  sig { override.params(block: T.proc.params(e: ActiveRecord::InternalMetadata).void).void }
+  sig { override.params(block: T.proc.params(e: ActiveRecord::InternalMetadata).void).returns(T::Array[ActiveRecord::InternalMetadata]) }
   def each(&block); end
 
   sig { params(level: T.nilable(Integer)).returns(T::Array[ActiveRecord::InternalMetadata]) }
@@ -546,7 +546,7 @@ class ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation < ActiveR
   sig { params(args: T.untyped).returns(T::Boolean) }
   def one?(*args); end
 
-  sig { override.params(block: T.proc.params(e: ActiveRecord::InternalMetadata).void).void }
+  sig { override.params(block: T.proc.params(e: ActiveRecord::InternalMetadata).void).returns(T::Array[ActiveRecord::InternalMetadata]) }
   def each(&block); end
 
   sig { params(level: T.nilable(Integer)).returns(T::Array[ActiveRecord::InternalMetadata]) }
@@ -718,7 +718,7 @@ class ActiveRecord::InternalMetadata::ActiveRecord_Associations_CollectionProxy 
   sig { params(args: T.untyped).returns(T::Boolean) }
   def one?(*args); end
 
-  sig { override.params(block: T.proc.params(e: ActiveRecord::InternalMetadata).void).void }
+  sig { override.params(block: T.proc.params(e: ActiveRecord::InternalMetadata).void).returns(T::Array[ActiveRecord::InternalMetadata]) }
   def each(&block); end
 
   sig { params(level: T.nilable(Integer)).returns(T::Array[ActiveRecord::InternalMetadata]) }

--- a/spec/test_data/v5.1/expected_potion.rbi
+++ b/spec/test_data/v5.1/expected_potion.rbi
@@ -332,7 +332,7 @@ class Potion::ActiveRecord_Relation < ActiveRecord::Relation
   sig { params(args: T.untyped).returns(T::Boolean) }
   def one?(*args); end
 
-  sig { override.params(block: T.proc.params(e: Potion).void).void }
+  sig { override.params(block: T.proc.params(e: Potion).void).returns(T::Array[Potion]) }
   def each(&block); end
 
   sig { params(level: T.nilable(Integer)).returns(T::Array[Potion]) }
@@ -505,7 +505,7 @@ class Potion::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelati
   sig { params(args: T.untyped).returns(T::Boolean) }
   def one?(*args); end
 
-  sig { override.params(block: T.proc.params(e: Potion).void).void }
+  sig { override.params(block: T.proc.params(e: Potion).void).returns(T::Array[Potion]) }
   def each(&block); end
 
   sig { params(level: T.nilable(Integer)).returns(T::Array[Potion]) }
@@ -677,7 +677,7 @@ class Potion::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associat
   sig { params(args: T.untyped).returns(T::Boolean) }
   def one?(*args); end
 
-  sig { override.params(block: T.proc.params(e: Potion).void).void }
+  sig { override.params(block: T.proc.params(e: Potion).void).returns(T::Array[Potion]) }
   def each(&block); end
 
   sig { params(level: T.nilable(Integer)).returns(T::Array[Potion]) }

--- a/spec/test_data/v5.1/expected_schema_migration.rbi
+++ b/spec/test_data/v5.1/expected_schema_migration.rbi
@@ -346,7 +346,7 @@ class ActiveRecord::SchemaMigration::ActiveRecord_Relation < ActiveRecord::Relat
   sig { params(args: T.untyped).returns(T::Boolean) }
   def one?(*args); end
 
-  sig { override.params(block: T.proc.params(e: ActiveRecord::SchemaMigration).void).void }
+  sig { override.params(block: T.proc.params(e: ActiveRecord::SchemaMigration).void).returns(T::Array[ActiveRecord::SchemaMigration]) }
   def each(&block); end
 
   sig { params(level: T.nilable(Integer)).returns(T::Array[ActiveRecord::SchemaMigration]) }
@@ -519,7 +519,7 @@ class ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation < ActiveRe
   sig { params(args: T.untyped).returns(T::Boolean) }
   def one?(*args); end
 
-  sig { override.params(block: T.proc.params(e: ActiveRecord::SchemaMigration).void).void }
+  sig { override.params(block: T.proc.params(e: ActiveRecord::SchemaMigration).void).returns(T::Array[ActiveRecord::SchemaMigration]) }
   def each(&block); end
 
   sig { params(level: T.nilable(Integer)).returns(T::Array[ActiveRecord::SchemaMigration]) }
@@ -691,7 +691,7 @@ class ActiveRecord::SchemaMigration::ActiveRecord_Associations_CollectionProxy <
   sig { params(args: T.untyped).returns(T::Boolean) }
   def one?(*args); end
 
-  sig { override.params(block: T.proc.params(e: ActiveRecord::SchemaMigration).void).void }
+  sig { override.params(block: T.proc.params(e: ActiveRecord::SchemaMigration).void).returns(T::Array[ActiveRecord::SchemaMigration]) }
   def each(&block); end
 
   sig { params(level: T.nilable(Integer)).returns(T::Array[ActiveRecord::SchemaMigration]) }

--- a/spec/test_data/v5.1/expected_spell_book.rbi
+++ b/spec/test_data/v5.1/expected_spell_book.rbi
@@ -428,7 +428,7 @@ class SpellBook::ActiveRecord_Relation < ActiveRecord::Relation
   sig { params(args: T.untyped).returns(T::Boolean) }
   def one?(*args); end
 
-  sig { override.params(block: T.proc.params(e: SpellBook).void).void }
+  sig { override.params(block: T.proc.params(e: SpellBook).void).returns(T::Array[SpellBook]) }
   def each(&block); end
 
   sig { params(level: T.nilable(Integer)).returns(T::Array[SpellBook]) }
@@ -610,7 +610,7 @@ class SpellBook::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRel
   sig { params(args: T.untyped).returns(T::Boolean) }
   def one?(*args); end
 
-  sig { override.params(block: T.proc.params(e: SpellBook).void).void }
+  sig { override.params(block: T.proc.params(e: SpellBook).void).returns(T::Array[SpellBook]) }
   def each(&block); end
 
   sig { params(level: T.nilable(Integer)).returns(T::Array[SpellBook]) }
@@ -791,7 +791,7 @@ class SpellBook::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Assoc
   sig { params(args: T.untyped).returns(T::Boolean) }
   def one?(*args); end
 
-  sig { override.params(block: T.proc.params(e: SpellBook).void).void }
+  sig { override.params(block: T.proc.params(e: SpellBook).void).returns(T::Array[SpellBook]) }
   def each(&block); end
 
   sig { params(level: T.nilable(Integer)).returns(T::Array[SpellBook]) }

--- a/spec/test_data/v5.1/expected_squib.rbi
+++ b/spec/test_data/v5.1/expected_squib.rbi
@@ -704,7 +704,7 @@ class Squib::ActiveRecord_Relation < ActiveRecord::Relation
   sig { params(args: T.untyped).returns(T::Boolean) }
   def one?(*args); end
 
-  sig { override.params(block: T.proc.params(e: Squib).void).void }
+  sig { override.params(block: T.proc.params(e: Squib).void).returns(T::Array[Squib]) }
   def each(&block); end
 
   sig { params(level: T.nilable(Integer)).returns(T::Array[Squib]) }
@@ -931,7 +931,7 @@ class Squib::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelatio
   sig { params(args: T.untyped).returns(T::Boolean) }
   def one?(*args); end
 
-  sig { override.params(block: T.proc.params(e: Squib).void).void }
+  sig { override.params(block: T.proc.params(e: Squib).void).returns(T::Array[Squib]) }
   def each(&block); end
 
   sig { params(level: T.nilable(Integer)).returns(T::Array[Squib]) }
@@ -1157,7 +1157,7 @@ class Squib::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associati
   sig { params(args: T.untyped).returns(T::Boolean) }
   def one?(*args); end
 
-  sig { override.params(block: T.proc.params(e: Squib).void).void }
+  sig { override.params(block: T.proc.params(e: Squib).void).returns(T::Array[Squib]) }
   def each(&block); end
 
   sig { params(level: T.nilable(Integer)).returns(T::Array[Squib]) }

--- a/spec/test_data/v5.1/expected_wand.rbi
+++ b/spec/test_data/v5.1/expected_wand.rbi
@@ -515,7 +515,7 @@ class Wand::ActiveRecord_Relation < ActiveRecord::Relation
   sig { params(args: T.untyped).returns(T::Boolean) }
   def one?(*args); end
 
-  sig { override.params(block: T.proc.params(e: Wand).void).void }
+  sig { override.params(block: T.proc.params(e: Wand).void).returns(T::Array[Wand]) }
   def each(&block); end
 
   sig { params(level: T.nilable(Integer)).returns(T::Array[Wand]) }
@@ -700,7 +700,7 @@ class Wand::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
   sig { params(args: T.untyped).returns(T::Boolean) }
   def one?(*args); end
 
-  sig { override.params(block: T.proc.params(e: Wand).void).void }
+  sig { override.params(block: T.proc.params(e: Wand).void).returns(T::Array[Wand]) }
   def each(&block); end
 
   sig { params(level: T.nilable(Integer)).returns(T::Array[Wand]) }
@@ -884,7 +884,7 @@ class Wand::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associatio
   sig { params(args: T.untyped).returns(T::Boolean) }
   def one?(*args); end
 
-  sig { override.params(block: T.proc.params(e: Wand).void).void }
+  sig { override.params(block: T.proc.params(e: Wand).void).returns(T::Array[Wand]) }
   def each(&block); end
 
   sig { params(level: T.nilable(Integer)).returns(T::Array[Wand]) }

--- a/spec/test_data/v5.1/expected_wizard.rbi
+++ b/spec/test_data/v5.1/expected_wizard.rbi
@@ -704,7 +704,7 @@ class Wizard::ActiveRecord_Relation < ActiveRecord::Relation
   sig { params(args: T.untyped).returns(T::Boolean) }
   def one?(*args); end
 
-  sig { override.params(block: T.proc.params(e: Wizard).void).void }
+  sig { override.params(block: T.proc.params(e: Wizard).void).returns(T::Array[Wizard]) }
   def each(&block); end
 
   sig { params(level: T.nilable(Integer)).returns(T::Array[Wizard]) }
@@ -931,7 +931,7 @@ class Wizard::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelati
   sig { params(args: T.untyped).returns(T::Boolean) }
   def one?(*args); end
 
-  sig { override.params(block: T.proc.params(e: Wizard).void).void }
+  sig { override.params(block: T.proc.params(e: Wizard).void).returns(T::Array[Wizard]) }
   def each(&block); end
 
   sig { params(level: T.nilable(Integer)).returns(T::Array[Wizard]) }
@@ -1157,7 +1157,7 @@ class Wizard::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associat
   sig { params(args: T.untyped).returns(T::Boolean) }
   def one?(*args); end
 
-  sig { override.params(block: T.proc.params(e: Wizard).void).void }
+  sig { override.params(block: T.proc.params(e: Wizard).void).returns(T::Array[Wizard]) }
   def each(&block); end
 
   sig { params(level: T.nilable(Integer)).returns(T::Array[Wizard]) }

--- a/spec/test_data/v5.1/expected_wizard_wo_spellbook.rbi
+++ b/spec/test_data/v5.1/expected_wizard_wo_spellbook.rbi
@@ -704,7 +704,7 @@ class Wizard::ActiveRecord_Relation < ActiveRecord::Relation
   sig { params(args: T.untyped).returns(T::Boolean) }
   def one?(*args); end
 
-  sig { override.params(block: T.proc.params(e: Wizard).void).void }
+  sig { override.params(block: T.proc.params(e: Wizard).void).returns(T::Array[Wizard]) }
   def each(&block); end
 
   sig { params(level: T.nilable(Integer)).returns(T::Array[Wizard]) }
@@ -931,7 +931,7 @@ class Wizard::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelati
   sig { params(args: T.untyped).returns(T::Boolean) }
   def one?(*args); end
 
-  sig { override.params(block: T.proc.params(e: Wizard).void).void }
+  sig { override.params(block: T.proc.params(e: Wizard).void).returns(T::Array[Wizard]) }
   def each(&block); end
 
   sig { params(level: T.nilable(Integer)).returns(T::Array[Wizard]) }
@@ -1157,7 +1157,7 @@ class Wizard::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associat
   sig { params(args: T.untyped).returns(T::Boolean) }
   def one?(*args); end
 
-  sig { override.params(block: T.proc.params(e: Wizard).void).void }
+  sig { override.params(block: T.proc.params(e: Wizard).void).returns(T::Array[Wizard]) }
   def each(&block); end
 
   sig { params(level: T.nilable(Integer)).returns(T::Array[Wizard]) }

--- a/spec/test_data/v5.2/expected_attachment.rbi
+++ b/spec/test_data/v5.2/expected_attachment.rbi
@@ -349,7 +349,7 @@ class ActiveStorage::Attachment::ActiveRecord_Relation < ActiveRecord::Relation
   sig { params(args: T.untyped).returns(T::Boolean) }
   def one?(*args); end
 
-  sig { override.params(block: T.proc.params(e: ActiveStorage::Attachment).void).void }
+  sig { override.params(block: T.proc.params(e: ActiveStorage::Attachment).void).returns(T::Array[ActiveStorage::Attachment]) }
   def each(&block); end
 
   sig { params(level: T.nilable(Integer)).returns(T::Array[ActiveStorage::Attachment]) }
@@ -522,7 +522,7 @@ class ActiveStorage::Attachment::ActiveRecord_AssociationRelation < ActiveRecord
   sig { params(args: T.untyped).returns(T::Boolean) }
   def one?(*args); end
 
-  sig { override.params(block: T.proc.params(e: ActiveStorage::Attachment).void).void }
+  sig { override.params(block: T.proc.params(e: ActiveStorage::Attachment).void).returns(T::Array[ActiveStorage::Attachment]) }
   def each(&block); end
 
   sig { params(level: T.nilable(Integer)).returns(T::Array[ActiveStorage::Attachment]) }
@@ -694,7 +694,7 @@ class ActiveStorage::Attachment::ActiveRecord_Associations_CollectionProxy < Act
   sig { params(args: T.untyped).returns(T::Boolean) }
   def one?(*args); end
 
-  sig { override.params(block: T.proc.params(e: ActiveStorage::Attachment).void).void }
+  sig { override.params(block: T.proc.params(e: ActiveStorage::Attachment).void).returns(T::Array[ActiveStorage::Attachment]) }
   def each(&block); end
 
   sig { params(level: T.nilable(Integer)).returns(T::Array[ActiveStorage::Attachment]) }

--- a/spec/test_data/v5.2/expected_blob.rbi
+++ b/spec/test_data/v5.2/expected_blob.rbi
@@ -367,7 +367,7 @@ class ActiveStorage::Blob::ActiveRecord_Relation < ActiveRecord::Relation
   sig { params(args: T.untyped).returns(T::Boolean) }
   def one?(*args); end
 
-  sig { override.params(block: T.proc.params(e: ActiveStorage::Blob).void).void }
+  sig { override.params(block: T.proc.params(e: ActiveStorage::Blob).void).returns(T::Array[ActiveStorage::Blob]) }
   def each(&block); end
 
   sig { params(level: T.nilable(Integer)).returns(T::Array[ActiveStorage::Blob]) }
@@ -546,7 +546,7 @@ class ActiveStorage::Blob::ActiveRecord_AssociationRelation < ActiveRecord::Asso
   sig { params(args: T.untyped).returns(T::Boolean) }
   def one?(*args); end
 
-  sig { override.params(block: T.proc.params(e: ActiveStorage::Blob).void).void }
+  sig { override.params(block: T.proc.params(e: ActiveStorage::Blob).void).returns(T::Array[ActiveStorage::Blob]) }
   def each(&block); end
 
   sig { params(level: T.nilable(Integer)).returns(T::Array[ActiveStorage::Blob]) }
@@ -724,7 +724,7 @@ class ActiveStorage::Blob::ActiveRecord_Associations_CollectionProxy < ActiveRec
   sig { params(args: T.untyped).returns(T::Boolean) }
   def one?(*args); end
 
-  sig { override.params(block: T.proc.params(e: ActiveStorage::Blob).void).void }
+  sig { override.params(block: T.proc.params(e: ActiveStorage::Blob).void).returns(T::Array[ActiveStorage::Blob]) }
   def each(&block); end
 
   sig { params(level: T.nilable(Integer)).returns(T::Array[ActiveStorage::Blob]) }

--- a/spec/test_data/v5.2/expected_internal_metadata.rbi
+++ b/spec/test_data/v5.2/expected_internal_metadata.rbi
@@ -373,7 +373,7 @@ class ActiveRecord::InternalMetadata::ActiveRecord_Relation < ActiveRecord::Rela
   sig { params(args: T.untyped).returns(T::Boolean) }
   def one?(*args); end
 
-  sig { override.params(block: T.proc.params(e: ActiveRecord::InternalMetadata).void).void }
+  sig { override.params(block: T.proc.params(e: ActiveRecord::InternalMetadata).void).returns(T::Array[ActiveRecord::InternalMetadata]) }
   def each(&block); end
 
   sig { params(level: T.nilable(Integer)).returns(T::Array[ActiveRecord::InternalMetadata]) }
@@ -546,7 +546,7 @@ class ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation < ActiveR
   sig { params(args: T.untyped).returns(T::Boolean) }
   def one?(*args); end
 
-  sig { override.params(block: T.proc.params(e: ActiveRecord::InternalMetadata).void).void }
+  sig { override.params(block: T.proc.params(e: ActiveRecord::InternalMetadata).void).returns(T::Array[ActiveRecord::InternalMetadata]) }
   def each(&block); end
 
   sig { params(level: T.nilable(Integer)).returns(T::Array[ActiveRecord::InternalMetadata]) }
@@ -718,7 +718,7 @@ class ActiveRecord::InternalMetadata::ActiveRecord_Associations_CollectionProxy 
   sig { params(args: T.untyped).returns(T::Boolean) }
   def one?(*args); end
 
-  sig { override.params(block: T.proc.params(e: ActiveRecord::InternalMetadata).void).void }
+  sig { override.params(block: T.proc.params(e: ActiveRecord::InternalMetadata).void).returns(T::Array[ActiveRecord::InternalMetadata]) }
   def each(&block); end
 
   sig { params(level: T.nilable(Integer)).returns(T::Array[ActiveRecord::InternalMetadata]) }

--- a/spec/test_data/v5.2/expected_potion.rbi
+++ b/spec/test_data/v5.2/expected_potion.rbi
@@ -332,7 +332,7 @@ class Potion::ActiveRecord_Relation < ActiveRecord::Relation
   sig { params(args: T.untyped).returns(T::Boolean) }
   def one?(*args); end
 
-  sig { override.params(block: T.proc.params(e: Potion).void).void }
+  sig { override.params(block: T.proc.params(e: Potion).void).returns(T::Array[Potion]) }
   def each(&block); end
 
   sig { params(level: T.nilable(Integer)).returns(T::Array[Potion]) }
@@ -505,7 +505,7 @@ class Potion::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelati
   sig { params(args: T.untyped).returns(T::Boolean) }
   def one?(*args); end
 
-  sig { override.params(block: T.proc.params(e: Potion).void).void }
+  sig { override.params(block: T.proc.params(e: Potion).void).returns(T::Array[Potion]) }
   def each(&block); end
 
   sig { params(level: T.nilable(Integer)).returns(T::Array[Potion]) }
@@ -677,7 +677,7 @@ class Potion::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associat
   sig { params(args: T.untyped).returns(T::Boolean) }
   def one?(*args); end
 
-  sig { override.params(block: T.proc.params(e: Potion).void).void }
+  sig { override.params(block: T.proc.params(e: Potion).void).returns(T::Array[Potion]) }
   def each(&block); end
 
   sig { params(level: T.nilable(Integer)).returns(T::Array[Potion]) }

--- a/spec/test_data/v5.2/expected_schema_migration.rbi
+++ b/spec/test_data/v5.2/expected_schema_migration.rbi
@@ -346,7 +346,7 @@ class ActiveRecord::SchemaMigration::ActiveRecord_Relation < ActiveRecord::Relat
   sig { params(args: T.untyped).returns(T::Boolean) }
   def one?(*args); end
 
-  sig { override.params(block: T.proc.params(e: ActiveRecord::SchemaMigration).void).void }
+  sig { override.params(block: T.proc.params(e: ActiveRecord::SchemaMigration).void).returns(T::Array[ActiveRecord::SchemaMigration]) }
   def each(&block); end
 
   sig { params(level: T.nilable(Integer)).returns(T::Array[ActiveRecord::SchemaMigration]) }
@@ -519,7 +519,7 @@ class ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation < ActiveRe
   sig { params(args: T.untyped).returns(T::Boolean) }
   def one?(*args); end
 
-  sig { override.params(block: T.proc.params(e: ActiveRecord::SchemaMigration).void).void }
+  sig { override.params(block: T.proc.params(e: ActiveRecord::SchemaMigration).void).returns(T::Array[ActiveRecord::SchemaMigration]) }
   def each(&block); end
 
   sig { params(level: T.nilable(Integer)).returns(T::Array[ActiveRecord::SchemaMigration]) }
@@ -691,7 +691,7 @@ class ActiveRecord::SchemaMigration::ActiveRecord_Associations_CollectionProxy <
   sig { params(args: T.untyped).returns(T::Boolean) }
   def one?(*args); end
 
-  sig { override.params(block: T.proc.params(e: ActiveRecord::SchemaMigration).void).void }
+  sig { override.params(block: T.proc.params(e: ActiveRecord::SchemaMigration).void).returns(T::Array[ActiveRecord::SchemaMigration]) }
   def each(&block); end
 
   sig { params(level: T.nilable(Integer)).returns(T::Array[ActiveRecord::SchemaMigration]) }

--- a/spec/test_data/v5.2/expected_spell_book.rbi
+++ b/spec/test_data/v5.2/expected_spell_book.rbi
@@ -428,7 +428,7 @@ class SpellBook::ActiveRecord_Relation < ActiveRecord::Relation
   sig { params(args: T.untyped).returns(T::Boolean) }
   def one?(*args); end
 
-  sig { override.params(block: T.proc.params(e: SpellBook).void).void }
+  sig { override.params(block: T.proc.params(e: SpellBook).void).returns(T::Array[SpellBook]) }
   def each(&block); end
 
   sig { params(level: T.nilable(Integer)).returns(T::Array[SpellBook]) }
@@ -610,7 +610,7 @@ class SpellBook::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRel
   sig { params(args: T.untyped).returns(T::Boolean) }
   def one?(*args); end
 
-  sig { override.params(block: T.proc.params(e: SpellBook).void).void }
+  sig { override.params(block: T.proc.params(e: SpellBook).void).returns(T::Array[SpellBook]) }
   def each(&block); end
 
   sig { params(level: T.nilable(Integer)).returns(T::Array[SpellBook]) }
@@ -791,7 +791,7 @@ class SpellBook::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Assoc
   sig { params(args: T.untyped).returns(T::Boolean) }
   def one?(*args); end
 
-  sig { override.params(block: T.proc.params(e: SpellBook).void).void }
+  sig { override.params(block: T.proc.params(e: SpellBook).void).returns(T::Array[SpellBook]) }
   def each(&block); end
 
   sig { params(level: T.nilable(Integer)).returns(T::Array[SpellBook]) }

--- a/spec/test_data/v5.2/expected_squib.rbi
+++ b/spec/test_data/v5.2/expected_squib.rbi
@@ -740,7 +740,7 @@ class Squib::ActiveRecord_Relation < ActiveRecord::Relation
   sig { params(args: T.untyped).returns(T::Boolean) }
   def one?(*args); end
 
-  sig { override.params(block: T.proc.params(e: Squib).void).void }
+  sig { override.params(block: T.proc.params(e: Squib).void).returns(T::Array[Squib]) }
   def each(&block); end
 
   sig { params(level: T.nilable(Integer)).returns(T::Array[Squib]) }
@@ -973,7 +973,7 @@ class Squib::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelatio
   sig { params(args: T.untyped).returns(T::Boolean) }
   def one?(*args); end
 
-  sig { override.params(block: T.proc.params(e: Squib).void).void }
+  sig { override.params(block: T.proc.params(e: Squib).void).returns(T::Array[Squib]) }
   def each(&block); end
 
   sig { params(level: T.nilable(Integer)).returns(T::Array[Squib]) }
@@ -1205,7 +1205,7 @@ class Squib::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associati
   sig { params(args: T.untyped).returns(T::Boolean) }
   def one?(*args); end
 
-  sig { override.params(block: T.proc.params(e: Squib).void).void }
+  sig { override.params(block: T.proc.params(e: Squib).void).returns(T::Array[Squib]) }
   def each(&block); end
 
   sig { params(level: T.nilable(Integer)).returns(T::Array[Squib]) }

--- a/spec/test_data/v5.2/expected_wand.rbi
+++ b/spec/test_data/v5.2/expected_wand.rbi
@@ -533,7 +533,7 @@ class Wand::ActiveRecord_Relation < ActiveRecord::Relation
   sig { params(args: T.untyped).returns(T::Boolean) }
   def one?(*args); end
 
-  sig { override.params(block: T.proc.params(e: Wand).void).void }
+  sig { override.params(block: T.proc.params(e: Wand).void).returns(T::Array[Wand]) }
   def each(&block); end
 
   sig { params(level: T.nilable(Integer)).returns(T::Array[Wand]) }
@@ -718,7 +718,7 @@ class Wand::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
   sig { params(args: T.untyped).returns(T::Boolean) }
   def one?(*args); end
 
-  sig { override.params(block: T.proc.params(e: Wand).void).void }
+  sig { override.params(block: T.proc.params(e: Wand).void).returns(T::Array[Wand]) }
   def each(&block); end
 
   sig { params(level: T.nilable(Integer)).returns(T::Array[Wand]) }
@@ -902,7 +902,7 @@ class Wand::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associatio
   sig { params(args: T.untyped).returns(T::Boolean) }
   def one?(*args); end
 
-  sig { override.params(block: T.proc.params(e: Wand).void).void }
+  sig { override.params(block: T.proc.params(e: Wand).void).returns(T::Array[Wand]) }
   def each(&block); end
 
   sig { params(level: T.nilable(Integer)).returns(T::Array[Wand]) }

--- a/spec/test_data/v5.2/expected_wizard.rbi
+++ b/spec/test_data/v5.2/expected_wizard.rbi
@@ -740,7 +740,7 @@ class Wizard::ActiveRecord_Relation < ActiveRecord::Relation
   sig { params(args: T.untyped).returns(T::Boolean) }
   def one?(*args); end
 
-  sig { override.params(block: T.proc.params(e: Wizard).void).void }
+  sig { override.params(block: T.proc.params(e: Wizard).void).returns(T::Array[Wizard]) }
   def each(&block); end
 
   sig { params(level: T.nilable(Integer)).returns(T::Array[Wizard]) }
@@ -973,7 +973,7 @@ class Wizard::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelati
   sig { params(args: T.untyped).returns(T::Boolean) }
   def one?(*args); end
 
-  sig { override.params(block: T.proc.params(e: Wizard).void).void }
+  sig { override.params(block: T.proc.params(e: Wizard).void).returns(T::Array[Wizard]) }
   def each(&block); end
 
   sig { params(level: T.nilable(Integer)).returns(T::Array[Wizard]) }
@@ -1205,7 +1205,7 @@ class Wizard::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associat
   sig { params(args: T.untyped).returns(T::Boolean) }
   def one?(*args); end
 
-  sig { override.params(block: T.proc.params(e: Wizard).void).void }
+  sig { override.params(block: T.proc.params(e: Wizard).void).returns(T::Array[Wizard]) }
   def each(&block); end
 
   sig { params(level: T.nilable(Integer)).returns(T::Array[Wizard]) }

--- a/spec/test_data/v5.2/expected_wizard_wo_spellbook.rbi
+++ b/spec/test_data/v5.2/expected_wizard_wo_spellbook.rbi
@@ -740,7 +740,7 @@ class Wizard::ActiveRecord_Relation < ActiveRecord::Relation
   sig { params(args: T.untyped).returns(T::Boolean) }
   def one?(*args); end
 
-  sig { override.params(block: T.proc.params(e: Wizard).void).void }
+  sig { override.params(block: T.proc.params(e: Wizard).void).returns(T::Array[Wizard]) }
   def each(&block); end
 
   sig { params(level: T.nilable(Integer)).returns(T::Array[Wizard]) }
@@ -973,7 +973,7 @@ class Wizard::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelati
   sig { params(args: T.untyped).returns(T::Boolean) }
   def one?(*args); end
 
-  sig { override.params(block: T.proc.params(e: Wizard).void).void }
+  sig { override.params(block: T.proc.params(e: Wizard).void).returns(T::Array[Wizard]) }
   def each(&block); end
 
   sig { params(level: T.nilable(Integer)).returns(T::Array[Wizard]) }
@@ -1205,7 +1205,7 @@ class Wizard::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associat
   sig { params(args: T.untyped).returns(T::Boolean) }
   def one?(*args); end
 
-  sig { override.params(block: T.proc.params(e: Wizard).void).void }
+  sig { override.params(block: T.proc.params(e: Wizard).void).returns(T::Array[Wizard]) }
   def each(&block); end
 
   sig { params(level: T.nilable(Integer)).returns(T::Array[Wizard]) }

--- a/spec/test_data/v6.0/expected_attachment.rbi
+++ b/spec/test_data/v6.0/expected_attachment.rbi
@@ -373,7 +373,7 @@ class ActiveStorage::Attachment::ActiveRecord_Relation < ActiveRecord::Relation
   sig { params(args: T.untyped).returns(T::Boolean) }
   def one?(*args); end
 
-  sig { override.params(block: T.proc.params(e: ActiveStorage::Attachment).void).void }
+  sig { override.params(block: T.proc.params(e: ActiveStorage::Attachment).void).returns(T::Array[ActiveStorage::Attachment]) }
   def each(&block); end
 
   sig { params(level: T.nilable(Integer)).returns(T::Array[ActiveStorage::Attachment]) }
@@ -558,7 +558,7 @@ class ActiveStorage::Attachment::ActiveRecord_AssociationRelation < ActiveRecord
   sig { params(args: T.untyped).returns(T::Boolean) }
   def one?(*args); end
 
-  sig { override.params(block: T.proc.params(e: ActiveStorage::Attachment).void).void }
+  sig { override.params(block: T.proc.params(e: ActiveStorage::Attachment).void).returns(T::Array[ActiveStorage::Attachment]) }
   def each(&block); end
 
   sig { params(level: T.nilable(Integer)).returns(T::Array[ActiveStorage::Attachment]) }
@@ -742,7 +742,7 @@ class ActiveStorage::Attachment::ActiveRecord_Associations_CollectionProxy < Act
   sig { params(args: T.untyped).returns(T::Boolean) }
   def one?(*args); end
 
-  sig { override.params(block: T.proc.params(e: ActiveStorage::Attachment).void).void }
+  sig { override.params(block: T.proc.params(e: ActiveStorage::Attachment).void).returns(T::Array[ActiveStorage::Attachment]) }
   def each(&block); end
 
   sig { params(level: T.nilable(Integer)).returns(T::Array[ActiveStorage::Attachment]) }

--- a/spec/test_data/v6.0/expected_blob.rbi
+++ b/spec/test_data/v6.0/expected_blob.rbi
@@ -369,7 +369,7 @@ class ActiveStorage::Blob::ActiveRecord_Relation < ActiveRecord::Relation
   sig { params(args: T.untyped).returns(T::Boolean) }
   def one?(*args); end
 
-  sig { override.params(block: T.proc.params(e: ActiveStorage::Blob).void).void }
+  sig { override.params(block: T.proc.params(e: ActiveStorage::Blob).void).returns(T::Array[ActiveStorage::Blob]) }
   def each(&block); end
 
   sig { params(level: T.nilable(Integer)).returns(T::Array[ActiveStorage::Blob]) }
@@ -560,7 +560,7 @@ class ActiveStorage::Blob::ActiveRecord_AssociationRelation < ActiveRecord::Asso
   sig { params(args: T.untyped).returns(T::Boolean) }
   def one?(*args); end
 
-  sig { override.params(block: T.proc.params(e: ActiveStorage::Blob).void).void }
+  sig { override.params(block: T.proc.params(e: ActiveStorage::Blob).void).returns(T::Array[ActiveStorage::Blob]) }
   def each(&block); end
 
   sig { params(level: T.nilable(Integer)).returns(T::Array[ActiveStorage::Blob]) }
@@ -750,7 +750,7 @@ class ActiveStorage::Blob::ActiveRecord_Associations_CollectionProxy < ActiveRec
   sig { params(args: T.untyped).returns(T::Boolean) }
   def one?(*args); end
 
-  sig { override.params(block: T.proc.params(e: ActiveStorage::Blob).void).void }
+  sig { override.params(block: T.proc.params(e: ActiveStorage::Blob).void).returns(T::Array[ActiveStorage::Blob]) }
   def each(&block); end
 
   sig { params(level: T.nilable(Integer)).returns(T::Array[ActiveStorage::Blob]) }

--- a/spec/test_data/v6.0/expected_internal_metadata.rbi
+++ b/spec/test_data/v6.0/expected_internal_metadata.rbi
@@ -397,7 +397,7 @@ class ActiveRecord::InternalMetadata::ActiveRecord_Relation < ActiveRecord::Rela
   sig { params(args: T.untyped).returns(T::Boolean) }
   def one?(*args); end
 
-  sig { override.params(block: T.proc.params(e: ActiveRecord::InternalMetadata).void).void }
+  sig { override.params(block: T.proc.params(e: ActiveRecord::InternalMetadata).void).returns(T::Array[ActiveRecord::InternalMetadata]) }
   def each(&block); end
 
   sig { params(level: T.nilable(Integer)).returns(T::Array[ActiveRecord::InternalMetadata]) }
@@ -582,7 +582,7 @@ class ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation < ActiveR
   sig { params(args: T.untyped).returns(T::Boolean) }
   def one?(*args); end
 
-  sig { override.params(block: T.proc.params(e: ActiveRecord::InternalMetadata).void).void }
+  sig { override.params(block: T.proc.params(e: ActiveRecord::InternalMetadata).void).returns(T::Array[ActiveRecord::InternalMetadata]) }
   def each(&block); end
 
   sig { params(level: T.nilable(Integer)).returns(T::Array[ActiveRecord::InternalMetadata]) }
@@ -766,7 +766,7 @@ class ActiveRecord::InternalMetadata::ActiveRecord_Associations_CollectionProxy 
   sig { params(args: T.untyped).returns(T::Boolean) }
   def one?(*args); end
 
-  sig { override.params(block: T.proc.params(e: ActiveRecord::InternalMetadata).void).void }
+  sig { override.params(block: T.proc.params(e: ActiveRecord::InternalMetadata).void).returns(T::Array[ActiveRecord::InternalMetadata]) }
   def each(&block); end
 
   sig { params(level: T.nilable(Integer)).returns(T::Array[ActiveRecord::InternalMetadata]) }

--- a/spec/test_data/v6.0/expected_potion.rbi
+++ b/spec/test_data/v6.0/expected_potion.rbi
@@ -356,7 +356,7 @@ class Potion::ActiveRecord_Relation < ActiveRecord::Relation
   sig { params(args: T.untyped).returns(T::Boolean) }
   def one?(*args); end
 
-  sig { override.params(block: T.proc.params(e: Potion).void).void }
+  sig { override.params(block: T.proc.params(e: Potion).void).returns(T::Array[Potion]) }
   def each(&block); end
 
   sig { params(level: T.nilable(Integer)).returns(T::Array[Potion]) }
@@ -541,7 +541,7 @@ class Potion::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelati
   sig { params(args: T.untyped).returns(T::Boolean) }
   def one?(*args); end
 
-  sig { override.params(block: T.proc.params(e: Potion).void).void }
+  sig { override.params(block: T.proc.params(e: Potion).void).returns(T::Array[Potion]) }
   def each(&block); end
 
   sig { params(level: T.nilable(Integer)).returns(T::Array[Potion]) }
@@ -725,7 +725,7 @@ class Potion::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associat
   sig { params(args: T.untyped).returns(T::Boolean) }
   def one?(*args); end
 
-  sig { override.params(block: T.proc.params(e: Potion).void).void }
+  sig { override.params(block: T.proc.params(e: Potion).void).returns(T::Array[Potion]) }
   def each(&block); end
 
   sig { params(level: T.nilable(Integer)).returns(T::Array[Potion]) }

--- a/spec/test_data/v6.0/expected_schema_migration.rbi
+++ b/spec/test_data/v6.0/expected_schema_migration.rbi
@@ -370,7 +370,7 @@ class ActiveRecord::SchemaMigration::ActiveRecord_Relation < ActiveRecord::Relat
   sig { params(args: T.untyped).returns(T::Boolean) }
   def one?(*args); end
 
-  sig { override.params(block: T.proc.params(e: ActiveRecord::SchemaMigration).void).void }
+  sig { override.params(block: T.proc.params(e: ActiveRecord::SchemaMigration).void).returns(T::Array[ActiveRecord::SchemaMigration]) }
   def each(&block); end
 
   sig { params(level: T.nilable(Integer)).returns(T::Array[ActiveRecord::SchemaMigration]) }
@@ -555,7 +555,7 @@ class ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation < ActiveRe
   sig { params(args: T.untyped).returns(T::Boolean) }
   def one?(*args); end
 
-  sig { override.params(block: T.proc.params(e: ActiveRecord::SchemaMigration).void).void }
+  sig { override.params(block: T.proc.params(e: ActiveRecord::SchemaMigration).void).returns(T::Array[ActiveRecord::SchemaMigration]) }
   def each(&block); end
 
   sig { params(level: T.nilable(Integer)).returns(T::Array[ActiveRecord::SchemaMigration]) }
@@ -739,7 +739,7 @@ class ActiveRecord::SchemaMigration::ActiveRecord_Associations_CollectionProxy <
   sig { params(args: T.untyped).returns(T::Boolean) }
   def one?(*args); end
 
-  sig { override.params(block: T.proc.params(e: ActiveRecord::SchemaMigration).void).void }
+  sig { override.params(block: T.proc.params(e: ActiveRecord::SchemaMigration).void).returns(T::Array[ActiveRecord::SchemaMigration]) }
   def each(&block); end
 
   sig { params(level: T.nilable(Integer)).returns(T::Array[ActiveRecord::SchemaMigration]) }

--- a/spec/test_data/v6.0/expected_spell_book.rbi
+++ b/spec/test_data/v6.0/expected_spell_book.rbi
@@ -470,7 +470,7 @@ class SpellBook::ActiveRecord_Relation < ActiveRecord::Relation
   sig { params(args: T.untyped).returns(T::Boolean) }
   def one?(*args); end
 
-  sig { override.params(block: T.proc.params(e: SpellBook).void).void }
+  sig { override.params(block: T.proc.params(e: SpellBook).void).returns(T::Array[SpellBook]) }
   def each(&block); end
 
   sig { params(level: T.nilable(Integer)).returns(T::Array[SpellBook]) }
@@ -673,7 +673,7 @@ class SpellBook::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRel
   sig { params(args: T.untyped).returns(T::Boolean) }
   def one?(*args); end
 
-  sig { override.params(block: T.proc.params(e: SpellBook).void).void }
+  sig { override.params(block: T.proc.params(e: SpellBook).void).returns(T::Array[SpellBook]) }
   def each(&block); end
 
   sig { params(level: T.nilable(Integer)).returns(T::Array[SpellBook]) }
@@ -875,7 +875,7 @@ class SpellBook::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Assoc
   sig { params(args: T.untyped).returns(T::Boolean) }
   def one?(*args); end
 
-  sig { override.params(block: T.proc.params(e: SpellBook).void).void }
+  sig { override.params(block: T.proc.params(e: SpellBook).void).returns(T::Array[SpellBook]) }
   def each(&block); end
 
   sig { params(level: T.nilable(Integer)).returns(T::Array[SpellBook]) }

--- a/spec/test_data/v6.0/expected_squib.rbi
+++ b/spec/test_data/v6.0/expected_squib.rbi
@@ -826,7 +826,7 @@ class Squib::ActiveRecord_Relation < ActiveRecord::Relation
   sig { params(args: T.untyped).returns(T::Boolean) }
   def one?(*args); end
 
-  sig { override.params(block: T.proc.params(e: Squib).void).void }
+  sig { override.params(block: T.proc.params(e: Squib).void).returns(T::Array[Squib]) }
   def each(&block); end
 
   sig { params(level: T.nilable(Integer)).returns(T::Array[Squib]) }
@@ -1122,7 +1122,7 @@ class Squib::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelatio
   sig { params(args: T.untyped).returns(T::Boolean) }
   def one?(*args); end
 
-  sig { override.params(block: T.proc.params(e: Squib).void).void }
+  sig { override.params(block: T.proc.params(e: Squib).void).returns(T::Array[Squib]) }
   def each(&block); end
 
   sig { params(level: T.nilable(Integer)).returns(T::Array[Squib]) }
@@ -1417,7 +1417,7 @@ class Squib::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associati
   sig { params(args: T.untyped).returns(T::Boolean) }
   def one?(*args); end
 
-  sig { override.params(block: T.proc.params(e: Squib).void).void }
+  sig { override.params(block: T.proc.params(e: Squib).void).returns(T::Array[Squib]) }
   def each(&block); end
 
   sig { params(level: T.nilable(Integer)).returns(T::Array[Squib]) }

--- a/spec/test_data/v6.0/expected_wand.rbi
+++ b/spec/test_data/v6.0/expected_wand.rbi
@@ -581,7 +581,7 @@ class Wand::ActiveRecord_Relation < ActiveRecord::Relation
   sig { params(args: T.untyped).returns(T::Boolean) }
   def one?(*args); end
 
-  sig { override.params(block: T.proc.params(e: Wand).void).void }
+  sig { override.params(block: T.proc.params(e: Wand).void).returns(T::Array[Wand]) }
   def each(&block); end
 
   sig { params(level: T.nilable(Integer)).returns(T::Array[Wand]) }
@@ -790,7 +790,7 @@ class Wand::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
   sig { params(args: T.untyped).returns(T::Boolean) }
   def one?(*args); end
 
-  sig { override.params(block: T.proc.params(e: Wand).void).void }
+  sig { override.params(block: T.proc.params(e: Wand).void).returns(T::Array[Wand]) }
   def each(&block); end
 
   sig { params(level: T.nilable(Integer)).returns(T::Array[Wand]) }
@@ -998,7 +998,7 @@ class Wand::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associatio
   sig { params(args: T.untyped).returns(T::Boolean) }
   def one?(*args); end
 
-  sig { override.params(block: T.proc.params(e: Wand).void).void }
+  sig { override.params(block: T.proc.params(e: Wand).void).returns(T::Array[Wand]) }
   def each(&block); end
 
   sig { params(level: T.nilable(Integer)).returns(T::Array[Wand]) }

--- a/spec/test_data/v6.0/expected_wizard.rbi
+++ b/spec/test_data/v6.0/expected_wizard.rbi
@@ -826,7 +826,7 @@ class Wizard::ActiveRecord_Relation < ActiveRecord::Relation
   sig { params(args: T.untyped).returns(T::Boolean) }
   def one?(*args); end
 
-  sig { override.params(block: T.proc.params(e: Wizard).void).void }
+  sig { override.params(block: T.proc.params(e: Wizard).void).returns(T::Array[Wizard]) }
   def each(&block); end
 
   sig { params(level: T.nilable(Integer)).returns(T::Array[Wizard]) }
@@ -1122,7 +1122,7 @@ class Wizard::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelati
   sig { params(args: T.untyped).returns(T::Boolean) }
   def one?(*args); end
 
-  sig { override.params(block: T.proc.params(e: Wizard).void).void }
+  sig { override.params(block: T.proc.params(e: Wizard).void).returns(T::Array[Wizard]) }
   def each(&block); end
 
   sig { params(level: T.nilable(Integer)).returns(T::Array[Wizard]) }
@@ -1417,7 +1417,7 @@ class Wizard::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associat
   sig { params(args: T.untyped).returns(T::Boolean) }
   def one?(*args); end
 
-  sig { override.params(block: T.proc.params(e: Wizard).void).void }
+  sig { override.params(block: T.proc.params(e: Wizard).void).returns(T::Array[Wizard]) }
   def each(&block); end
 
   sig { params(level: T.nilable(Integer)).returns(T::Array[Wizard]) }

--- a/spec/test_data/v6.0/expected_wizard_wo_spellbook.rbi
+++ b/spec/test_data/v6.0/expected_wizard_wo_spellbook.rbi
@@ -826,7 +826,7 @@ class Wizard::ActiveRecord_Relation < ActiveRecord::Relation
   sig { params(args: T.untyped).returns(T::Boolean) }
   def one?(*args); end
 
-  sig { override.params(block: T.proc.params(e: Wizard).void).void }
+  sig { override.params(block: T.proc.params(e: Wizard).void).returns(T::Array[Wizard]) }
   def each(&block); end
 
   sig { params(level: T.nilable(Integer)).returns(T::Array[Wizard]) }
@@ -1122,7 +1122,7 @@ class Wizard::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelati
   sig { params(args: T.untyped).returns(T::Boolean) }
   def one?(*args); end
 
-  sig { override.params(block: T.proc.params(e: Wizard).void).void }
+  sig { override.params(block: T.proc.params(e: Wizard).void).returns(T::Array[Wizard]) }
   def each(&block); end
 
   sig { params(level: T.nilable(Integer)).returns(T::Array[Wizard]) }
@@ -1417,7 +1417,7 @@ class Wizard::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associat
   sig { params(args: T.untyped).returns(T::Boolean) }
   def one?(*args); end
 
-  sig { override.params(block: T.proc.params(e: Wizard).void).void }
+  sig { override.params(block: T.proc.params(e: Wizard).void).returns(T::Array[Wizard]) }
   def each(&block); end
 
   sig { params(level: T.nilable(Integer)).returns(T::Array[Wizard]) }


### PR DESCRIPTION
Currently the sigs we generate say that `each` returns `void`. This is incorrect—`each` always returns an array, just like `Enumerable#each`.

```
Wizard.first.spell_books.each(&:id).class
# => Array
```

This is because `each` actually gets delegated to `records`, which is just an array:

https://github.com/rails/rails/blob/v6.0.0/activerecord/lib/active_record/relation/delegation.rb#L85-L88