### PR TITLE
Set correct types for time, date and datetime attributes

### DIFF
--- a/lib/sorbet-rails/model_plugins/active_record_attribute.rb
+++ b/lib/sorbet-rails/model_plugins/active_record_attribute.rb
@@ -42,7 +42,7 @@ class SorbetRails::ModelPlugins::ActiveRecordAttribute < SorbetRails::ModelPlugi
         attribute_module_rbi.create_method(
           "#{column_name}=",
           parameters: [
-            Parameter.new("value", type: column_type.to_s)
+            Parameter.new("value", type: value_type_for_attr_writer(column_type))
           ],
           return_type: nil,
         )
@@ -61,7 +61,11 @@ class SorbetRails::ModelPlugins::ActiveRecordAttribute < SorbetRails::ModelPlugi
       ActiveRecord::Base.connection.lookup_cast_type_from_column(column_def) :
       column_def.cast_type
 
-    strict_type = active_record_type_to_sorbet_type(cast_type)
+    strict_type =
+      active_record_type_to_sorbet_type(
+        cast_type,
+        time_zone_aware: time_zone_aware_column?(column_def, cast_type),
+      )
 
     if column_def.respond_to?(:array?) && column_def.array?
       strict_type = "T::Array[#{strict_type}]"
@@ -72,25 +76,26 @@ class SorbetRails::ModelPlugins::ActiveRecordAttribute < SorbetRails::ModelPlugi
   sig do
     params(
       # in v4.2, datetime can be TimeZoneConverter
-      klass: T.any(Object, ActiveRecord::AttributeMethods::TimeZoneConversion::TimeZoneConverter)
+      klass: T.any(Object, ActiveRecord::AttributeMethods::TimeZoneConversion::TimeZoneConverter),
+      time_zone_aware: T::Boolean,
     ).returns(T.any(String, Class))
   end
-  def active_record_type_to_sorbet_type(klass)
+  def active_record_type_to_sorbet_type(klass, time_zone_aware: false)
     case klass
     when ActiveRecord::Type::Boolean
       "T::Boolean"
-    when ActiveRecord::Type::DateTime
-      DateTime
+    when ActiveRecord::Type::DateTime, ActiveRecord::Type::Time
+      time_zone_aware ? ActiveSupport::TimeWithZone : Time
     when ActiveRecord::Type::Date
       Date
     when ActiveRecord::AttributeMethods::TimeZoneConversion::TimeZoneConverter
-      klass.klass
+      # if type has already been decorated with TimeZoneConverter, it's probably
+      # a Rails 4.2 datetime column and can be considered a TimeWithZone
+      ActiveSupport::TimeWithZone
     when ActiveRecord::Type::Decimal
       BigDecimal
     when ActiveRecord::Type::Float
       Float
-    when ActiveRecord::Type::Time
-      Time
     when ActiveRecord::Type::BigInteger, ActiveRecord::Type::Integer, ActiveRecord::Type::DecimalWithoutScale, ActiveRecord::Type::UnsignedInteger
       Integer
     when ActiveRecord::Type::Binary, ActiveRecord::Type::String, ActiveRecord::Type::Text
@@ -105,6 +110,43 @@ class SorbetRails::ModelPlugins::ActiveRecordAttribute < SorbetRails::ModelPlugi
       else
         "T.untyped"
       end
+    end
+  end
+
+  # True if this column is "time zone aware", which means it'll be converted on
+  # access from its original class (e.g. `DateTime`) to something with better
+  # support for time zones (usually `ActiveSupport::TimeWithZone`)
+  sig do
+    params(column_def: T.untyped, cast_type: T.untyped).returns(T::Boolean)
+  end
+  def time_zone_aware_column?(column_def, cast_type)
+    # this private class method returns true if the attribute should be "time
+    # zone aware"; it takes into account various global and model-specific
+    # configuration options as described here:
+    # https://api.rubyonrails.org/classes/ActiveRecord/Timestamp.html
+    #
+    # although it's private, it's better this than trying to reimplement the "is
+    # this attribute tz aware?" logic ourselves
+    @model_class.send(
+      :create_time_zone_conversion_attribute?,
+      column_def.name,
+      cast_type
+    )
+  end
+
+  sig { params(column_type: Object).returns(String) }
+  def value_type_for_attr_writer(column_type)
+    assignable_time_types = [DateTime, Date, Time, ActiveSupport::TimeWithZone].map(&:to_s)
+
+    # it's safe - and convenient - to assign any "time like" object to a time zone
+    # aware attribute because Rails will cast it to a `ActiveSupport::TimeWithZone`
+    # (so rereading the attribute will always return the `TimeWithZone` type)
+    if column_type == ActiveSupport::TimeWithZone
+      "T.any(#{assignable_time_types.join(', ')})"
+    elsif column_type == "T.nilable(ActiveSupport::TimeWithZone)"
+      "T.nilable(T.any(#{assignable_time_types.join(', ')}))"
+    else
+      column_type.to_s
     end
   end
 end

--- a/spec/generators/sorbet_test_cases.rb
+++ b/spec/generators/sorbet_test_cases.rb
@@ -1,11 +1,28 @@
 # typed: false
 require 'sorbet-runtime'
 
+wand = Wand.first!
 wizard = Wizard.first!
 T.assert_type!(wizard, Wizard)
 
 # -- model columns
 T.assert_type!(wizard.name, T.nilable(String))
+
+# -- time/date columns
+T.assert_type!(wizard.created_at, ActiveSupport::TimeWithZone)
+T.assert_type!(wand.broken_at, T.nilable(Time))
+T.assert_type!(wand.chosen_at_date, T.nilable(Date))
+
+# assert that TZ aware attributes are casted to TimeWithZone after assigning
+wizard.created_at = DateTime.now
+T.assert_type!(wizard.created_at, ActiveSupport::TimeWithZone)
+
+if ENV["RAILS_VERSION"] != "4.2"
+  # note: this is expected to fail in Rails 4.2, because in that version only
+  # `datetime` fields are made time zone aware (so this will have the type
+  # `T.nilable(Time)` instead)
+  T.assert_type!(wand.chosen_at_time, T.nilable(ActiveSupport::TimeWithZone))
+end
 
 # -- model associations
 T.assert_type!(wizard.wand, T.nilable(Wand))

--- a/spec/sorbet_spec.rb
+++ b/spec/sorbet_spec.rb
@@ -20,6 +20,10 @@ RSpec.describe 'sorbet' do
       wizard: harry,
       core_type: :phoenix_feather,
       wood_type: "holly",
+      chosen_at_date: Date.parse('2019-09-01'),
+      chosen_at_time: Time.parse('2019-09-01T09:00:00Z'),
+      broken: true,
+      broken_at: Time.parse('2019-09-05T15:30:00Z'),
     )
   end
 

--- a/spec/support/v4.2/Gemfile.lock
+++ b/spec/support/v4.2/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../..
   specs:
-    sorbet-rails (0.5.5)
+    sorbet-rails (0.5.5.1)
       parlour (~> 0.8.0)
 
 GEM
@@ -95,10 +95,10 @@ GEM
       thor (>= 0.18.1, < 2.0)
     rainbow (3.0.0)
     rake (12.3.3)
-    sorbet (0.4.4755)
-      sorbet-static (= 0.4.4755)
-    sorbet-runtime (0.4.4755)
-    sorbet-static (0.4.4755-x86_64-linux)
+    sorbet (0.4.4761)
+      sorbet-static (= 0.4.4761)
+    sorbet-runtime (0.4.4761)
+    sorbet-static (0.4.4761-universal-darwin-14)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)

--- a/spec/support/v4.2/app/models/wand.rb
+++ b/spec/support/v4.2/app/models/wand.rb
@@ -2,6 +2,8 @@
 class Wand < ApplicationRecord
   include Mythical
 
+  self.skip_time_zone_conversion_for_attributes = [:broken_at]
+
   enum core_type: {
     phoenix_feather: 0,
     dragon_heartstring: 1,

--- a/spec/support/v4.2/app/models/wizard.rb
+++ b/spec/support/v4.2/app/models/wizard.rb
@@ -1,4 +1,4 @@
-# typed: ignore
+# typed: strict
 class Wizard < ApplicationRecord
   validates :name, length: { minimum: 5 }, presence: true
 

--- a/spec/support/v4.2/config/initializers/sorbet_rails.rb
+++ b/spec/support/v4.2/config/initializers/sorbet_rails.rb
@@ -1,3 +1,3 @@
-# typed: strict
+# typed: false
 require(Rails.root.join('lib/mythical_rbi_plugin'))
 SorbetRails::ModelRbiFormatter.register_plugin(MythicalRbiPlugin)

--- a/spec/support/v4.2/db/migrate/20190620000001_create_wizards.rb
+++ b/spec/support/v4.2/db/migrate/20190620000001_create_wizards.rb
@@ -7,7 +7,7 @@ class CreateWizards < ActiveRecord::Migration
       t.string :parent_email
       t.text :notes
 
-      t.timestamps
+      t.timestamps null: false
     end
   end
 end

--- a/spec/support/v4.2/db/migrate/20190620000004_add_more_column_types_to_wands.rb
+++ b/spec/support/v4.2/db/migrate/20190620000004_add_more_column_types_to_wands.rb
@@ -5,6 +5,7 @@ class AddMoreColumnTypesToWands < ActiveRecord::Migration
     add_column :wands, :hardness,       :decimal, null: false, precision: 10, scale: 10, default: 5
     add_column :wands, :reflectance,    :decimal, null: false, precision: 10, scale: 0, default: 0.5
     add_column :wands, :broken,         :boolean, null: false, default: false
+    add_column :wands, :broken_at,      :datetime, null: true
     add_column :wands, :chosen_at_date, :date
     add_column :wands, :chosen_at_time, :time
     # JSON column type is only supported on 5.2 or higher

--- a/spec/support/v4.2/db/schema.rb
+++ b/spec/support/v4.2/db/schema.rb
@@ -30,6 +30,7 @@ ActiveRecord::Schema.define(version: 20190620000007) do
     t.decimal  "hardness",       precision: 10, scale: 10, default: 5.0,   null: false
     t.decimal  "reflectance",    precision: 10,            default: 0,     null: false
     t.boolean  "broken",                                   default: false, null: false
+    t.datetime "broken_at"
     t.date     "chosen_at_date"
     t.time     "chosen_at_time"
   end
@@ -39,8 +40,8 @@ ActiveRecord::Schema.define(version: 20190620000007) do
     t.integer  "house"
     t.string   "parent_email"
     t.text     "notes"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",                      null: false
+    t.datetime "updated_at",                      null: false
     t.string   "broom"
     t.string   "type",         default: "Wizard", null: false
   end

--- a/spec/support/v4.2/sorbet_test_cases.rb
+++ b/spec/support/v4.2/sorbet_test_cases.rb
@@ -1,11 +1,28 @@
 # typed: false
 require 'sorbet-runtime'
 
+wand = Wand.first!
 wizard = Wizard.first!
 T.assert_type!(wizard, Wizard)
 
 # -- model columns
 T.assert_type!(wizard.name, T.nilable(String))
+
+# -- time/date columns
+T.assert_type!(wizard.created_at, ActiveSupport::TimeWithZone)
+T.assert_type!(wand.broken_at, T.nilable(Time))
+T.assert_type!(wand.chosen_at_date, T.nilable(Date))
+
+# assert that TZ aware attributes are casted to TimeWithZone after assigning
+wizard.created_at = DateTime.now
+T.assert_type!(wizard.created_at, ActiveSupport::TimeWithZone)
+
+if ENV["RAILS_VERSION"] != "4.2"
+  # note: this is expected to fail in Rails 4.2, because in that version only
+  # `datetime` fields are made time zone aware (so this will have the type
+  # `T.nilable(Time)` instead)
+  T.assert_type!(wand.chosen_at_time, T.nilable(ActiveSupport::TimeWithZone))
+end
 
 # -- model associations
 T.assert_type!(wizard.wand, T.nilable(Wand))

--- a/spec/support/v5.0/Gemfile.lock
+++ b/spec/support/v5.0/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../..
   specs:
-    sorbet-rails (0.5.5)
+    sorbet-rails (0.5.5.1)
       parlour (~> 0.8.0)
 
 GEM
@@ -100,10 +100,10 @@ GEM
       thor (>= 0.18.1, < 2.0)
     rainbow (3.0.0)
     rake (12.3.3)
-    sorbet (0.4.4755)
-      sorbet-static (= 0.4.4755)
-    sorbet-runtime (0.4.4755)
-    sorbet-static (0.4.4755-universal-darwin-14)
+    sorbet (0.4.4761)
+      sorbet-static (= 0.4.4761)
+    sorbet-runtime (0.4.4761)
+    sorbet-static (0.4.4761-universal-darwin-14)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)

--- a/spec/support/v5.0/app/models/wand.rb
+++ b/spec/support/v5.0/app/models/wand.rb
@@ -2,6 +2,8 @@
 class Wand < ApplicationRecord
   include Mythical
 
+  self.skip_time_zone_conversion_for_attributes = [:broken_at]
+
   enum core_type: {
     phoenix_feather: 0,
     dragon_heartstring: 1,

--- a/spec/support/v5.0/app/models/wizard.rb
+++ b/spec/support/v5.0/app/models/wizard.rb
@@ -1,4 +1,4 @@
-# typed: ignore
+# typed: strict
 class Wizard < ApplicationRecord
   validates :name, length: { minimum: 5 }, presence: true
 

--- a/spec/support/v5.0/config/application.rb
+++ b/spec/support/v5.0/config/application.rb
@@ -19,6 +19,7 @@ Bundler.require(*Rails.groups)
 
 module V50
   class Application < Rails::Application
+    config.active_record.time_zone_aware_types = [:datetime, :time]
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.

--- a/spec/support/v5.0/config/initializers/sorbet_rails.rb
+++ b/spec/support/v5.0/config/initializers/sorbet_rails.rb
@@ -1,3 +1,3 @@
-# typed: strict
+# typed: false
 require(Rails.root.join('lib/mythical_rbi_plugin'))
 SorbetRails::ModelRbiFormatter.register_plugin(MythicalRbiPlugin)

--- a/spec/support/v5.0/db/migrate/20190620000001_create_wizards.rb
+++ b/spec/support/v5.0/db/migrate/20190620000001_create_wizards.rb
@@ -7,7 +7,7 @@ class CreateWizards < ActiveRecord::Migration[5.0]
       t.string :parent_email
       t.text :notes
 
-      t.timestamps
+      t.timestamps null: false
     end
   end
 end

--- a/spec/support/v5.0/db/migrate/20190620000004_add_more_column_types_to_wands.rb
+++ b/spec/support/v5.0/db/migrate/20190620000004_add_more_column_types_to_wands.rb
@@ -5,6 +5,7 @@ class AddMoreColumnTypesToWands < ActiveRecord::Migration[5.0]
     add_column :wands, :hardness,       :decimal, null: false, precision: 10, scale: 10, default: 5
     add_column :wands, :reflectance,    :decimal, null: false, precision: 10, scale: 0, default: 0.5
     add_column :wands, :broken,         :boolean, null: false, default: false
+    add_column :wands, :broken_at,      :datetime, null: true
     add_column :wands, :chosen_at_date, :date
     add_column :wands, :chosen_at_time, :time
     # JSON column type is only supported on 5.2 or higher

--- a/spec/support/v5.0/db/schema.rb
+++ b/spec/support/v5.0/db/schema.rb
@@ -30,6 +30,7 @@ ActiveRecord::Schema.define(version: 20190620000007) do
     t.decimal  "hardness",       precision: 10, scale: 10, default: "5.0", null: false
     t.decimal  "reflectance",    precision: 10,            default: 0,     null: false
     t.boolean  "broken",                                   default: false, null: false
+    t.datetime "broken_at"
     t.date     "chosen_at_date"
     t.time     "chosen_at_time"
     t.index ["wizard_id"], name: "index_wands_on_wizard_id"

--- a/spec/support/v5.0/sorbet_test_cases.rb
+++ b/spec/support/v5.0/sorbet_test_cases.rb
@@ -1,11 +1,28 @@
 # typed: false
 require 'sorbet-runtime'
 
+wand = Wand.first!
 wizard = Wizard.first!
 T.assert_type!(wizard, Wizard)
 
 # -- model columns
 T.assert_type!(wizard.name, T.nilable(String))
+
+# -- time/date columns
+T.assert_type!(wizard.created_at, ActiveSupport::TimeWithZone)
+T.assert_type!(wand.broken_at, T.nilable(Time))
+T.assert_type!(wand.chosen_at_date, T.nilable(Date))
+
+# assert that TZ aware attributes are casted to TimeWithZone after assigning
+wizard.created_at = DateTime.now
+T.assert_type!(wizard.created_at, ActiveSupport::TimeWithZone)
+
+if ENV["RAILS_VERSION"] != "4.2"
+  # note: this is expected to fail in Rails 4.2, because in that version only
+  # `datetime` fields are made time zone aware (so this will have the type
+  # `T.nilable(Time)` instead)
+  T.assert_type!(wand.chosen_at_time, T.nilable(ActiveSupport::TimeWithZone))
+end
 
 # -- model associations
 T.assert_type!(wizard.wand, T.nilable(Wand))

--- a/spec/support/v5.1/Gemfile.lock
+++ b/spec/support/v5.1/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../..
   specs:
-    sorbet-rails (0.5.5)
+    sorbet-rails (0.5.5.1)
       parlour (~> 0.8.0)
 
 GEM
@@ -101,10 +101,10 @@ GEM
       thor (>= 0.18.1, < 2.0)
     rainbow (3.0.0)
     rake (12.3.3)
-    sorbet (0.4.4755)
-      sorbet-static (= 0.4.4755)
-    sorbet-runtime (0.4.4755)
-    sorbet-static (0.4.4755-universal-darwin-14)
+    sorbet (0.4.4761)
+      sorbet-static (= 0.4.4761)
+    sorbet-runtime (0.4.4761)
+    sorbet-static (0.4.4761-universal-darwin-14)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)

--- a/spec/support/v5.1/app/models/wand.rb
+++ b/spec/support/v5.1/app/models/wand.rb
@@ -2,6 +2,8 @@
 class Wand < ApplicationRecord
   include Mythical
 
+  self.skip_time_zone_conversion_for_attributes = [:broken_at]
+
   enum core_type: {
     phoenix_feather: 0,
     dragon_heartstring: 1,

--- a/spec/support/v5.1/app/models/wizard.rb
+++ b/spec/support/v5.1/app/models/wizard.rb
@@ -1,4 +1,4 @@
-# typed: ignore
+# typed: strict
 class Wizard < ApplicationRecord
   validates :name, length: { minimum: 5 }, presence: true
 

--- a/spec/support/v5.1/config/initializers/sorbet_rails.rb
+++ b/spec/support/v5.1/config/initializers/sorbet_rails.rb
@@ -1,3 +1,3 @@
-# typed: strict
+# typed: false
 require(Rails.root.join('lib/mythical_rbi_plugin'))
 SorbetRails::ModelRbiFormatter.register_plugin(MythicalRbiPlugin)

--- a/spec/support/v5.1/db/migrate/20190620000001_create_wizards.rb
+++ b/spec/support/v5.1/db/migrate/20190620000001_create_wizards.rb
@@ -7,7 +7,7 @@ class CreateWizards < ActiveRecord::Migration[5.1]
       t.string :parent_email
       t.text :notes
 
-      t.timestamps
+      t.timestamps null: false
     end
   end
 end

--- a/spec/support/v5.1/db/migrate/20190620000004_add_more_column_types_to_wands.rb
+++ b/spec/support/v5.1/db/migrate/20190620000004_add_more_column_types_to_wands.rb
@@ -5,6 +5,7 @@ class AddMoreColumnTypesToWands < ActiveRecord::Migration[5.1]
     add_column :wands, :hardness,       :decimal, null: false, precision: 10, scale: 10, default: 5
     add_column :wands, :reflectance,    :decimal, null: false, precision: 10, scale: 0, default: 0.5
     add_column :wands, :broken,         :boolean, null: false, default: false
+    add_column :wands, :broken_at,      :datetime, null: true
     add_column :wands, :chosen_at_date, :date
     add_column :wands, :chosen_at_time, :time
     # JSON column type is only supported on 5.2 or higher

--- a/spec/support/v5.1/db/schema.rb
+++ b/spec/support/v5.1/db/schema.rb
@@ -30,6 +30,7 @@ ActiveRecord::Schema.define(version: 20190620000007) do
     t.decimal "hardness", precision: 10, scale: 10, default: "5.0", null: false
     t.decimal "reflectance", precision: 10, default: "0", null: false
     t.boolean "broken", default: false, null: false
+    t.datetime "broken_at"
     t.date "chosen_at_date"
     t.time "chosen_at_time"
     t.index ["wizard_id"], name: "index_wands_on_wizard_id"

--- a/spec/support/v5.1/sorbet_test_cases.rb
+++ b/spec/support/v5.1/sorbet_test_cases.rb
@@ -1,11 +1,28 @@
 # typed: false
 require 'sorbet-runtime'
 
+wand = Wand.first!
 wizard = Wizard.first!
 T.assert_type!(wizard, Wizard)
 
 # -- model columns
 T.assert_type!(wizard.name, T.nilable(String))
+
+# -- time/date columns
+T.assert_type!(wizard.created_at, ActiveSupport::TimeWithZone)
+T.assert_type!(wand.broken_at, T.nilable(Time))
+T.assert_type!(wand.chosen_at_date, T.nilable(Date))
+
+# assert that TZ aware attributes are casted to TimeWithZone after assigning
+wizard.created_at = DateTime.now
+T.assert_type!(wizard.created_at, ActiveSupport::TimeWithZone)
+
+if ENV["RAILS_VERSION"] != "4.2"
+  # note: this is expected to fail in Rails 4.2, because in that version only
+  # `datetime` fields are made time zone aware (so this will have the type
+  # `T.nilable(Time)` instead)
+  T.assert_type!(wand.chosen_at_time, T.nilable(ActiveSupport::TimeWithZone))
+end
 
 # -- model associations
 T.assert_type!(wizard.wand, T.nilable(Wand))

--- a/spec/support/v5.2/Gemfile.lock
+++ b/spec/support/v5.2/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../..
   specs:
-    sorbet-rails (0.5.5)
+    sorbet-rails (0.5.5.1)
       parlour (~> 0.8.0)
 
 GEM
@@ -109,10 +109,10 @@ GEM
       thor (>= 0.19.0, < 2.0)
     rainbow (3.0.0)
     rake (12.3.3)
-    sorbet (0.4.4755)
-      sorbet-static (= 0.4.4755)
-    sorbet-runtime (0.4.4755)
-    sorbet-static (0.4.4755-universal-darwin-14)
+    sorbet (0.4.4761)
+      sorbet-static (= 0.4.4761)
+    sorbet-runtime (0.4.4761)
+    sorbet-static (0.4.4761-universal-darwin-14)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)

--- a/spec/support/v5.2/app/models/wand.rb
+++ b/spec/support/v5.2/app/models/wand.rb
@@ -2,6 +2,8 @@
 class Wand < ApplicationRecord
   include Mythical
 
+  self.skip_time_zone_conversion_for_attributes = [:broken_at]
+
   enum core_type: {
     phoenix_feather: 0,
     dragon_heartstring: 1,

--- a/spec/support/v5.2/app/models/wizard.rb
+++ b/spec/support/v5.2/app/models/wizard.rb
@@ -1,4 +1,4 @@
-# typed: ignore
+# typed: strict
 class Wizard < ApplicationRecord
   validates :name, length: { minimum: 5 }, presence: true
 

--- a/spec/support/v5.2/config/initializers/sorbet_rails.rb
+++ b/spec/support/v5.2/config/initializers/sorbet_rails.rb
@@ -1,3 +1,3 @@
-# typed: strict
+# typed: false
 require(Rails.root.join('lib/mythical_rbi_plugin'))
 SorbetRails::ModelRbiFormatter.register_plugin(MythicalRbiPlugin)

--- a/spec/support/v5.2/db/migrate/20190620000001_create_wizards.rb
+++ b/spec/support/v5.2/db/migrate/20190620000001_create_wizards.rb
@@ -7,7 +7,7 @@ class CreateWizards < ActiveRecord::Migration[5.2]
       t.string :parent_email
       t.text :notes
 
-      t.timestamps
+      t.timestamps null: false
     end
   end
 end

--- a/spec/support/v5.2/db/migrate/20190620000004_add_more_column_types_to_wands.rb
+++ b/spec/support/v5.2/db/migrate/20190620000004_add_more_column_types_to_wands.rb
@@ -5,6 +5,7 @@ class AddMoreColumnTypesToWands < ActiveRecord::Migration[5.2]
     add_column :wands, :hardness,       :decimal, null: false, precision: 10, scale: 10, default: 5
     add_column :wands, :reflectance,    :decimal, null: false, precision: 10, scale: 0, default: 0.5
     add_column :wands, :broken,         :boolean, null: false, default: false
+    add_column :wands, :broken_at,      :datetime, null: true
     add_column :wands, :chosen_at_date, :date
     add_column :wands, :chosen_at_time, :time
     # JSON column type is only supported on 5.2 or higher

--- a/spec/support/v5.2/db/schema.rb
+++ b/spec/support/v5.2/db/schema.rb
@@ -30,6 +30,7 @@ ActiveRecord::Schema.define(version: 2019_06_20_000007) do
     t.decimal "hardness", precision: 10, scale: 10, default: "5.0", null: false
     t.decimal "reflectance", precision: 10, default: "0", null: false
     t.boolean "broken", default: false, null: false
+    t.datetime "broken_at"
     t.date "chosen_at_date"
     t.time "chosen_at_time"
     t.json "spell_history"

--- a/spec/support/v5.2/sorbet_test_cases.rb
+++ b/spec/support/v5.2/sorbet_test_cases.rb
@@ -1,11 +1,28 @@
 # typed: false
 require 'sorbet-runtime'
 
+wand = Wand.first!
 wizard = Wizard.first!
 T.assert_type!(wizard, Wizard)
 
 # -- model columns
 T.assert_type!(wizard.name, T.nilable(String))
+
+# -- time/date columns
+T.assert_type!(wizard.created_at, ActiveSupport::TimeWithZone)
+T.assert_type!(wand.broken_at, T.nilable(Time))
+T.assert_type!(wand.chosen_at_date, T.nilable(Date))
+
+# assert that TZ aware attributes are casted to TimeWithZone after assigning
+wizard.created_at = DateTime.now
+T.assert_type!(wizard.created_at, ActiveSupport::TimeWithZone)
+
+if ENV["RAILS_VERSION"] != "4.2"
+  # note: this is expected to fail in Rails 4.2, because in that version only
+  # `datetime` fields are made time zone aware (so this will have the type
+  # `T.nilable(Time)` instead)
+  T.assert_type!(wand.chosen_at_time, T.nilable(ActiveSupport::TimeWithZone))
+end
 
 # -- model associations
 T.assert_type!(wizard.wand, T.nilable(Wand))

--- a/spec/support/v6.0/Gemfile.lock
+++ b/spec/support/v6.0/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../..
   specs:
-    sorbet-rails (0.5.5)
+    sorbet-rails (0.5.5.1)
       parlour (~> 0.8.0)
 
 GEM
@@ -124,10 +124,10 @@ GEM
       thor (>= 0.20.3, < 2.0)
     rainbow (3.0.0)
     rake (12.3.3)
-    sorbet (0.4.4755)
-      sorbet-static (= 0.4.4755)
-    sorbet-runtime (0.4.4755)
-    sorbet-static (0.4.4755-universal-darwin-14)
+    sorbet (0.4.4761)
+      sorbet-static (= 0.4.4761)
+    sorbet-runtime (0.4.4761)
+    sorbet-static (0.4.4761-universal-darwin-14)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)

--- a/spec/support/v6.0/app/models/wand.rb
+++ b/spec/support/v6.0/app/models/wand.rb
@@ -2,6 +2,8 @@
 class Wand < ApplicationRecord
   include Mythical
 
+  self.skip_time_zone_conversion_for_attributes = [:broken_at]
+
   enum core_type: {
     phoenix_feather: 0,
     dragon_heartstring: 1,

--- a/spec/support/v6.0/app/models/wizard.rb
+++ b/spec/support/v6.0/app/models/wizard.rb
@@ -1,4 +1,4 @@
-# typed: ignore
+# typed: false
 class Wizard < ApplicationRecord
   validates :name, length: { minimum: 5 }, presence: true
 

--- a/spec/support/v6.0/config/initializers/sorbet_rails.rb
+++ b/spec/support/v6.0/config/initializers/sorbet_rails.rb
@@ -1,3 +1,3 @@
-# typed: strict
+# typed: false
 require(Rails.root.join('lib/mythical_rbi_plugin'))
 SorbetRails::ModelRbiFormatter.register_plugin(MythicalRbiPlugin)

--- a/spec/support/v6.0/config/initializers/wrap_parameters.rb
+++ b/spec/support/v6.0/config/initializers/wrap_parameters.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: false
 # Be sure to restart your server when you modify this file.
 
 # This file contains settings for ActionController::ParamsWrapper which

--- a/spec/support/v6.0/db/migrate/20190620000001_create_wizards.rb
+++ b/spec/support/v6.0/db/migrate/20190620000001_create_wizards.rb
@@ -7,7 +7,7 @@ class CreateWizards < ActiveRecord::Migration[6.0]
       t.string :parent_email
       t.text :notes
 
-      t.timestamps
+      t.timestamps null: false
     end
   end
 end

--- a/spec/support/v6.0/db/migrate/20190620000004_add_more_column_types_to_wands.rb
+++ b/spec/support/v6.0/db/migrate/20190620000004_add_more_column_types_to_wands.rb
@@ -5,6 +5,7 @@ class AddMoreColumnTypesToWands < ActiveRecord::Migration[6.0]
     add_column :wands, :hardness,       :decimal, null: false, precision: 10, scale: 10, default: 5
     add_column :wands, :reflectance,    :decimal, null: false, precision: 10, scale: 0, default: 0.5
     add_column :wands, :broken,         :boolean, null: false, default: false
+    add_column :wands, :broken_at,      :datetime, null: true
     add_column :wands, :chosen_at_date, :date
     add_column :wands, :chosen_at_time, :time
     # JSON column type is only supported on 5.2 or higher

--- a/spec/support/v6.0/db/schema.rb
+++ b/spec/support/v6.0/db/schema.rb
@@ -30,6 +30,7 @@ ActiveRecord::Schema.define(version: 2019_06_20_000007) do
     t.decimal "hardness", precision: 10, scale: 10, default: "5.0", null: false
     t.decimal "reflectance", precision: 10, default: "0", null: false
     t.boolean "broken", default: false, null: false
+    t.datetime "broken_at"
     t.date "chosen_at_date"
     t.time "chosen_at_time"
     t.json "spell_history"

--- a/spec/support/v6.0/sorbet_test_cases.rb
+++ b/spec/support/v6.0/sorbet_test_cases.rb
@@ -1,11 +1,28 @@
 # typed: false
 require 'sorbet-runtime'
 
+wand = Wand.first!
 wizard = Wizard.first!
 T.assert_type!(wizard, Wizard)
 
 # -- model columns
 T.assert_type!(wizard.name, T.nilable(String))
+
+# -- time/date columns
+T.assert_type!(wizard.created_at, ActiveSupport::TimeWithZone)
+T.assert_type!(wand.broken_at, T.nilable(Time))
+T.assert_type!(wand.chosen_at_date, T.nilable(Date))
+
+# assert that TZ aware attributes are casted to TimeWithZone after assigning
+wizard.created_at = DateTime.now
+T.assert_type!(wizard.created_at, ActiveSupport::TimeWithZone)
+
+if ENV["RAILS_VERSION"] != "4.2"
+  # note: this is expected to fail in Rails 4.2, because in that version only
+  # `datetime` fields are made time zone aware (so this will have the type
+  # `T.nilable(Time)` instead)
+  T.assert_type!(wand.chosen_at_time, T.nilable(ActiveSupport::TimeWithZone))
+end
 
 # -- model associations
 T.assert_type!(wizard.wand, T.nilable(Wand))

--- a/spec/test_data/v4.2/expected_squib.rbi
+++ b/spec/test_data/v4.2/expected_squib.rbi
@@ -65,10 +65,10 @@ module Squib::GeneratedAttributeMethods
   sig { returns(T::Boolean) }
   def broom?; end
 
-  sig { returns(T.nilable(Time)) }
+  sig { returns(ActiveSupport::TimeWithZone) }
   def created_at; end
 
-  sig { params(value: T.nilable(Time)).void }
+  sig { params(value: T.any(DateTime, Date, Time, ActiveSupport::TimeWithZone)).void }
   def created_at=(value); end
 
   sig { returns(T::Boolean) }
@@ -128,10 +128,10 @@ module Squib::GeneratedAttributeMethods
   sig { returns(T::Boolean) }
   def type?; end
 
-  sig { returns(T.nilable(Time)) }
+  sig { returns(ActiveSupport::TimeWithZone) }
   def updated_at; end
 
-  sig { params(value: T.nilable(Time)).void }
+  sig { params(value: T.any(DateTime, Date, Time, ActiveSupport::TimeWithZone)).void }
   def updated_at=(value); end
 
   sig { returns(T::Boolean) }

--- a/spec/test_data/v4.2/expected_srb_tc_output.txt
+++ b/spec/test_data/v4.2/expected_srb_tc_output.txt
@@ -1,57 +1,65 @@
-sorbet_test_cases.rb:167: Method `broom_nimbus?` does not exist on `Wizard` https://srb.help/7003
-     167 |  T.assert_type!(wizard.broom_nimbus?, T::Boolean)
+sorbet_test_cases.rb:24: Argument does not have asserted type `T.nilable(ActiveSupport::TimeWithZone)` https://srb.help/7007
+    24 |  T.assert_type!(wand.chosen_at_time, T.nilable(ActiveSupport::TimeWithZone))
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Got T.nilable(Time) originating from:
+    sorbet_test_cases.rb:24:
+    24 |  T.assert_type!(wand.chosen_at_time, T.nilable(ActiveSupport::TimeWithZone))
+                         ^^^^^^^^^^^^^^^^^^^
+
+sorbet_test_cases.rb:184: Method `broom_nimbus?` does not exist on `Wizard` https://srb.help/7003
+     184 |  T.assert_type!(wizard.broom_nimbus?, T::Boolean)
                            ^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Use `-a` to autocorrect
-    sorbet_test_cases.rb:167: Replace with `nimbus?`
-     167 |  T.assert_type!(wizard.broom_nimbus?, T::Boolean)
+    sorbet_test_cases.rb:184: Replace with `nimbus?`
+     184 |  T.assert_type!(wizard.broom_nimbus?, T::Boolean)
                                   ^^^^^^^^^^^^^
 
 
-sorbet_test_cases.rb:167: The typechecker was unable to infer the type of the asserted value https://srb.help/7007
-     167 |  T.assert_type!(wizard.broom_nimbus?, T::Boolean)
+sorbet_test_cases.rb:184: The typechecker was unable to infer the type of the asserted value https://srb.help/7007
+     184 |  T.assert_type!(wizard.broom_nimbus?, T::Boolean)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Got T.untyped originating from:
-    sorbet_test_cases.rb:167:
-     167 |  T.assert_type!(wizard.broom_nimbus?, T::Boolean)
+    sorbet_test_cases.rb:184:
+     184 |  T.assert_type!(wizard.broom_nimbus?, T::Boolean)
                            ^^^^^^^^^^^^^^^^^^^^
   You may need to add additional `sig` annotations
 
-sorbet_test_cases.rb:168: Method `color_brown_eyes?` does not exist on `Wizard` https://srb.help/7003
-     168 |  T.assert_type!(wizard.color_brown_eyes?, T::Boolean)
+sorbet_test_cases.rb:185: Method `color_brown_eyes?` does not exist on `Wizard` https://srb.help/7003
+     185 |  T.assert_type!(wizard.color_brown_eyes?, T::Boolean)
                            ^^^^^^^^^^^^^^^^^^^^^^^^
 
-sorbet_test_cases.rb:168: The typechecker was unable to infer the type of the asserted value https://srb.help/7007
-     168 |  T.assert_type!(wizard.color_brown_eyes?, T::Boolean)
+sorbet_test_cases.rb:185: The typechecker was unable to infer the type of the asserted value https://srb.help/7007
+     185 |  T.assert_type!(wizard.color_brown_eyes?, T::Boolean)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Got T.untyped originating from:
-    sorbet_test_cases.rb:168:
-     168 |  T.assert_type!(wizard.color_brown_eyes?, T::Boolean)
+    sorbet_test_cases.rb:185:
+     185 |  T.assert_type!(wizard.color_brown_eyes?, T::Boolean)
                            ^^^^^^^^^^^^^^^^^^^^^^^^
   You may need to add additional `sig` annotations
 
-sorbet_test_cases.rb:169: Method `quidditch_keeper?` does not exist on `Wizard` https://srb.help/7003
-     169 |  T.assert_type!(wizard.quidditch_keeper?, T::Boolean)
+sorbet_test_cases.rb:186: Method `quidditch_keeper?` does not exist on `Wizard` https://srb.help/7003
+     186 |  T.assert_type!(wizard.quidditch_keeper?, T::Boolean)
                            ^^^^^^^^^^^^^^^^^^^^^^^^
 
-sorbet_test_cases.rb:169: The typechecker was unable to infer the type of the asserted value https://srb.help/7007
-     169 |  T.assert_type!(wizard.quidditch_keeper?, T::Boolean)
+sorbet_test_cases.rb:186: The typechecker was unable to infer the type of the asserted value https://srb.help/7007
+     186 |  T.assert_type!(wizard.quidditch_keeper?, T::Boolean)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Got T.untyped originating from:
-    sorbet_test_cases.rb:169:
-     169 |  T.assert_type!(wizard.quidditch_keeper?, T::Boolean)
+    sorbet_test_cases.rb:186:
+     186 |  T.assert_type!(wizard.quidditch_keeper?, T::Boolean)
                            ^^^^^^^^^^^^^^^^^^^^^^^^
   You may need to add additional `sig` annotations
 
-sorbet_test_cases.rb:170: Method `brown_hair?` does not exist on `Wizard` https://srb.help/7003
-     170 |  T.assert_type!(wizard.brown_hair?, T::Boolean)
+sorbet_test_cases.rb:187: Method `brown_hair?` does not exist on `Wizard` https://srb.help/7003
+     187 |  T.assert_type!(wizard.brown_hair?, T::Boolean)
                            ^^^^^^^^^^^^^^^^^^
 
-sorbet_test_cases.rb:170: The typechecker was unable to infer the type of the asserted value https://srb.help/7007
-     170 |  T.assert_type!(wizard.brown_hair?, T::Boolean)
+sorbet_test_cases.rb:187: The typechecker was unable to infer the type of the asserted value https://srb.help/7007
+     187 |  T.assert_type!(wizard.brown_hair?, T::Boolean)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Got T.untyped originating from:
-    sorbet_test_cases.rb:170:
-     170 |  T.assert_type!(wizard.brown_hair?, T::Boolean)
+    sorbet_test_cases.rb:187:
+     187 |  T.assert_type!(wizard.brown_hair?, T::Boolean)
                            ^^^^^^^^^^^^^^^^^^
   You may need to add additional `sig` annotations
-Errors: 8
+Errors: 9

--- a/spec/test_data/v4.2/expected_wand.rbi
+++ b/spec/test_data/v4.2/expected_wand.rbi
@@ -47,6 +47,15 @@ module Wand::GeneratedAttributeMethods
   sig { returns(T::Boolean) }
   def broken?; end
 
+  sig { returns(T.nilable(Time)) }
+  def broken_at; end
+
+  sig { params(value: T.nilable(Time)).void }
+  def broken_at=(value); end
+
+  sig { returns(T::Boolean) }
+  def broken_at?; end
+
   sig { returns(T.nilable(Date)) }
   def chosen_at_date; end
 
@@ -74,10 +83,10 @@ module Wand::GeneratedAttributeMethods
   sig { returns(T::Boolean) }
   def core_type?; end
 
-  sig { returns(T.nilable(Time)) }
+  sig { returns(T.nilable(ActiveSupport::TimeWithZone)) }
   def created_at; end
 
-  sig { params(value: T.nilable(Time)).void }
+  sig { params(value: T.nilable(T.any(DateTime, Date, Time, ActiveSupport::TimeWithZone))).void }
   def created_at=(value); end
 
   sig { returns(T::Boolean) }
@@ -119,10 +128,10 @@ module Wand::GeneratedAttributeMethods
   sig { returns(T::Boolean) }
   def reflectance?; end
 
-  sig { returns(T.nilable(Time)) }
+  sig { returns(T.nilable(ActiveSupport::TimeWithZone)) }
   def updated_at; end
 
-  sig { params(value: T.nilable(Time)).void }
+  sig { params(value: T.nilable(T.any(DateTime, Date, Time, ActiveSupport::TimeWithZone))).void }
   def updated_at=(value); end
 
   sig { returns(T::Boolean) }

--- a/spec/test_data/v4.2/expected_wizard.rbi
+++ b/spec/test_data/v4.2/expected_wizard.rbi
@@ -65,10 +65,10 @@ module Wizard::GeneratedAttributeMethods
   sig { returns(T::Boolean) }
   def broom?; end
 
-  sig { returns(T.nilable(Time)) }
+  sig { returns(ActiveSupport::TimeWithZone) }
   def created_at; end
 
-  sig { params(value: T.nilable(Time)).void }
+  sig { params(value: T.any(DateTime, Date, Time, ActiveSupport::TimeWithZone)).void }
   def created_at=(value); end
 
   sig { returns(T::Boolean) }
@@ -128,10 +128,10 @@ module Wizard::GeneratedAttributeMethods
   sig { returns(T::Boolean) }
   def type?; end
 
-  sig { returns(T.nilable(Time)) }
+  sig { returns(ActiveSupport::TimeWithZone) }
   def updated_at; end
 
-  sig { params(value: T.nilable(Time)).void }
+  sig { params(value: T.any(DateTime, Date, Time, ActiveSupport::TimeWithZone)).void }
   def updated_at=(value); end
 
   sig { returns(T::Boolean) }

--- a/spec/test_data/v4.2/expected_wizard_wo_spellbook.rbi
+++ b/spec/test_data/v4.2/expected_wizard_wo_spellbook.rbi
@@ -65,10 +65,10 @@ module Wizard::GeneratedAttributeMethods
   sig { returns(T::Boolean) }
   def broom?; end
 
-  sig { returns(T.nilable(Time)) }
+  sig { returns(ActiveSupport::TimeWithZone) }
   def created_at; end
 
-  sig { params(value: T.nilable(Time)).void }
+  sig { params(value: T.any(DateTime, Date, Time, ActiveSupport::TimeWithZone)).void }
   def created_at=(value); end
 
   sig { returns(T::Boolean) }
@@ -128,10 +128,10 @@ module Wizard::GeneratedAttributeMethods
   sig { returns(T::Boolean) }
   def type?; end
 
-  sig { returns(T.nilable(Time)) }
+  sig { returns(ActiveSupport::TimeWithZone) }
   def updated_at; end
 
-  sig { params(value: T.nilable(Time)).void }
+  sig { params(value: T.any(DateTime, Date, Time, ActiveSupport::TimeWithZone)).void }
   def updated_at=(value); end
 
   sig { returns(T::Boolean) }

--- a/spec/test_data/v5.0/expected_internal_metadata.rbi
+++ b/spec/test_data/v5.0/expected_internal_metadata.rbi
@@ -10,10 +10,10 @@ end
 module ActiveRecord::InternalMetadata::GeneratedAttributeMethods
   extend T::Sig
 
-  sig { returns(DateTime) }
+  sig { returns(ActiveSupport::TimeWithZone) }
   def created_at; end
 
-  sig { params(value: DateTime).void }
+  sig { params(value: T.any(DateTime, Date, Time, ActiveSupport::TimeWithZone)).void }
   def created_at=(value); end
 
   sig { returns(T::Boolean) }
@@ -28,10 +28,10 @@ module ActiveRecord::InternalMetadata::GeneratedAttributeMethods
   sig { returns(T::Boolean) }
   def key?; end
 
-  sig { returns(DateTime) }
+  sig { returns(ActiveSupport::TimeWithZone) }
   def updated_at; end
 
-  sig { params(value: DateTime).void }
+  sig { params(value: T.any(DateTime, Date, Time, ActiveSupport::TimeWithZone)).void }
   def updated_at=(value); end
 
   sig { returns(T::Boolean) }

--- a/spec/test_data/v5.0/expected_squib.rbi
+++ b/spec/test_data/v5.0/expected_squib.rbi
@@ -125,10 +125,10 @@ module Squib::GeneratedAttributeMethods
   sig { returns(T::Boolean) }
   def broom?; end
 
-  sig { returns(DateTime) }
+  sig { returns(ActiveSupport::TimeWithZone) }
   def created_at; end
 
-  sig { params(value: DateTime).void }
+  sig { params(value: T.any(DateTime, Date, Time, ActiveSupport::TimeWithZone)).void }
   def created_at=(value); end
 
   sig { returns(T::Boolean) }
@@ -224,10 +224,10 @@ module Squib::GeneratedAttributeMethods
   sig { returns(T::Boolean) }
   def type?; end
 
-  sig { returns(DateTime) }
+  sig { returns(ActiveSupport::TimeWithZone) }
   def updated_at; end
 
-  sig { params(value: DateTime).void }
+  sig { params(value: T.any(DateTime, Date, Time, ActiveSupport::TimeWithZone)).void }
   def updated_at=(value); end
 
   sig { returns(T::Boolean) }

--- a/spec/test_data/v5.0/expected_wand.rbi
+++ b/spec/test_data/v5.0/expected_wand.rbi
@@ -47,6 +47,15 @@ module Wand::GeneratedAttributeMethods
   sig { returns(T::Boolean) }
   def broken?; end
 
+  sig { returns(T.nilable(Time)) }
+  def broken_at; end
+
+  sig { params(value: T.nilable(Time)).void }
+  def broken_at=(value); end
+
+  sig { returns(T::Boolean) }
+  def broken_at?; end
+
   sig { returns(T.nilable(Date)) }
   def chosen_at_date; end
 
@@ -56,10 +65,10 @@ module Wand::GeneratedAttributeMethods
   sig { returns(T::Boolean) }
   def chosen_at_date?; end
 
-  sig { returns(T.nilable(Time)) }
+  sig { returns(T.nilable(ActiveSupport::TimeWithZone)) }
   def chosen_at_time; end
 
-  sig { params(value: T.nilable(Time)).void }
+  sig { params(value: T.nilable(T.any(DateTime, Date, Time, ActiveSupport::TimeWithZone))).void }
   def chosen_at_time=(value); end
 
   sig { returns(T::Boolean) }
@@ -74,10 +83,10 @@ module Wand::GeneratedAttributeMethods
   sig { returns(T::Boolean) }
   def core_type?; end
 
-  sig { returns(DateTime) }
+  sig { returns(ActiveSupport::TimeWithZone) }
   def created_at; end
 
-  sig { params(value: DateTime).void }
+  sig { params(value: T.any(DateTime, Date, Time, ActiveSupport::TimeWithZone)).void }
   def created_at=(value); end
 
   sig { returns(T::Boolean) }
@@ -119,10 +128,10 @@ module Wand::GeneratedAttributeMethods
   sig { returns(T::Boolean) }
   def reflectance?; end
 
-  sig { returns(DateTime) }
+  sig { returns(ActiveSupport::TimeWithZone) }
   def updated_at; end
 
-  sig { params(value: DateTime).void }
+  sig { params(value: T.any(DateTime, Date, Time, ActiveSupport::TimeWithZone)).void }
   def updated_at=(value); end
 
   sig { returns(T::Boolean) }

--- a/spec/test_data/v5.0/expected_wizard.rbi
+++ b/spec/test_data/v5.0/expected_wizard.rbi
@@ -125,10 +125,10 @@ module Wizard::GeneratedAttributeMethods
   sig { returns(T::Boolean) }
   def broom?; end
 
-  sig { returns(DateTime) }
+  sig { returns(ActiveSupport::TimeWithZone) }
   def created_at; end
 
-  sig { params(value: DateTime).void }
+  sig { params(value: T.any(DateTime, Date, Time, ActiveSupport::TimeWithZone)).void }
   def created_at=(value); end
 
   sig { returns(T::Boolean) }
@@ -224,10 +224,10 @@ module Wizard::GeneratedAttributeMethods
   sig { returns(T::Boolean) }
   def type?; end
 
-  sig { returns(DateTime) }
+  sig { returns(ActiveSupport::TimeWithZone) }
   def updated_at; end
 
-  sig { params(value: DateTime).void }
+  sig { params(value: T.any(DateTime, Date, Time, ActiveSupport::TimeWithZone)).void }
   def updated_at=(value); end
 
   sig { returns(T::Boolean) }

--- a/spec/test_data/v5.0/expected_wizard_wo_spellbook.rbi
+++ b/spec/test_data/v5.0/expected_wizard_wo_spellbook.rbi
@@ -125,10 +125,10 @@ module Wizard::GeneratedAttributeMethods
   sig { returns(T::Boolean) }
   def broom?; end
 
-  sig { returns(DateTime) }
+  sig { returns(ActiveSupport::TimeWithZone) }
   def created_at; end
 
-  sig { params(value: DateTime).void }
+  sig { params(value: T.any(DateTime, Date, Time, ActiveSupport::TimeWithZone)).void }
   def created_at=(value); end
 
   sig { returns(T::Boolean) }
@@ -224,10 +224,10 @@ module Wizard::GeneratedAttributeMethods
   sig { returns(T::Boolean) }
   def type?; end
 
-  sig { returns(DateTime) }
+  sig { returns(ActiveSupport::TimeWithZone) }
   def updated_at; end
 
-  sig { params(value: DateTime).void }
+  sig { params(value: T.any(DateTime, Date, Time, ActiveSupport::TimeWithZone)).void }
   def updated_at=(value); end
 
   sig { returns(T::Boolean) }

--- a/spec/test_data/v5.1/expected_internal_metadata.rbi
+++ b/spec/test_data/v5.1/expected_internal_metadata.rbi
@@ -10,10 +10,10 @@ end
 module ActiveRecord::InternalMetadata::GeneratedAttributeMethods
   extend T::Sig
 
-  sig { returns(DateTime) }
+  sig { returns(ActiveSupport::TimeWithZone) }
   def created_at; end
 
-  sig { params(value: DateTime).void }
+  sig { params(value: T.any(DateTime, Date, Time, ActiveSupport::TimeWithZone)).void }
   def created_at=(value); end
 
   sig { returns(T::Boolean) }
@@ -28,10 +28,10 @@ module ActiveRecord::InternalMetadata::GeneratedAttributeMethods
   sig { returns(T::Boolean) }
   def key?; end
 
-  sig { returns(DateTime) }
+  sig { returns(ActiveSupport::TimeWithZone) }
   def updated_at; end
 
-  sig { params(value: DateTime).void }
+  sig { params(value: T.any(DateTime, Date, Time, ActiveSupport::TimeWithZone)).void }
   def updated_at=(value); end
 
   sig { returns(T::Boolean) }

--- a/spec/test_data/v5.1/expected_squib.rbi
+++ b/spec/test_data/v5.1/expected_squib.rbi
@@ -125,10 +125,10 @@ module Squib::GeneratedAttributeMethods
   sig { returns(T::Boolean) }
   def broom?; end
 
-  sig { returns(DateTime) }
+  sig { returns(ActiveSupport::TimeWithZone) }
   def created_at; end
 
-  sig { params(value: DateTime).void }
+  sig { params(value: T.any(DateTime, Date, Time, ActiveSupport::TimeWithZone)).void }
   def created_at=(value); end
 
   sig { returns(T::Boolean) }
@@ -224,10 +224,10 @@ module Squib::GeneratedAttributeMethods
   sig { returns(T::Boolean) }
   def type?; end
 
-  sig { returns(DateTime) }
+  sig { returns(ActiveSupport::TimeWithZone) }
   def updated_at; end
 
-  sig { params(value: DateTime).void }
+  sig { params(value: T.any(DateTime, Date, Time, ActiveSupport::TimeWithZone)).void }
   def updated_at=(value); end
 
   sig { returns(T::Boolean) }

--- a/spec/test_data/v5.1/expected_wand.rbi
+++ b/spec/test_data/v5.1/expected_wand.rbi
@@ -47,6 +47,15 @@ module Wand::GeneratedAttributeMethods
   sig { returns(T::Boolean) }
   def broken?; end
 
+  sig { returns(T.nilable(Time)) }
+  def broken_at; end
+
+  sig { params(value: T.nilable(Time)).void }
+  def broken_at=(value); end
+
+  sig { returns(T::Boolean) }
+  def broken_at?; end
+
   sig { returns(T.nilable(Date)) }
   def chosen_at_date; end
 
@@ -56,10 +65,10 @@ module Wand::GeneratedAttributeMethods
   sig { returns(T::Boolean) }
   def chosen_at_date?; end
 
-  sig { returns(T.nilable(Time)) }
+  sig { returns(T.nilable(ActiveSupport::TimeWithZone)) }
   def chosen_at_time; end
 
-  sig { params(value: T.nilable(Time)).void }
+  sig { params(value: T.nilable(T.any(DateTime, Date, Time, ActiveSupport::TimeWithZone))).void }
   def chosen_at_time=(value); end
 
   sig { returns(T::Boolean) }
@@ -74,10 +83,10 @@ module Wand::GeneratedAttributeMethods
   sig { returns(T::Boolean) }
   def core_type?; end
 
-  sig { returns(DateTime) }
+  sig { returns(ActiveSupport::TimeWithZone) }
   def created_at; end
 
-  sig { params(value: DateTime).void }
+  sig { params(value: T.any(DateTime, Date, Time, ActiveSupport::TimeWithZone)).void }
   def created_at=(value); end
 
   sig { returns(T::Boolean) }
@@ -119,10 +128,10 @@ module Wand::GeneratedAttributeMethods
   sig { returns(T::Boolean) }
   def reflectance?; end
 
-  sig { returns(DateTime) }
+  sig { returns(ActiveSupport::TimeWithZone) }
   def updated_at; end
 
-  sig { params(value: DateTime).void }
+  sig { params(value: T.any(DateTime, Date, Time, ActiveSupport::TimeWithZone)).void }
   def updated_at=(value); end
 
   sig { returns(T::Boolean) }

--- a/spec/test_data/v5.1/expected_wizard.rbi
+++ b/spec/test_data/v5.1/expected_wizard.rbi
@@ -125,10 +125,10 @@ module Wizard::GeneratedAttributeMethods
   sig { returns(T::Boolean) }
   def broom?; end
 
-  sig { returns(DateTime) }
+  sig { returns(ActiveSupport::TimeWithZone) }
   def created_at; end
 
-  sig { params(value: DateTime).void }
+  sig { params(value: T.any(DateTime, Date, Time, ActiveSupport::TimeWithZone)).void }
   def created_at=(value); end
 
   sig { returns(T::Boolean) }
@@ -224,10 +224,10 @@ module Wizard::GeneratedAttributeMethods
   sig { returns(T::Boolean) }
   def type?; end
 
-  sig { returns(DateTime) }
+  sig { returns(ActiveSupport::TimeWithZone) }
   def updated_at; end
 
-  sig { params(value: DateTime).void }
+  sig { params(value: T.any(DateTime, Date, Time, ActiveSupport::TimeWithZone)).void }
   def updated_at=(value); end
 
   sig { returns(T::Boolean) }

--- a/spec/test_data/v5.1/expected_wizard_wo_spellbook.rbi
+++ b/spec/test_data/v5.1/expected_wizard_wo_spellbook.rbi
@@ -125,10 +125,10 @@ module Wizard::GeneratedAttributeMethods
   sig { returns(T::Boolean) }
   def broom?; end
 
-  sig { returns(DateTime) }
+  sig { returns(ActiveSupport::TimeWithZone) }
   def created_at; end
 
-  sig { params(value: DateTime).void }
+  sig { params(value: T.any(DateTime, Date, Time, ActiveSupport::TimeWithZone)).void }
   def created_at=(value); end
 
   sig { returns(T::Boolean) }
@@ -224,10 +224,10 @@ module Wizard::GeneratedAttributeMethods
   sig { returns(T::Boolean) }
   def type?; end
 
-  sig { returns(DateTime) }
+  sig { returns(ActiveSupport::TimeWithZone) }
   def updated_at; end
 
-  sig { params(value: DateTime).void }
+  sig { params(value: T.any(DateTime, Date, Time, ActiveSupport::TimeWithZone)).void }
   def updated_at=(value); end
 
   sig { returns(T::Boolean) }

--- a/spec/test_data/v5.2/expected_internal_metadata.rbi
+++ b/spec/test_data/v5.2/expected_internal_metadata.rbi
@@ -10,10 +10,10 @@ end
 module ActiveRecord::InternalMetadata::GeneratedAttributeMethods
   extend T::Sig
 
-  sig { returns(DateTime) }
+  sig { returns(ActiveSupport::TimeWithZone) }
   def created_at; end
 
-  sig { params(value: DateTime).void }
+  sig { params(value: T.any(DateTime, Date, Time, ActiveSupport::TimeWithZone)).void }
   def created_at=(value); end
 
   sig { returns(T::Boolean) }
@@ -28,10 +28,10 @@ module ActiveRecord::InternalMetadata::GeneratedAttributeMethods
   sig { returns(T::Boolean) }
   def key?; end
 
-  sig { returns(DateTime) }
+  sig { returns(ActiveSupport::TimeWithZone) }
   def updated_at; end
 
-  sig { params(value: DateTime).void }
+  sig { params(value: T.any(DateTime, Date, Time, ActiveSupport::TimeWithZone)).void }
   def updated_at=(value); end
 
   sig { returns(T::Boolean) }

--- a/spec/test_data/v5.2/expected_squib.rbi
+++ b/spec/test_data/v5.2/expected_squib.rbi
@@ -125,10 +125,10 @@ module Squib::GeneratedAttributeMethods
   sig { returns(T::Boolean) }
   def broom?; end
 
-  sig { returns(DateTime) }
+  sig { returns(ActiveSupport::TimeWithZone) }
   def created_at; end
 
-  sig { params(value: DateTime).void }
+  sig { params(value: T.any(DateTime, Date, Time, ActiveSupport::TimeWithZone)).void }
   def created_at=(value); end
 
   sig { returns(T::Boolean) }
@@ -224,10 +224,10 @@ module Squib::GeneratedAttributeMethods
   sig { returns(T::Boolean) }
   def type?; end
 
-  sig { returns(DateTime) }
+  sig { returns(ActiveSupport::TimeWithZone) }
   def updated_at; end
 
-  sig { params(value: DateTime).void }
+  sig { params(value: T.any(DateTime, Date, Time, ActiveSupport::TimeWithZone)).void }
   def updated_at=(value); end
 
   sig { returns(T::Boolean) }

--- a/spec/test_data/v5.2/expected_wand.rbi
+++ b/spec/test_data/v5.2/expected_wand.rbi
@@ -47,6 +47,15 @@ module Wand::GeneratedAttributeMethods
   sig { returns(T::Boolean) }
   def broken?; end
 
+  sig { returns(T.nilable(Time)) }
+  def broken_at; end
+
+  sig { params(value: T.nilable(Time)).void }
+  def broken_at=(value); end
+
+  sig { returns(T::Boolean) }
+  def broken_at?; end
+
   sig { returns(T.nilable(Date)) }
   def chosen_at_date; end
 
@@ -56,10 +65,10 @@ module Wand::GeneratedAttributeMethods
   sig { returns(T::Boolean) }
   def chosen_at_date?; end
 
-  sig { returns(T.nilable(Time)) }
+  sig { returns(T.nilable(ActiveSupport::TimeWithZone)) }
   def chosen_at_time; end
 
-  sig { params(value: T.nilable(Time)).void }
+  sig { params(value: T.nilable(T.any(DateTime, Date, Time, ActiveSupport::TimeWithZone))).void }
   def chosen_at_time=(value); end
 
   sig { returns(T::Boolean) }
@@ -74,10 +83,10 @@ module Wand::GeneratedAttributeMethods
   sig { returns(T::Boolean) }
   def core_type?; end
 
-  sig { returns(DateTime) }
+  sig { returns(ActiveSupport::TimeWithZone) }
   def created_at; end
 
-  sig { params(value: DateTime).void }
+  sig { params(value: T.any(DateTime, Date, Time, ActiveSupport::TimeWithZone)).void }
   def created_at=(value); end
 
   sig { returns(T::Boolean) }
@@ -137,10 +146,10 @@ module Wand::GeneratedAttributeMethods
   sig { returns(T::Boolean) }
   def spell_history?; end
 
-  sig { returns(DateTime) }
+  sig { returns(ActiveSupport::TimeWithZone) }
   def updated_at; end
 
-  sig { params(value: DateTime).void }
+  sig { params(value: T.any(DateTime, Date, Time, ActiveSupport::TimeWithZone)).void }
   def updated_at=(value); end
 
   sig { returns(T::Boolean) }

--- a/spec/test_data/v5.2/expected_wizard.rbi
+++ b/spec/test_data/v5.2/expected_wizard.rbi
@@ -125,10 +125,10 @@ module Wizard::GeneratedAttributeMethods
   sig { returns(T::Boolean) }
   def broom?; end
 
-  sig { returns(DateTime) }
+  sig { returns(ActiveSupport::TimeWithZone) }
   def created_at; end
 
-  sig { params(value: DateTime).void }
+  sig { params(value: T.any(DateTime, Date, Time, ActiveSupport::TimeWithZone)).void }
   def created_at=(value); end
 
   sig { returns(T::Boolean) }
@@ -224,10 +224,10 @@ module Wizard::GeneratedAttributeMethods
   sig { returns(T::Boolean) }
   def type?; end
 
-  sig { returns(DateTime) }
+  sig { returns(ActiveSupport::TimeWithZone) }
   def updated_at; end
 
-  sig { params(value: DateTime).void }
+  sig { params(value: T.any(DateTime, Date, Time, ActiveSupport::TimeWithZone)).void }
   def updated_at=(value); end
 
   sig { returns(T::Boolean) }

--- a/spec/test_data/v5.2/expected_wizard_wo_spellbook.rbi
+++ b/spec/test_data/v5.2/expected_wizard_wo_spellbook.rbi
@@ -125,10 +125,10 @@ module Wizard::GeneratedAttributeMethods
   sig { returns(T::Boolean) }
   def broom?; end
 
-  sig { returns(DateTime) }
+  sig { returns(ActiveSupport::TimeWithZone) }
   def created_at; end
 
-  sig { params(value: DateTime).void }
+  sig { params(value: T.any(DateTime, Date, Time, ActiveSupport::TimeWithZone)).void }
   def created_at=(value); end
 
   sig { returns(T::Boolean) }
@@ -224,10 +224,10 @@ module Wizard::GeneratedAttributeMethods
   sig { returns(T::Boolean) }
   def type?; end
 
-  sig { returns(DateTime) }
+  sig { returns(ActiveSupport::TimeWithZone) }
   def updated_at; end
 
-  sig { params(value: DateTime).void }
+  sig { params(value: T.any(DateTime, Date, Time, ActiveSupport::TimeWithZone)).void }
   def updated_at=(value); end
 
   sig { returns(T::Boolean) }

--- a/spec/test_data/v6.0/expected_internal_metadata.rbi
+++ b/spec/test_data/v6.0/expected_internal_metadata.rbi
@@ -10,10 +10,10 @@ end
 module ActiveRecord::InternalMetadata::GeneratedAttributeMethods
   extend T::Sig
 
-  sig { returns(DateTime) }
+  sig { returns(ActiveSupport::TimeWithZone) }
   def created_at; end
 
-  sig { params(value: DateTime).void }
+  sig { params(value: T.any(DateTime, Date, Time, ActiveSupport::TimeWithZone)).void }
   def created_at=(value); end
 
   sig { returns(T::Boolean) }
@@ -28,10 +28,10 @@ module ActiveRecord::InternalMetadata::GeneratedAttributeMethods
   sig { returns(T::Boolean) }
   def key?; end
 
-  sig { returns(DateTime) }
+  sig { returns(ActiveSupport::TimeWithZone) }
   def updated_at; end
 
-  sig { params(value: DateTime).void }
+  sig { params(value: T.any(DateTime, Date, Time, ActiveSupport::TimeWithZone)).void }
   def updated_at=(value); end
 
   sig { returns(T::Boolean) }

--- a/spec/test_data/v6.0/expected_squib.rbi
+++ b/spec/test_data/v6.0/expected_squib.rbi
@@ -125,10 +125,10 @@ module Squib::GeneratedAttributeMethods
   sig { returns(T::Boolean) }
   def broom?; end
 
-  sig { returns(DateTime) }
+  sig { returns(ActiveSupport::TimeWithZone) }
   def created_at; end
 
-  sig { params(value: DateTime).void }
+  sig { params(value: T.any(DateTime, Date, Time, ActiveSupport::TimeWithZone)).void }
   def created_at=(value); end
 
   sig { returns(T::Boolean) }
@@ -224,10 +224,10 @@ module Squib::GeneratedAttributeMethods
   sig { returns(T::Boolean) }
   def type?; end
 
-  sig { returns(DateTime) }
+  sig { returns(ActiveSupport::TimeWithZone) }
   def updated_at; end
 
-  sig { params(value: DateTime).void }
+  sig { params(value: T.any(DateTime, Date, Time, ActiveSupport::TimeWithZone)).void }
   def updated_at=(value); end
 
   sig { returns(T::Boolean) }

--- a/spec/test_data/v6.0/expected_wand.rbi
+++ b/spec/test_data/v6.0/expected_wand.rbi
@@ -47,6 +47,15 @@ module Wand::GeneratedAttributeMethods
   sig { returns(T::Boolean) }
   def broken?; end
 
+  sig { returns(T.nilable(Time)) }
+  def broken_at; end
+
+  sig { params(value: T.nilable(Time)).void }
+  def broken_at=(value); end
+
+  sig { returns(T::Boolean) }
+  def broken_at?; end
+
   sig { returns(T.nilable(Date)) }
   def chosen_at_date; end
 
@@ -56,10 +65,10 @@ module Wand::GeneratedAttributeMethods
   sig { returns(T::Boolean) }
   def chosen_at_date?; end
 
-  sig { returns(T.nilable(Time)) }
+  sig { returns(T.nilable(ActiveSupport::TimeWithZone)) }
   def chosen_at_time; end
 
-  sig { params(value: T.nilable(Time)).void }
+  sig { params(value: T.nilable(T.any(DateTime, Date, Time, ActiveSupport::TimeWithZone))).void }
   def chosen_at_time=(value); end
 
   sig { returns(T::Boolean) }
@@ -74,10 +83,10 @@ module Wand::GeneratedAttributeMethods
   sig { returns(T::Boolean) }
   def core_type?; end
 
-  sig { returns(DateTime) }
+  sig { returns(ActiveSupport::TimeWithZone) }
   def created_at; end
 
-  sig { params(value: DateTime).void }
+  sig { params(value: T.any(DateTime, Date, Time, ActiveSupport::TimeWithZone)).void }
   def created_at=(value); end
 
   sig { returns(T::Boolean) }
@@ -137,10 +146,10 @@ module Wand::GeneratedAttributeMethods
   sig { returns(T::Boolean) }
   def spell_history?; end
 
-  sig { returns(DateTime) }
+  sig { returns(ActiveSupport::TimeWithZone) }
   def updated_at; end
 
-  sig { params(value: DateTime).void }
+  sig { params(value: T.any(DateTime, Date, Time, ActiveSupport::TimeWithZone)).void }
   def updated_at=(value); end
 
   sig { returns(T::Boolean) }

--- a/spec/test_data/v6.0/expected_wizard.rbi
+++ b/spec/test_data/v6.0/expected_wizard.rbi
@@ -125,10 +125,10 @@ module Wizard::GeneratedAttributeMethods
   sig { returns(T::Boolean) }
   def broom?; end
 
-  sig { returns(DateTime) }
+  sig { returns(ActiveSupport::TimeWithZone) }
   def created_at; end
 
-  sig { params(value: DateTime).void }
+  sig { params(value: T.any(DateTime, Date, Time, ActiveSupport::TimeWithZone)).void }
   def created_at=(value); end
 
   sig { returns(T::Boolean) }
@@ -224,10 +224,10 @@ module Wizard::GeneratedAttributeMethods
   sig { returns(T::Boolean) }
   def type?; end
 
-  sig { returns(DateTime) }
+  sig { returns(ActiveSupport::TimeWithZone) }
   def updated_at; end
 
-  sig { params(value: DateTime).void }
+  sig { params(value: T.any(DateTime, Date, Time, ActiveSupport::TimeWithZone)).void }
   def updated_at=(value); end
 
   sig { returns(T::Boolean) }

--- a/spec/test_data/v6.0/expected_wizard_wo_spellbook.rbi
+++ b/spec/test_data/v6.0/expected_wizard_wo_spellbook.rbi
@@ -125,10 +125,10 @@ module Wizard::GeneratedAttributeMethods
   sig { returns(T::Boolean) }
   def broom?; end
 
-  sig { returns(DateTime) }
+  sig { returns(ActiveSupport::TimeWithZone) }
   def created_at; end
 
-  sig { params(value: DateTime).void }
+  sig { params(value: T.any(DateTime, Date, Time, ActiveSupport::TimeWithZone)).void }
   def created_at=(value); end
 
   sig { returns(T::Boolean) }
@@ -224,10 +224,10 @@ module Wizard::GeneratedAttributeMethods
   sig { returns(T::Boolean) }
   def type?; end
 
-  sig { returns(DateTime) }
+  sig { returns(ActiveSupport::TimeWithZone) }
   def updated_at; end
 
-  sig { params(value: DateTime).void }
+  sig { params(value: T.any(DateTime, Date, Time, ActiveSupport::TimeWithZone)).void }
   def updated_at=(value); end
 
   sig { returns(T::Boolean) }


### PR DESCRIPTION
**Supports Rails 4.2+**

"Time like" attributes in ActiveRecord may be considered "time zone aware". This is the default in Rails 4.2 for `datetime` attributes, and from Rails 5.1 the default was extended to include `time` attributes too.

When an attribute is time zone aware, [its ActiveRecord type is decorated](https://github.com/rails/rails/blob/v6.0.0/activerecord/lib/active_record/attribute_methods/time_zone_conversion.rb#L76) and it will [begin casting its value](https://github.com/rails/rails/blob/v6.0.0/activerecord/lib/active_record/attribute_methods/time_zone_conversion.rb#L29) (which is usually a `DateTime` or `Time` instance) to an `ActiveSupport::TimeWithZone` instance when it's accessed or deserialized from the DB.

It's possible to disable this casting, [as described here](https://api.rubyonrails.org/classes/ActiveRecord/Timestamp.html). This PR takes these options into account by calling [a private class method](https://github.com/rails/rails/blob/v6.0.0/activerecord/lib/active_record/attribute_methods/time_zone_conversion.rb#L82) on the model with each "time like" attribute to determine if it's time zone aware or not. Unfortunately there is no public method that covers the full logic of this check, so the private method will have to do.

The end result is that all `date`, `datetime`, `timestamp` etc attributes should now be correctly typed as either `ActiveSupport::WithTimeZone` (if they're TZ-aware) or `Time` (if they're not).

As a convenience, TZ-aware attributes have their attribute writers typed as accepting a union type of `DateTime, Date, Time, ActiveSupport::TimeWithZone`. This is safe to do because Rails will always cast a TZ-aware attribute when it's assigned:

```rb
wand = Wand.first
wand.chosen_at_time.class # => ActiveSupport::TimeWithZone
wand.chosen_at_time = DateTime.now
wand.chosen_at_time.class # => ActiveSupport::TimeWithZone
```

---

In addition to the core functionality I regenerated all Rails apps (updating Sorbet in the process) and made a few changes to the `rails-template`:

- added a configuration option so that Rails 5.0 treats `time` columns as TZ-aware (this became the default behaviour in Rails 5.1 and makes the fixtures more consistent)
 - enforced not-null timestamps for `Wizard`, so the `created_at/updated_at` fields are consistently not null across all versions (allows for simpler `sorbet_test_cases`)
- added a `broken_at` column to `wands` table to support some additional assertions
- updated `Wand` model to ensure the new `broken_at` isn't TZ-aware for some assertions
