### PR TITLE
Add sigs for ActiveRecord::Core module

### DIFF
--- a/lib/sorbet-rails/activerecord.rbi
+++ b/lib/sorbet-rails/activerecord.rbi
@@ -25,6 +25,42 @@ class ActiveRecord::Base < Object
   def self.attachment_reflections; end
 end
 
+module ActiveRecord::Core
+  extend T::Sig
+
+  sig { params(other_object: T.untyped).returns(T.nilable(Integer)) }
+  def <=>(other_object); end
+
+  sig { params(comparison_object: T.untyped).returns(T::Boolean) }
+  def ==(comparison_object); end
+
+  sig { returns(ActiveRecord::ConnectionAdapters::ConnectionHandler) }
+  def connection_handler; end
+
+  sig { returns(T::Boolean) }
+  def custom_inspect_method_defined?; end
+
+  sig { params(comparison_object: T.untyped).returns(T::Boolean) }
+  def eql?(comparison_object); end
+
+  sig { returns(T::Boolean) }
+  def frozen?; end
+
+  sig { returns(Integer) }
+  def hash; end
+
+  sig { returns(String) }
+  def inspect; end
+
+  sig { returns(TrueClass) }
+  def readonly!; end
+
+  sig { returns(T::Boolean) }
+  def readonly?; end
+
+  extend ActiveSupport::Concern
+end
+
 class ActiveRecord::AttributeMethods::TimeZoneConversion::TimeZoneConverter;
   def klass; end
 end


### PR DESCRIPTION
Add signatures for some methods in [ActiveRecord::Core](https://api.rubyonrails.org/classes/ActiveRecord/Core.html).

Since not all methods can be statically typed easily, this module is still in `todo.rbi`. 