### PR TITLE
Allow symbols to be assignable for AR attributes

### DIFF
--- a/lib/sorbet-rails/model_plugins/active_record_attribute.rb
+++ b/lib/sorbet-rails/model_plugins/active_record_attribute.rb
@@ -140,6 +140,8 @@ class SorbetRails::ModelPlugins::ActiveRecordAttribute < SorbetRails::ModelPlugi
       "T.any(#{assignable_time_types.join(', ')})"
     elsif column_type == "T.nilable(ActiveSupport::TimeWithZone)"
       "T.nilable(T.any(#{assignable_time_types.join(', ')}))"
+    elsif column_type == String
+      'T.any(String, Symbol)'
     else
       column_type.to_s
     end

--- a/spec/support/v5.0/config/boot.rb
+++ b/spec/support/v5.0/config/boot.rb
@@ -1,4 +1,4 @@
-# typed: strong
+# typed: strict
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
 
 require 'bundler/setup' # Set up gems listed in the Gemfile.

--- a/spec/support/v5.0/config/initializers/sorbet_rails.rb
+++ b/spec/support/v5.0/config/initializers/sorbet_rails.rb
@@ -1,3 +1,3 @@
-# typed: false
+# typed: strict
 require(Rails.root.join('lib/mythical_rbi_plugin'))
 SorbetRails::ModelRbiFormatter.register_plugin(MythicalRbiPlugin)

--- a/spec/support/v5.1/config/boot.rb
+++ b/spec/support/v5.1/config/boot.rb
@@ -1,4 +1,4 @@
-# typed: strong
+# typed: strict
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
 
 require 'bundler/setup' # Set up gems listed in the Gemfile.

--- a/spec/support/v5.1/config/initializers/sorbet_rails.rb
+++ b/spec/support/v5.1/config/initializers/sorbet_rails.rb
@@ -1,3 +1,3 @@
-# typed: false
+# typed: strict
 require(Rails.root.join('lib/mythical_rbi_plugin'))
 SorbetRails::ModelRbiFormatter.register_plugin(MythicalRbiPlugin)

--- a/spec/support/v5.2/config/boot.rb
+++ b/spec/support/v5.2/config/boot.rb
@@ -1,4 +1,4 @@
-# typed: strong
+# typed: strict
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
 
 require 'bundler/setup' # Set up gems listed in the Gemfile.

--- a/spec/support/v5.2/config/initializers/sorbet_rails.rb
+++ b/spec/support/v5.2/config/initializers/sorbet_rails.rb
@@ -1,3 +1,3 @@
-# typed: false
+# typed: strict
 require(Rails.root.join('lib/mythical_rbi_plugin'))
 SorbetRails::ModelRbiFormatter.register_plugin(MythicalRbiPlugin)

--- a/spec/support/v6.0/app/models/wizard.rb
+++ b/spec/support/v6.0/app/models/wizard.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: false
 class Wizard < ApplicationRecord
   validates :name, length: { minimum: 5 }, presence: true
 

--- a/spec/support/v6.0/config/boot.rb
+++ b/spec/support/v6.0/config/boot.rb
@@ -1,4 +1,4 @@
-# typed: strong
+# typed: strict
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
 
 require 'bundler/setup' # Set up gems listed in the Gemfile.

--- a/spec/support/v6.0/config/initializers/sorbet_rails.rb
+++ b/spec/support/v6.0/config/initializers/sorbet_rails.rb
@@ -1,3 +1,3 @@
-# typed: false
+# typed: strict
 require(Rails.root.join('lib/mythical_rbi_plugin'))
 SorbetRails::ModelRbiFormatter.register_plugin(MythicalRbiPlugin)

--- a/spec/support/v6.0/config/initializers/wrap_parameters.rb
+++ b/spec/support/v6.0/config/initializers/wrap_parameters.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: strict
 # Be sure to restart your server when you modify this file.
 
 # This file contains settings for ActionController::ParamsWrapper which

--- a/spec/test_data/v5.0/expected_internal_metadata.rbi
+++ b/spec/test_data/v5.0/expected_internal_metadata.rbi
@@ -22,7 +22,7 @@ module ActiveRecord::InternalMetadata::GeneratedAttributeMethods
   sig { returns(String) }
   def key; end
 
-  sig { params(value: String).void }
+  sig { params(value: T.any(String, Symbol)).void }
   def key=(value); end
 
   sig { returns(T::Boolean) }

--- a/spec/test_data/v5.0/expected_schema_migration.rbi
+++ b/spec/test_data/v5.0/expected_schema_migration.rbi
@@ -13,7 +13,7 @@ module ActiveRecord::SchemaMigration::GeneratedAttributeMethods
   sig { returns(String) }
   def version; end
 
-  sig { params(value: String).void }
+  sig { params(value: T.any(String, Symbol)).void }
   def version=(value); end
 
   sig { returns(T::Boolean) }

--- a/spec/test_data/v5.0/expected_squib.rbi
+++ b/spec/test_data/v5.0/expected_squib.rbi
@@ -218,7 +218,7 @@ module Squib::GeneratedAttributeMethods
   sig { returns(String) }
   def type; end
 
-  sig { params(value: String).void }
+  sig { params(value: T.any(String, Symbol)).void }
   def type=(value); end
 
   sig { returns(T::Boolean) }

--- a/spec/test_data/v5.0/expected_wizard.rbi
+++ b/spec/test_data/v5.0/expected_wizard.rbi
@@ -218,7 +218,7 @@ module Wizard::GeneratedAttributeMethods
   sig { returns(String) }
   def type; end
 
-  sig { params(value: String).void }
+  sig { params(value: T.any(String, Symbol)).void }
   def type=(value); end
 
   sig { returns(T::Boolean) }

--- a/spec/test_data/v5.0/expected_wizard_wo_spellbook.rbi
+++ b/spec/test_data/v5.0/expected_wizard_wo_spellbook.rbi
@@ -218,7 +218,7 @@ module Wizard::GeneratedAttributeMethods
   sig { returns(String) }
   def type; end
 
-  sig { params(value: String).void }
+  sig { params(value: T.any(String)).void }
   def type=(value); end
 
   sig { returns(T::Boolean) }

--- a/spec/test_data/v5.0/expected_wizard_wo_spellbook.rbi
+++ b/spec/test_data/v5.0/expected_wizard_wo_spellbook.rbi
@@ -218,7 +218,7 @@ module Wizard::GeneratedAttributeMethods
   sig { returns(String) }
   def type; end
 
-  sig { params(value: T.any(String)).void }
+  sig { params(value: T.any(String, Symbol)).void }
   def type=(value); end
 
   sig { returns(T::Boolean) }

--- a/spec/test_data/v5.1/expected_internal_metadata.rbi
+++ b/spec/test_data/v5.1/expected_internal_metadata.rbi
@@ -22,7 +22,7 @@ module ActiveRecord::InternalMetadata::GeneratedAttributeMethods
   sig { returns(String) }
   def key; end
 
-  sig { params(value: String).void }
+  sig { params(value: T.any(String, Symbol)).void }
   def key=(value); end
 
   sig { returns(T::Boolean) }

--- a/spec/test_data/v5.1/expected_schema_migration.rbi
+++ b/spec/test_data/v5.1/expected_schema_migration.rbi
@@ -13,7 +13,7 @@ module ActiveRecord::SchemaMigration::GeneratedAttributeMethods
   sig { returns(String) }
   def version; end
 
-  sig { params(value: String).void }
+  sig { params(value: T.any(String, Symbol)).void }
   def version=(value); end
 
   sig { returns(T::Boolean) }

--- a/spec/test_data/v5.1/expected_squib.rbi
+++ b/spec/test_data/v5.1/expected_squib.rbi
@@ -218,7 +218,7 @@ module Squib::GeneratedAttributeMethods
   sig { returns(String) }
   def type; end
 
-  sig { params(value: String).void }
+  sig { params(value: T.any(String, Symbol)).void }
   def type=(value); end
 
   sig { returns(T::Boolean) }

--- a/spec/test_data/v5.1/expected_wizard.rbi
+++ b/spec/test_data/v5.1/expected_wizard.rbi
@@ -218,7 +218,7 @@ module Wizard::GeneratedAttributeMethods
   sig { returns(String) }
   def type; end
 
-  sig { params(value: String).void }
+  sig { params(value: T.any(String, Symbol).void }
   def type=(value); end
 
   sig { returns(T::Boolean) }

--- a/spec/test_data/v5.1/expected_wizard.rbi
+++ b/spec/test_data/v5.1/expected_wizard.rbi
@@ -218,7 +218,7 @@ module Wizard::GeneratedAttributeMethods
   sig { returns(String) }
   def type; end
 
-  sig { params(value: T.any(String, Symbol).void }
+  sig { params(value: T.any(String, Symbol)).void }
   def type=(value); end
 
   sig { returns(T::Boolean) }

--- a/spec/test_data/v5.1/expected_wizard_wo_spellbook.rbi
+++ b/spec/test_data/v5.1/expected_wizard_wo_spellbook.rbi
@@ -218,7 +218,7 @@ module Wizard::GeneratedAttributeMethods
   sig { returns(String) }
   def type; end
 
-  sig { params(value: String).void }
+  sig { params(value: T.any(String, Symbol)).void }
   def type=(value); end
 
   sig { returns(T::Boolean) }

--- a/spec/test_data/v5.2/expected_internal_metadata.rbi
+++ b/spec/test_data/v5.2/expected_internal_metadata.rbi
@@ -22,7 +22,7 @@ module ActiveRecord::InternalMetadata::GeneratedAttributeMethods
   sig { returns(String) }
   def key; end
 
-  sig { params(value: String).void }
+  sig { params(value: T.any(String, Symbol)).void }
   def key=(value); end
 
   sig { returns(T::Boolean) }

--- a/spec/test_data/v5.2/expected_schema_migration.rbi
+++ b/spec/test_data/v5.2/expected_schema_migration.rbi
@@ -13,7 +13,7 @@ module ActiveRecord::SchemaMigration::GeneratedAttributeMethods
   sig { returns(String) }
   def version; end
 
-  sig { params(value: String).void }
+  sig { params(value: T.any(String, Symbol)).void }
   def version=(value); end
 
   sig { returns(T::Boolean) }

--- a/spec/test_data/v5.2/expected_squib.rbi
+++ b/spec/test_data/v5.2/expected_squib.rbi
@@ -218,7 +218,7 @@ module Squib::GeneratedAttributeMethods
   sig { returns(String) }
   def type; end
 
-  sig { params(value: String).void }
+  sig { params(value: T.any(String, Symbol)).void }
   def type=(value); end
 
   sig { returns(T::Boolean) }

--- a/spec/test_data/v5.2/expected_wizard.rbi
+++ b/spec/test_data/v5.2/expected_wizard.rbi
@@ -218,7 +218,7 @@ module Wizard::GeneratedAttributeMethods
   sig { returns(String) }
   def type; end
 
-  sig { params(value: String).void }
+  sig { params(value: T.any(String, Symbol)).void }
   def type=(value); end
 
   sig { returns(T::Boolean) }

--- a/spec/test_data/v5.2/expected_wizard_wo_spellbook.rbi
+++ b/spec/test_data/v5.2/expected_wizard_wo_spellbook.rbi
@@ -218,7 +218,7 @@ module Wizard::GeneratedAttributeMethods
   sig { returns(String) }
   def type; end
 
-  sig { params(value: String).void }
+  sig { params(value: T.any(String, Symbol)).void }
   def type=(value); end
 
   sig { returns(T::Boolean) }

--- a/spec/test_data/v6.0/expected_internal_metadata.rbi
+++ b/spec/test_data/v6.0/expected_internal_metadata.rbi
@@ -22,7 +22,7 @@ module ActiveRecord::InternalMetadata::GeneratedAttributeMethods
   sig { returns(String) }
   def key; end
 
-  sig { params(value: String).void }
+  sig { params(value: T.any(String, Symbol)).void }
   def key=(value); end
 
   sig { returns(T::Boolean) }

--- a/spec/test_data/v6.0/expected_schema_migration.rbi
+++ b/spec/test_data/v6.0/expected_schema_migration.rbi
@@ -13,7 +13,7 @@ module ActiveRecord::SchemaMigration::GeneratedAttributeMethods
   sig { returns(String) }
   def version; end
 
-  sig { params(value: String).void }
+  sig { params(value: T.any(String, Symbol)).void }
   def version=(value); end
 
   sig { returns(T::Boolean) }

--- a/spec/test_data/v6.0/expected_squib.rbi
+++ b/spec/test_data/v6.0/expected_squib.rbi
@@ -218,7 +218,7 @@ module Squib::GeneratedAttributeMethods
   sig { returns(String) }
   def type; end
 
-  sig { params(value: String).void }
+  sig { params(value: T.any(String, Symbol)).void }
   def type=(value); end
 
   sig { returns(T::Boolean) }

--- a/spec/test_data/v6.0/expected_wizard.rbi
+++ b/spec/test_data/v6.0/expected_wizard.rbi
@@ -218,7 +218,7 @@ module Wizard::GeneratedAttributeMethods
   sig { returns(String) }
   def type; end
 
-  sig { params(value: String).void }
+  sig { params(value: T.any(String)).void }
   def type=(value); end
 
   sig { returns(T::Boolean) }

--- a/spec/test_data/v6.0/expected_wizard.rbi
+++ b/spec/test_data/v6.0/expected_wizard.rbi
@@ -218,7 +218,7 @@ module Wizard::GeneratedAttributeMethods
   sig { returns(String) }
   def type; end
 
-  sig { params(value: T.any(String)).void }
+  sig { params(value: T.any(String, Symbol)).void }
   def type=(value); end
 
   sig { returns(T::Boolean) }

--- a/spec/test_data/v6.0/expected_wizard_wo_spellbook.rbi
+++ b/spec/test_data/v6.0/expected_wizard_wo_spellbook.rbi
@@ -218,7 +218,7 @@ module Wizard::GeneratedAttributeMethods
   sig { returns(String) }
   def type; end
 
-  sig { params(value: String).void }
+  sig { params(value: T.any(String, Symbol)).void }
   def type=(value); end
 
   sig { returns(T::Boolean) }


### PR DESCRIPTION
The params for attribute assignment to string DB columns appears to be overly restrictive. 

In principle, I think, you can assign almost any `Object` to these columns, e.g. `model.attr = Object.new` gives something like `attr:  "#<Object:0x00007f94b66f3d10>"`. But I'm not sure a change that general makes sense.

Probably should allow symbols though given their ubiquity and similarity to strings.