### PR TITLE
Remove block parameter from querying methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,10 @@ with:
 Model.unscoped.scoping do … end
 ```
 
+### `select` with a block
+
+The [`select` method](https://apidock.com/rails/v4.0.2/ActiveRecord/QueryMethods/select) method in Rails has two modes: it can be given a list of symbols, in which case rails will only return the given columns from the database, or it can be given a block, in which case it acts like [`Enumerable.select`](https://ruby-doc.org/core-2.6.4/Enumerable.html) and returns an array. We have chosen to support the first use case. If you want to pass a block to `select`, you can simply call `to_a` before you do. Note that this would be done within the `select` call anyway, so the performance penalty will be minimal.
+
 ## Extending Model Generation Task with Custom Plugins
 
 `sorbet-rails` support a customizable plugin system that you can use to generate additional RBI for each model. This will be useful to generate RBI for methods dynamically added by gems or private concerns. If you write plugins for public gems, please feel free to contribute it to this repo.

--- a/lib/sorbet-rails/model_plugins/active_record_querying.rb
+++ b/lib/sorbet-rails/model_plugins/active_record_querying.rb
@@ -24,7 +24,7 @@ class SorbetRails::ModelPlugins::ActiveRecordQuerying < SorbetRails::ModelPlugin
     # rails/activerecord/lib/active_record/querying.rb
     model_query_relation_methods = [
       :select, :reselect, :order, :reorder, :group, :limit, :offset, :joins, :left_joins, :left_outer_joins,
-      :where, :rewhere, :preload, :extract_associated, :eager_load, :includes, :from, :lock, :readonly, :extending, :or,
+      :where, :rewhere, :preload, :extract_associated, :eager_load, :includes, :from, :lock, :readonly, :or,
       :having, :create_with, :distinct, :references, :none, :unscope, :optimizer_hints, :merge, :except, :only,
     ]
     model_query_relation_methods.each do |method_name|
@@ -36,5 +36,14 @@ class SorbetRails::ModelPlugins::ActiveRecordQuerying < SorbetRails::ModelPlugin
         ],
       ) if exists_class_method?(method_name)
     end
+
+    add_relation_query_method(
+      root,
+      "extending",
+      parameters: [
+        Parameter.new("*args", type: "T.untyped"),
+        Parameter.new("&block", type: "T.nilable(T.proc.void)"),
+      ]
+    )
   end
 end

--- a/lib/sorbet-rails/model_plugins/active_record_querying.rb
+++ b/lib/sorbet-rails/model_plugins/active_record_querying.rb
@@ -33,7 +33,6 @@ class SorbetRails::ModelPlugins::ActiveRecordQuerying < SorbetRails::ModelPlugin
         method_name.to_s,
         parameters: [
           Parameter.new("*args", type: "T.untyped"),
-          Parameter.new("&block", type: "T.nilable(T.proc.void)"),
         ],
       ) if exists_class_method?(method_name)
     end

--- a/spec/test_data/v5.0/expected_internal_metadata.rbi
+++ b/spec/test_data/v5.0/expected_internal_metadata.rbi
@@ -76,80 +76,80 @@ class ActiveRecord::InternalMetadata < ActiveRecord::Base
   sig { params(block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
   def self.unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.select(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def self.select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.order(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def self.order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def self.reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.group(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def self.group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.limit(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def self.limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.offset(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def self.offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def self.joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def self.left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def self.left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.where(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def self.where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def self.rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.preload(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def self.preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def self.eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.includes(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def self.includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.from(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def self.from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.lock(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def self.lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def self.readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.or(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def self.or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.having(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def self.having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def self.create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def self.distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.references(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def self.references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.none(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def self.none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def self.unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.except(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def self.except(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata) }
   def self.find(*args); end
@@ -235,80 +235,80 @@ class ActiveRecord::InternalMetadata::ActiveRecord_Relation < ActiveRecord::Rela
   sig { params(block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
   def unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def select(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def order(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def group(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def limit(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def offset(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def where(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def preload(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def includes(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def from(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def lock(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def or(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def having(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def references(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def none(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def except(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def except(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata) }
   def find(*args); end
@@ -402,80 +402,80 @@ class ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation < ActiveR
   sig { params(block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
   def unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def select(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def order(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def group(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def limit(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def offset(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def where(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def preload(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def includes(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def from(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def lock(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def or(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def having(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def references(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def none(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def except(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def except(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata) }
   def find(*args); end
@@ -568,80 +568,80 @@ class ActiveRecord::InternalMetadata::ActiveRecord_Associations_CollectionProxy 
   sig { params(block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
   def unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def select(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def order(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def group(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def limit(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def offset(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def where(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def preload(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def includes(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def from(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def lock(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def or(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def having(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def references(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def none(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def except(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def except(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata) }
   def find(*args); end

--- a/spec/test_data/v5.0/expected_internal_metadata.rbi
+++ b/spec/test_data/v5.0/expected_internal_metadata.rbi
@@ -151,6 +151,9 @@ class ActiveRecord::InternalMetadata < ActiveRecord::Base
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
   def self.except(*args); end
 
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def self.extending(*args, &block); end
+
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata) }
   def self.find(*args); end
 
@@ -309,6 +312,9 @@ class ActiveRecord::InternalMetadata::ActiveRecord_Relation < ActiveRecord::Rela
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
   def except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def extending(*args, &block); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata) }
   def find(*args); end
@@ -477,6 +483,9 @@ class ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation < ActiveR
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
   def except(*args); end
 
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def extending(*args, &block); end
+
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata) }
   def find(*args); end
 
@@ -642,6 +651,9 @@ class ActiveRecord::InternalMetadata::ActiveRecord_Associations_CollectionProxy 
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
   def except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def extending(*args, &block); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata) }
   def find(*args); end

--- a/spec/test_data/v5.0/expected_potion.rbi
+++ b/spec/test_data/v5.0/expected_potion.rbi
@@ -35,80 +35,80 @@ class Potion < ApplicationRecord
   sig { params(block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def self.unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def self.select(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def self.select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def self.order(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def self.order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def self.reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def self.reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def self.group(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def self.group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def self.limit(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def self.limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def self.offset(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def self.offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def self.joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def self.joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def self.left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def self.left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def self.left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def self.left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def self.where(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def self.where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def self.rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def self.rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def self.preload(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def self.preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def self.eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def self.eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def self.includes(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def self.includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def self.from(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def self.from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def self.lock(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def self.lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def self.readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def self.readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def self.or(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def self.or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def self.having(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def self.having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def self.create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def self.create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def self.distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def self.distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def self.references(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def self.references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def self.none(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def self.none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def self.unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def self.unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def self.except(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def self.except(*args); end
 
   sig { params(args: T.untyped).returns(Potion) }
   def self.find(*args); end
@@ -194,80 +194,80 @@ class Potion::ActiveRecord_Relation < ActiveRecord::Relation
   sig { params(block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def select(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def order(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def group(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def limit(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def offset(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def where(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def preload(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def includes(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def from(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def lock(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def or(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def having(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def references(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def none(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def except(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def except(*args); end
 
   sig { params(args: T.untyped).returns(Potion) }
   def find(*args); end
@@ -361,80 +361,80 @@ class Potion::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelati
   sig { params(block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
   def unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def select(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def order(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def group(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def limit(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def offset(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def where(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def preload(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def includes(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def from(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def lock(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def or(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def having(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def references(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def none(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def except(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def except(*args); end
 
   sig { params(args: T.untyped).returns(Potion) }
   def find(*args); end
@@ -527,80 +527,80 @@ class Potion::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associat
   sig { params(block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
   def unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def select(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def order(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def group(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def limit(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def offset(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def where(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def preload(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def includes(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def from(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def lock(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def or(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def having(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def references(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def none(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def except(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def except(*args); end
 
   sig { params(args: T.untyped).returns(Potion) }
   def find(*args); end

--- a/spec/test_data/v5.0/expected_potion.rbi
+++ b/spec/test_data/v5.0/expected_potion.rbi
@@ -110,6 +110,9 @@ class Potion < ApplicationRecord
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
   def self.except(*args); end
 
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
+  def self.extending(*args, &block); end
+
   sig { params(args: T.untyped).returns(Potion) }
   def self.find(*args); end
 
@@ -268,6 +271,9 @@ class Potion::ActiveRecord_Relation < ActiveRecord::Relation
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
   def except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
+  def extending(*args, &block); end
 
   sig { params(args: T.untyped).returns(Potion) }
   def find(*args); end
@@ -436,6 +442,9 @@ class Potion::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelati
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
   def except(*args); end
 
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
+  def extending(*args, &block); end
+
   sig { params(args: T.untyped).returns(Potion) }
   def find(*args); end
 
@@ -601,6 +610,9 @@ class Potion::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associat
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
   def except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
+  def extending(*args, &block); end
 
   sig { params(args: T.untyped).returns(Potion) }
   def find(*args); end

--- a/spec/test_data/v5.0/expected_schema_migration.rbi
+++ b/spec/test_data/v5.0/expected_schema_migration.rbi
@@ -49,80 +49,80 @@ class ActiveRecord::SchemaMigration < ActiveRecord::Base
   sig { params(block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
   def self.unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.select(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def self.select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.order(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def self.order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def self.reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.group(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def self.group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.limit(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def self.limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.offset(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def self.offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def self.joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def self.left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def self.left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.where(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def self.where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def self.rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.preload(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def self.preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def self.eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.includes(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def self.includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.from(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def self.from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.lock(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def self.lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def self.readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.or(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def self.or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.having(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def self.having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def self.create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def self.distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.references(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def self.references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.none(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def self.none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def self.unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.except(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def self.except(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration) }
   def self.find(*args); end
@@ -208,80 +208,80 @@ class ActiveRecord::SchemaMigration::ActiveRecord_Relation < ActiveRecord::Relat
   sig { params(block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
   def unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def select(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def order(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def group(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def limit(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def offset(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def where(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def preload(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def includes(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def from(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def lock(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def or(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def having(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def references(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def none(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def except(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def except(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration) }
   def find(*args); end
@@ -375,80 +375,80 @@ class ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation < ActiveRe
   sig { params(block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
   def unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def select(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def order(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def group(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def limit(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def offset(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def where(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def preload(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def includes(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def from(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def lock(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def or(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def having(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def references(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def none(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def except(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def except(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration) }
   def find(*args); end
@@ -541,80 +541,80 @@ class ActiveRecord::SchemaMigration::ActiveRecord_Associations_CollectionProxy <
   sig { params(block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
   def unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def select(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def order(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def group(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def limit(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def offset(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def where(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def preload(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def includes(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def from(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def lock(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def or(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def having(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def references(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def none(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def except(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def except(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration) }
   def find(*args); end

--- a/spec/test_data/v5.0/expected_schema_migration.rbi
+++ b/spec/test_data/v5.0/expected_schema_migration.rbi
@@ -124,6 +124,9 @@ class ActiveRecord::SchemaMigration < ActiveRecord::Base
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
   def self.except(*args); end
 
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def self.extending(*args, &block); end
+
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration) }
   def self.find(*args); end
 
@@ -282,6 +285,9 @@ class ActiveRecord::SchemaMigration::ActiveRecord_Relation < ActiveRecord::Relat
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
   def except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def extending(*args, &block); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration) }
   def find(*args); end
@@ -450,6 +456,9 @@ class ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation < ActiveRe
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
   def except(*args); end
 
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def extending(*args, &block); end
+
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration) }
   def find(*args); end
 
@@ -615,6 +624,9 @@ class ActiveRecord::SchemaMigration::ActiveRecord_Associations_CollectionProxy <
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
   def except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def extending(*args, &block); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration) }
   def find(*args); end

--- a/spec/test_data/v5.0/expected_spell_book.rbi
+++ b/spec/test_data/v5.0/expected_spell_book.rbi
@@ -122,80 +122,80 @@ class SpellBook < ApplicationRecord
   sig { params(block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def self.unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def self.select(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def self.select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def self.order(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def self.order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def self.reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def self.reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def self.group(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def self.group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def self.limit(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def self.limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def self.offset(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def self.offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def self.joins(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def self.joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def self.left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def self.left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def self.left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def self.left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def self.where(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def self.where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def self.rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def self.rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def self.preload(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def self.preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def self.eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def self.eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def self.includes(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def self.includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def self.from(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def self.from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def self.lock(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def self.lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def self.readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def self.readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def self.or(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def self.or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def self.having(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def self.having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def self.create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def self.create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def self.distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def self.distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def self.references(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def self.references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def self.none(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def self.none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def self.unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def self.unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def self.except(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def self.except(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook) }
   def self.find(*args); end
@@ -290,80 +290,80 @@ class SpellBook::ActiveRecord_Relation < ActiveRecord::Relation
   sig { params(block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def select(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def order(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def group(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def limit(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def offset(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def joins(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def where(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def preload(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def includes(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def from(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def lock(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def or(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def having(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def references(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def none(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def except(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def except(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook) }
   def find(*args); end
@@ -466,80 +466,80 @@ class SpellBook::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRel
   sig { params(block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
   def unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def select(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def order(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def group(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def limit(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def offset(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def joins(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def where(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def preload(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def includes(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def from(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def lock(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def or(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def having(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def references(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def none(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def except(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def except(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook) }
   def find(*args); end
@@ -641,80 +641,80 @@ class SpellBook::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Assoc
   sig { params(block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
   def unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def select(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def order(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def group(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def limit(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def offset(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def joins(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def where(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def preload(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def includes(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def from(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def lock(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def or(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def having(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def references(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def none(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def except(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def except(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook) }
   def find(*args); end

--- a/spec/test_data/v5.0/expected_spell_book.rbi
+++ b/spec/test_data/v5.0/expected_spell_book.rbi
@@ -197,6 +197,9 @@ class SpellBook < ApplicationRecord
   sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
   def self.except(*args); end
 
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
+  def self.extending(*args, &block); end
+
   sig { params(args: T.untyped).returns(SpellBook) }
   def self.find(*args); end
 
@@ -364,6 +367,9 @@ class SpellBook::ActiveRecord_Relation < ActiveRecord::Relation
 
   sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
   def except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
+  def extending(*args, &block); end
 
   sig { params(args: T.untyped).returns(SpellBook) }
   def find(*args); end
@@ -541,6 +547,9 @@ class SpellBook::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRel
   sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
   def except(*args); end
 
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def extending(*args, &block); end
+
   sig { params(args: T.untyped).returns(SpellBook) }
   def find(*args); end
 
@@ -715,6 +724,9 @@ class SpellBook::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Assoc
 
   sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
   def except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def extending(*args, &block); end
 
   sig { params(args: T.untyped).returns(SpellBook) }
   def find(*args); end

--- a/spec/test_data/v5.0/expected_squib.rbi
+++ b/spec/test_data/v5.0/expected_squib.rbi
@@ -428,6 +428,9 @@ class Squib < Wizard
   sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
   def self.except(*args); end
 
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
+  def self.extending(*args, &block); end
+
   sig { params(args: T.untyped).returns(Squib) }
   def self.find(*args); end
 
@@ -640,6 +643,9 @@ class Squib::ActiveRecord_Relation < ActiveRecord::Relation
 
   sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
   def except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
+  def extending(*args, &block); end
 
   sig { params(args: T.untyped).returns(Squib) }
   def find(*args); end
@@ -862,6 +868,9 @@ class Squib::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelatio
   sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
   def except(*args); end
 
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
+  def extending(*args, &block); end
+
   sig { params(args: T.untyped).returns(Squib) }
   def find(*args); end
 
@@ -1081,6 +1090,9 @@ class Squib::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associati
 
   sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
   def except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
+  def extending(*args, &block); end
 
   sig { params(args: T.untyped).returns(Squib) }
   def find(*args); end

--- a/spec/test_data/v5.0/expected_squib.rbi
+++ b/spec/test_data/v5.0/expected_squib.rbi
@@ -353,80 +353,80 @@ class Squib < Wizard
   sig { params(block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
   def self.unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def self.select(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def self.order(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def self.reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def self.group(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def self.limit(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def self.offset(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def self.joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def self.left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def self.left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def self.where(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def self.rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def self.preload(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def self.eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def self.includes(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def self.from(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def self.lock(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def self.readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def self.or(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def self.having(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def self.create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def self.distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def self.references(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def self.none(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def self.unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def self.except(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.except(*args); end
 
   sig { params(args: T.untyped).returns(Squib) }
   def self.find(*args); end
@@ -566,80 +566,80 @@ class Squib::ActiveRecord_Relation < ActiveRecord::Relation
   sig { params(block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
   def unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def select(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def order(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def group(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def limit(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def offset(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def where(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def preload(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def includes(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def from(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def lock(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def or(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def having(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def references(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def none(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def except(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def except(*args); end
 
   sig { params(args: T.untyped).returns(Squib) }
   def find(*args); end
@@ -787,80 +787,80 @@ class Squib::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelatio
   sig { params(block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
   def unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def select(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def order(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def group(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def limit(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def offset(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def where(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def preload(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def includes(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def from(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def lock(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def or(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def having(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def references(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def none(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def except(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def except(*args); end
 
   sig { params(args: T.untyped).returns(Squib) }
   def find(*args); end
@@ -1007,80 +1007,80 @@ class Squib::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associati
   sig { params(block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
   def unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def select(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def order(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def group(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def limit(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def offset(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def where(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def preload(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def includes(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def from(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def lock(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def or(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def having(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def references(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def none(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def except(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def except(*args); end
 
   sig { params(args: T.untyped).returns(Squib) }
   def find(*args); end

--- a/spec/test_data/v5.0/expected_wand.rbi
+++ b/spec/test_data/v5.0/expected_wand.rbi
@@ -287,6 +287,9 @@ class Wand < ApplicationRecord
   sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
   def self.except(*args); end
 
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
+  def self.extending(*args, &block); end
+
   sig { params(args: T.untyped).returns(Wand) }
   def self.find(*args); end
 
@@ -460,6 +463,9 @@ class Wand::ActiveRecord_Relation < ActiveRecord::Relation
 
   sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
   def except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
+  def extending(*args, &block); end
 
   sig { params(args: T.untyped).returns(Wand) }
   def find(*args); end
@@ -640,6 +646,9 @@ class Wand::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
   sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
   def except(*args); end
 
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
+  def extending(*args, &block); end
+
   sig { params(args: T.untyped).returns(Wand) }
   def find(*args); end
 
@@ -817,6 +826,9 @@ class Wand::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associatio
 
   sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
   def except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
+  def extending(*args, &block); end
 
   sig { params(args: T.untyped).returns(Wand) }
   def find(*args); end

--- a/spec/test_data/v5.0/expected_wand.rbi
+++ b/spec/test_data/v5.0/expected_wand.rbi
@@ -212,80 +212,80 @@ class Wand < ApplicationRecord
   sig { params(block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def self.unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def self.select(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def self.order(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def self.reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def self.group(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def self.limit(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def self.offset(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def self.joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def self.left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def self.left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def self.where(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def self.rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def self.preload(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def self.eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def self.includes(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def self.from(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def self.lock(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def self.readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def self.or(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def self.having(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def self.create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def self.distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def self.references(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def self.none(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def self.unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def self.except(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.except(*args); end
 
   sig { params(args: T.untyped).returns(Wand) }
   def self.find(*args); end
@@ -386,80 +386,80 @@ class Wand::ActiveRecord_Relation < ActiveRecord::Relation
   sig { params(block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def select(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def order(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def group(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def limit(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def offset(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def where(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def preload(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def includes(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def from(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def lock(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def or(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def having(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def references(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def none(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def except(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def except(*args); end
 
   sig { params(args: T.untyped).returns(Wand) }
   def find(*args); end
@@ -565,80 +565,80 @@ class Wand::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
   sig { params(block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
   def unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def select(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def order(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def group(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def limit(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def offset(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def where(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def preload(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def includes(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def from(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def lock(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def or(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def having(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def references(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def none(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def except(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def except(*args); end
 
   sig { params(args: T.untyped).returns(Wand) }
   def find(*args); end
@@ -743,80 +743,80 @@ class Wand::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associatio
   sig { params(block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
   def unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def select(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def order(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def group(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def limit(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def offset(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def where(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def preload(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def includes(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def from(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def lock(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def or(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def having(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def references(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def none(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def except(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def except(*args); end
 
   sig { params(args: T.untyped).returns(Wand) }
   def find(*args); end

--- a/spec/test_data/v5.0/expected_wizard.rbi
+++ b/spec/test_data/v5.0/expected_wizard.rbi
@@ -353,80 +353,80 @@ class Wizard < ApplicationRecord
   sig { params(block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def self.unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.select(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.order(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.group(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.limit(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.offset(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.where(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.preload(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.includes(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.from(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.lock(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.or(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.having(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.references(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.none(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.except(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.except(*args); end
 
   sig { params(args: T.untyped).returns(Wizard) }
   def self.find(*args); end
@@ -566,80 +566,80 @@ class Wizard::ActiveRecord_Relation < ActiveRecord::Relation
   sig { params(block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def select(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def order(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def group(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def limit(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def offset(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def where(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def preload(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def includes(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def from(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def lock(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def or(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def having(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def references(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def none(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def except(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def except(*args); end
 
   sig { params(args: T.untyped).returns(Wizard) }
   def find(*args); end
@@ -787,80 +787,80 @@ class Wizard::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelati
   sig { params(block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
   def unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def select(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def order(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def group(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def limit(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def offset(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def where(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def preload(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def includes(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def from(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def lock(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def or(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def having(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def references(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def none(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def except(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def except(*args); end
 
   sig { params(args: T.untyped).returns(Wizard) }
   def find(*args); end
@@ -1007,80 +1007,80 @@ class Wizard::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associat
   sig { params(block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
   def unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def select(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def order(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def group(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def limit(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def offset(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def where(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def preload(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def includes(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def from(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def lock(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def or(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def having(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def references(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def none(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def except(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def except(*args); end
 
   sig { params(args: T.untyped).returns(Wizard) }
   def find(*args); end

--- a/spec/test_data/v5.0/expected_wizard.rbi
+++ b/spec/test_data/v5.0/expected_wizard.rbi
@@ -428,6 +428,9 @@ class Wizard < ApplicationRecord
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
   def self.except(*args); end
 
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
+  def self.extending(*args, &block); end
+
   sig { params(args: T.untyped).returns(Wizard) }
   def self.find(*args); end
 
@@ -640,6 +643,9 @@ class Wizard::ActiveRecord_Relation < ActiveRecord::Relation
 
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
   def except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
+  def extending(*args, &block); end
 
   sig { params(args: T.untyped).returns(Wizard) }
   def find(*args); end
@@ -862,6 +868,9 @@ class Wizard::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelati
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
   def except(*args); end
 
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def extending(*args, &block); end
+
   sig { params(args: T.untyped).returns(Wizard) }
   def find(*args); end
 
@@ -1081,6 +1090,9 @@ class Wizard::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associat
 
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
   def except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def extending(*args, &block); end
 
   sig { params(args: T.untyped).returns(Wizard) }
   def find(*args); end

--- a/spec/test_data/v5.0/expected_wizard_wo_spellbook.rbi
+++ b/spec/test_data/v5.0/expected_wizard_wo_spellbook.rbi
@@ -353,80 +353,80 @@ class Wizard < ApplicationRecord
   sig { params(block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def self.unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.select(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.order(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.group(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.limit(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.offset(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.where(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.preload(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.includes(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.from(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.lock(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.or(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.having(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.references(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.none(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.except(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.except(*args); end
 
   sig { params(args: T.untyped).returns(Wizard) }
   def self.find(*args); end
@@ -566,80 +566,80 @@ class Wizard::ActiveRecord_Relation < ActiveRecord::Relation
   sig { params(block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def select(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def order(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def group(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def limit(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def offset(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def where(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def preload(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def includes(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def from(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def lock(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def or(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def having(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def references(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def none(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def except(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def except(*args); end
 
   sig { params(args: T.untyped).returns(Wizard) }
   def find(*args); end
@@ -787,80 +787,80 @@ class Wizard::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelati
   sig { params(block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
   def unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def select(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def order(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def group(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def limit(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def offset(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def where(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def preload(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def includes(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def from(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def lock(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def or(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def having(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def references(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def none(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def except(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def except(*args); end
 
   sig { params(args: T.untyped).returns(Wizard) }
   def find(*args); end
@@ -1007,80 +1007,80 @@ class Wizard::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associat
   sig { params(block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
   def unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def select(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def order(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def group(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def limit(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def offset(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def where(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def preload(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def includes(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def from(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def lock(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def or(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def having(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def references(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def none(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def except(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def except(*args); end
 
   sig { params(args: T.untyped).returns(Wizard) }
   def find(*args); end

--- a/spec/test_data/v5.0/expected_wizard_wo_spellbook.rbi
+++ b/spec/test_data/v5.0/expected_wizard_wo_spellbook.rbi
@@ -428,6 +428,9 @@ class Wizard < ApplicationRecord
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
   def self.except(*args); end
 
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
+  def self.extending(*args, &block); end
+
   sig { params(args: T.untyped).returns(Wizard) }
   def self.find(*args); end
 
@@ -640,6 +643,9 @@ class Wizard::ActiveRecord_Relation < ActiveRecord::Relation
 
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
   def except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
+  def extending(*args, &block); end
 
   sig { params(args: T.untyped).returns(Wizard) }
   def find(*args); end
@@ -862,6 +868,9 @@ class Wizard::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelati
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
   def except(*args); end
 
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def extending(*args, &block); end
+
   sig { params(args: T.untyped).returns(Wizard) }
   def find(*args); end
 
@@ -1081,6 +1090,9 @@ class Wizard::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associat
 
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
   def except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def extending(*args, &block); end
 
   sig { params(args: T.untyped).returns(Wizard) }
   def find(*args); end

--- a/spec/test_data/v5.1/expected_internal_metadata.rbi
+++ b/spec/test_data/v5.1/expected_internal_metadata.rbi
@@ -76,86 +76,86 @@ class ActiveRecord::InternalMetadata < ActiveRecord::Base
   sig { params(block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
   def self.unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.select(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def self.select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.order(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def self.order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def self.reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.group(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def self.group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.limit(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def self.limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.offset(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def self.offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def self.joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def self.left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def self.left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.where(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def self.where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def self.rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.preload(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def self.preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def self.eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.includes(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def self.includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.from(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def self.from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.lock(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def self.lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def self.readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.extending(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def self.extending(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.or(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def self.or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.having(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def self.having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def self.create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def self.distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.references(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def self.references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.none(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def self.none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def self.unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.merge(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def self.merge(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.except(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def self.except(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata) }
   def self.find(*args); end
@@ -241,86 +241,86 @@ class ActiveRecord::InternalMetadata::ActiveRecord_Relation < ActiveRecord::Rela
   sig { params(block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
   def unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def select(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def order(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def group(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def limit(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def offset(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def where(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def preload(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def includes(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def from(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def lock(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def extending(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def extending(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def or(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def having(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def references(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def none(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def merge(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def merge(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def except(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def except(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata) }
   def find(*args); end
@@ -414,86 +414,86 @@ class ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation < ActiveR
   sig { params(block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
   def unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def select(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def order(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def group(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def limit(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def offset(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def where(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def preload(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def includes(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def from(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def lock(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def extending(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def or(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def having(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def references(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def none(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def merge(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def merge(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def except(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def except(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata) }
   def find(*args); end
@@ -586,86 +586,86 @@ class ActiveRecord::InternalMetadata::ActiveRecord_Associations_CollectionProxy 
   sig { params(block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
   def unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def select(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def order(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def group(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def limit(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def offset(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def where(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def preload(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def includes(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def from(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def lock(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def extending(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def or(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def having(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def references(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def none(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def merge(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def merge(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def except(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def except(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata) }
   def find(*args); end

--- a/spec/test_data/v5.1/expected_internal_metadata.rbi
+++ b/spec/test_data/v5.1/expected_internal_metadata.rbi
@@ -128,9 +128,6 @@ class ActiveRecord::InternalMetadata < ActiveRecord::Base
   def self.readonly(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.extending(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
   def self.or(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
@@ -156,6 +153,9 @@ class ActiveRecord::InternalMetadata < ActiveRecord::Base
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
   def self.except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def self.extending(*args, &block); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata) }
   def self.find(*args); end
@@ -293,9 +293,6 @@ class ActiveRecord::InternalMetadata::ActiveRecord_Relation < ActiveRecord::Rela
   def readonly(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def extending(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
   def or(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
@@ -321,6 +318,9 @@ class ActiveRecord::InternalMetadata::ActiveRecord_Relation < ActiveRecord::Rela
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
   def except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def extending(*args, &block); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata) }
   def find(*args); end
@@ -466,9 +466,6 @@ class ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation < ActiveR
   def readonly(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def extending(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
   def or(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
@@ -494,6 +491,9 @@ class ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation < ActiveR
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
   def except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def extending(*args, &block); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata) }
   def find(*args); end
@@ -638,9 +638,6 @@ class ActiveRecord::InternalMetadata::ActiveRecord_Associations_CollectionProxy 
   def readonly(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def extending(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
   def or(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
@@ -666,6 +663,9 @@ class ActiveRecord::InternalMetadata::ActiveRecord_Associations_CollectionProxy 
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
   def except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def extending(*args, &block); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata) }
   def find(*args); end

--- a/spec/test_data/v5.1/expected_potion.rbi
+++ b/spec/test_data/v5.1/expected_potion.rbi
@@ -87,9 +87,6 @@ class Potion < ApplicationRecord
   def self.readonly(*args); end
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def self.extending(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
   def self.or(*args); end
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
@@ -115,6 +112,9 @@ class Potion < ApplicationRecord
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
   def self.except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
+  def self.extending(*args, &block); end
 
   sig { params(args: T.untyped).returns(Potion) }
   def self.find(*args); end
@@ -252,9 +252,6 @@ class Potion::ActiveRecord_Relation < ActiveRecord::Relation
   def readonly(*args); end
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def extending(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
   def or(*args); end
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
@@ -280,6 +277,9 @@ class Potion::ActiveRecord_Relation < ActiveRecord::Relation
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
   def except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
+  def extending(*args, &block); end
 
   sig { params(args: T.untyped).returns(Potion) }
   def find(*args); end
@@ -425,9 +425,6 @@ class Potion::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelati
   def readonly(*args); end
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def extending(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
   def or(*args); end
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
@@ -453,6 +450,9 @@ class Potion::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelati
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
   def except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
+  def extending(*args, &block); end
 
   sig { params(args: T.untyped).returns(Potion) }
   def find(*args); end
@@ -597,9 +597,6 @@ class Potion::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associat
   def readonly(*args); end
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def extending(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
   def or(*args); end
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
@@ -625,6 +622,9 @@ class Potion::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associat
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
   def except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
+  def extending(*args, &block); end
 
   sig { params(args: T.untyped).returns(Potion) }
   def find(*args); end

--- a/spec/test_data/v5.1/expected_potion.rbi
+++ b/spec/test_data/v5.1/expected_potion.rbi
@@ -35,86 +35,86 @@ class Potion < ApplicationRecord
   sig { params(block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def self.unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def self.select(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def self.select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def self.order(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def self.order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def self.reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def self.reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def self.group(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def self.group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def self.limit(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def self.limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def self.offset(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def self.offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def self.joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def self.joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def self.left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def self.left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def self.left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def self.left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def self.where(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def self.where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def self.rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def self.rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def self.preload(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def self.preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def self.eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def self.eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def self.includes(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def self.includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def self.from(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def self.from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def self.lock(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def self.lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def self.readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def self.readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def self.extending(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def self.extending(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def self.or(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def self.or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def self.having(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def self.having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def self.create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def self.create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def self.distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def self.distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def self.references(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def self.references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def self.none(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def self.none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def self.unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def self.unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def self.merge(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def self.merge(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def self.except(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def self.except(*args); end
 
   sig { params(args: T.untyped).returns(Potion) }
   def self.find(*args); end
@@ -200,86 +200,86 @@ class Potion::ActiveRecord_Relation < ActiveRecord::Relation
   sig { params(block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def select(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def order(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def group(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def limit(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def offset(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def where(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def preload(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def includes(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def from(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def lock(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def extending(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def extending(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def or(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def having(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def references(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def none(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def merge(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def merge(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def except(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def except(*args); end
 
   sig { params(args: T.untyped).returns(Potion) }
   def find(*args); end
@@ -373,86 +373,86 @@ class Potion::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelati
   sig { params(block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
   def unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def select(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def order(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def group(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def limit(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def offset(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def where(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def preload(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def includes(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def from(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def lock(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def extending(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def or(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def having(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def references(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def none(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def merge(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def merge(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def except(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def except(*args); end
 
   sig { params(args: T.untyped).returns(Potion) }
   def find(*args); end
@@ -545,86 +545,86 @@ class Potion::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associat
   sig { params(block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
   def unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def select(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def order(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def group(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def limit(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def offset(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def where(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def preload(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def includes(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def from(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def lock(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def extending(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def or(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def having(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def references(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def none(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def merge(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def merge(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def except(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def except(*args); end
 
   sig { params(args: T.untyped).returns(Potion) }
   def find(*args); end

--- a/spec/test_data/v5.1/expected_schema_migration.rbi
+++ b/spec/test_data/v5.1/expected_schema_migration.rbi
@@ -101,9 +101,6 @@ class ActiveRecord::SchemaMigration < ActiveRecord::Base
   def self.readonly(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.extending(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
   def self.or(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
@@ -129,6 +126,9 @@ class ActiveRecord::SchemaMigration < ActiveRecord::Base
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
   def self.except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def self.extending(*args, &block); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration) }
   def self.find(*args); end
@@ -266,9 +266,6 @@ class ActiveRecord::SchemaMigration::ActiveRecord_Relation < ActiveRecord::Relat
   def readonly(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def extending(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
   def or(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
@@ -294,6 +291,9 @@ class ActiveRecord::SchemaMigration::ActiveRecord_Relation < ActiveRecord::Relat
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
   def except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def extending(*args, &block); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration) }
   def find(*args); end
@@ -439,9 +439,6 @@ class ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation < ActiveRe
   def readonly(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def extending(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
   def or(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
@@ -467,6 +464,9 @@ class ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation < ActiveRe
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
   def except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def extending(*args, &block); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration) }
   def find(*args); end
@@ -611,9 +611,6 @@ class ActiveRecord::SchemaMigration::ActiveRecord_Associations_CollectionProxy <
   def readonly(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def extending(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
   def or(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
@@ -639,6 +636,9 @@ class ActiveRecord::SchemaMigration::ActiveRecord_Associations_CollectionProxy <
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
   def except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def extending(*args, &block); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration) }
   def find(*args); end

--- a/spec/test_data/v5.1/expected_schema_migration.rbi
+++ b/spec/test_data/v5.1/expected_schema_migration.rbi
@@ -49,86 +49,86 @@ class ActiveRecord::SchemaMigration < ActiveRecord::Base
   sig { params(block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
   def self.unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.select(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def self.select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.order(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def self.order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def self.reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.group(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def self.group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.limit(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def self.limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.offset(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def self.offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def self.joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def self.left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def self.left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.where(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def self.where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def self.rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.preload(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def self.preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def self.eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.includes(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def self.includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.from(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def self.from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.lock(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def self.lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def self.readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.extending(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def self.extending(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.or(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def self.or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.having(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def self.having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def self.create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def self.distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.references(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def self.references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.none(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def self.none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def self.unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.merge(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def self.merge(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.except(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def self.except(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration) }
   def self.find(*args); end
@@ -214,86 +214,86 @@ class ActiveRecord::SchemaMigration::ActiveRecord_Relation < ActiveRecord::Relat
   sig { params(block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
   def unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def select(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def order(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def group(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def limit(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def offset(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def where(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def preload(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def includes(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def from(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def lock(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def extending(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def extending(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def or(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def having(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def references(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def none(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def merge(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def merge(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def except(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def except(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration) }
   def find(*args); end
@@ -387,86 +387,86 @@ class ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation < ActiveRe
   sig { params(block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
   def unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def select(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def order(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def group(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def limit(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def offset(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def where(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def preload(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def includes(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def from(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def lock(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def extending(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def or(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def having(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def references(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def none(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def merge(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def merge(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def except(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def except(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration) }
   def find(*args); end
@@ -559,86 +559,86 @@ class ActiveRecord::SchemaMigration::ActiveRecord_Associations_CollectionProxy <
   sig { params(block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
   def unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def select(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def order(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def group(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def limit(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def offset(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def where(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def preload(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def includes(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def from(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def lock(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def extending(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def or(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def having(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def references(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def none(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def merge(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def merge(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def except(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def except(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration) }
   def find(*args); end

--- a/spec/test_data/v5.1/expected_spell_book.rbi
+++ b/spec/test_data/v5.1/expected_spell_book.rbi
@@ -174,9 +174,6 @@ class SpellBook < ApplicationRecord
   def self.readonly(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def self.extending(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
   def self.or(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
@@ -202,6 +199,9 @@ class SpellBook < ApplicationRecord
 
   sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
   def self.except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
+  def self.extending(*args, &block); end
 
   sig { params(args: T.untyped).returns(SpellBook) }
   def self.find(*args); end
@@ -348,9 +348,6 @@ class SpellBook::ActiveRecord_Relation < ActiveRecord::Relation
   def readonly(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def extending(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
   def or(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
@@ -376,6 +373,9 @@ class SpellBook::ActiveRecord_Relation < ActiveRecord::Relation
 
   sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
   def except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
+  def extending(*args, &block); end
 
   sig { params(args: T.untyped).returns(SpellBook) }
   def find(*args); end
@@ -530,9 +530,6 @@ class SpellBook::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRel
   def readonly(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def extending(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
   def or(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
@@ -558,6 +555,9 @@ class SpellBook::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRel
 
   sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
   def except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def extending(*args, &block); end
 
   sig { params(args: T.untyped).returns(SpellBook) }
   def find(*args); end
@@ -711,9 +711,6 @@ class SpellBook::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Assoc
   def readonly(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def extending(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
   def or(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
@@ -739,6 +736,9 @@ class SpellBook::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Assoc
 
   sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
   def except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def extending(*args, &block); end
 
   sig { params(args: T.untyped).returns(SpellBook) }
   def find(*args); end

--- a/spec/test_data/v5.1/expected_spell_book.rbi
+++ b/spec/test_data/v5.1/expected_spell_book.rbi
@@ -122,86 +122,86 @@ class SpellBook < ApplicationRecord
   sig { params(block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def self.unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def self.select(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def self.select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def self.order(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def self.order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def self.reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def self.reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def self.group(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def self.group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def self.limit(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def self.limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def self.offset(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def self.offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def self.joins(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def self.joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def self.left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def self.left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def self.left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def self.left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def self.where(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def self.where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def self.rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def self.rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def self.preload(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def self.preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def self.eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def self.eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def self.includes(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def self.includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def self.from(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def self.from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def self.lock(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def self.lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def self.readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def self.readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def self.extending(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def self.extending(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def self.or(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def self.or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def self.having(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def self.having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def self.create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def self.create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def self.distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def self.distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def self.references(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def self.references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def self.none(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def self.none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def self.unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def self.unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def self.merge(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def self.merge(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def self.except(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def self.except(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook) }
   def self.find(*args); end
@@ -296,86 +296,86 @@ class SpellBook::ActiveRecord_Relation < ActiveRecord::Relation
   sig { params(block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def select(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def order(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def group(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def limit(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def offset(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def joins(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def where(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def preload(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def includes(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def from(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def lock(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def extending(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def extending(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def or(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def having(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def references(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def none(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def merge(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def merge(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def except(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def except(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook) }
   def find(*args); end
@@ -478,86 +478,86 @@ class SpellBook::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRel
   sig { params(block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
   def unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def select(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def order(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def group(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def limit(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def offset(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def joins(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def where(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def preload(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def includes(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def from(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def lock(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def extending(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def or(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def having(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def references(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def none(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def merge(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def merge(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def except(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def except(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook) }
   def find(*args); end
@@ -659,86 +659,86 @@ class SpellBook::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Assoc
   sig { params(block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
   def unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def select(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def order(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def group(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def limit(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def offset(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def joins(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def where(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def preload(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def includes(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def from(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def lock(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def extending(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def or(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def having(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def references(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def none(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def merge(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def merge(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def except(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def except(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook) }
   def find(*args); end

--- a/spec/test_data/v5.1/expected_squib.rbi
+++ b/spec/test_data/v5.1/expected_squib.rbi
@@ -405,9 +405,6 @@ class Squib < Wizard
   def self.readonly(*args); end
 
   sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.extending(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
   def self.or(*args); end
 
   sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
@@ -433,6 +430,9 @@ class Squib < Wizard
 
   sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
   def self.except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
+  def self.extending(*args, &block); end
 
   sig { params(args: T.untyped).returns(Squib) }
   def self.find(*args); end
@@ -624,9 +624,6 @@ class Squib::ActiveRecord_Relation < ActiveRecord::Relation
   def readonly(*args); end
 
   sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def extending(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
   def or(*args); end
 
   sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
@@ -652,6 +649,9 @@ class Squib::ActiveRecord_Relation < ActiveRecord::Relation
 
   sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
   def except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
+  def extending(*args, &block); end
 
   sig { params(args: T.untyped).returns(Squib) }
   def find(*args); end
@@ -851,9 +851,6 @@ class Squib::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelatio
   def readonly(*args); end
 
   sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def extending(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
   def or(*args); end
 
   sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
@@ -879,6 +876,9 @@ class Squib::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelatio
 
   sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
   def except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
+  def extending(*args, &block); end
 
   sig { params(args: T.untyped).returns(Squib) }
   def find(*args); end
@@ -1077,9 +1077,6 @@ class Squib::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associati
   def readonly(*args); end
 
   sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def extending(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
   def or(*args); end
 
   sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
@@ -1105,6 +1102,9 @@ class Squib::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associati
 
   sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
   def except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
+  def extending(*args, &block); end
 
   sig { params(args: T.untyped).returns(Squib) }
   def find(*args); end

--- a/spec/test_data/v5.1/expected_squib.rbi
+++ b/spec/test_data/v5.1/expected_squib.rbi
@@ -353,86 +353,86 @@ class Squib < Wizard
   sig { params(block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
   def self.unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def self.select(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def self.order(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def self.reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def self.group(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def self.limit(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def self.offset(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def self.joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def self.left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def self.left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def self.where(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def self.rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def self.preload(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def self.eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def self.includes(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def self.from(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def self.lock(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def self.readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def self.extending(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.extending(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def self.or(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def self.having(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def self.create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def self.distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def self.references(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def self.none(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def self.unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def self.merge(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.merge(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def self.except(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.except(*args); end
 
   sig { params(args: T.untyped).returns(Squib) }
   def self.find(*args); end
@@ -572,86 +572,86 @@ class Squib::ActiveRecord_Relation < ActiveRecord::Relation
   sig { params(block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
   def unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def select(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def order(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def group(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def limit(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def offset(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def where(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def preload(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def includes(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def from(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def lock(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def extending(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def extending(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def or(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def having(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def references(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def none(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def merge(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def merge(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def except(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def except(*args); end
 
   sig { params(args: T.untyped).returns(Squib) }
   def find(*args); end
@@ -799,86 +799,86 @@ class Squib::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelatio
   sig { params(block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
   def unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def select(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def order(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def group(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def limit(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def offset(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def where(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def preload(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def includes(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def from(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def lock(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def extending(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def or(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def having(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def references(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def none(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def merge(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def merge(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def except(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def except(*args); end
 
   sig { params(args: T.untyped).returns(Squib) }
   def find(*args); end
@@ -1025,86 +1025,86 @@ class Squib::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associati
   sig { params(block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
   def unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def select(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def order(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def group(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def limit(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def offset(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def where(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def preload(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def includes(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def from(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def lock(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def extending(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def or(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def having(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def references(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def none(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def merge(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def merge(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def except(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def except(*args); end
 
   sig { params(args: T.untyped).returns(Squib) }
   def find(*args); end

--- a/spec/test_data/v5.1/expected_wand.rbi
+++ b/spec/test_data/v5.1/expected_wand.rbi
@@ -212,86 +212,86 @@ class Wand < ApplicationRecord
   sig { params(block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def self.unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def self.select(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def self.order(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def self.reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def self.group(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def self.limit(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def self.offset(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def self.joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def self.left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def self.left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def self.where(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def self.rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def self.preload(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def self.eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def self.includes(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def self.from(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def self.lock(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def self.readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def self.extending(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.extending(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def self.or(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def self.having(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def self.create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def self.distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def self.references(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def self.none(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def self.unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def self.merge(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.merge(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def self.except(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.except(*args); end
 
   sig { params(args: T.untyped).returns(Wand) }
   def self.find(*args); end
@@ -392,86 +392,86 @@ class Wand::ActiveRecord_Relation < ActiveRecord::Relation
   sig { params(block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def select(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def order(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def group(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def limit(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def offset(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def where(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def preload(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def includes(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def from(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def lock(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def extending(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def extending(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def or(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def having(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def references(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def none(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def merge(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def merge(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def except(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def except(*args); end
 
   sig { params(args: T.untyped).returns(Wand) }
   def find(*args); end
@@ -577,86 +577,86 @@ class Wand::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
   sig { params(block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
   def unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def select(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def order(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def group(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def limit(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def offset(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def where(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def preload(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def includes(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def from(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def lock(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def extending(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def or(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def having(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def references(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def none(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def merge(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def merge(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def except(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def except(*args); end
 
   sig { params(args: T.untyped).returns(Wand) }
   def find(*args); end
@@ -761,86 +761,86 @@ class Wand::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associatio
   sig { params(block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
   def unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def select(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def order(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def group(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def limit(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def offset(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def where(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def preload(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def includes(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def from(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def lock(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def extending(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def or(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def having(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def references(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def none(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def merge(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def merge(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def except(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def except(*args); end
 
   sig { params(args: T.untyped).returns(Wand) }
   def find(*args); end

--- a/spec/test_data/v5.1/expected_wand.rbi
+++ b/spec/test_data/v5.1/expected_wand.rbi
@@ -264,9 +264,6 @@ class Wand < ApplicationRecord
   def self.readonly(*args); end
 
   sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
-  def self.extending(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
   def self.or(*args); end
 
   sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
@@ -292,6 +289,9 @@ class Wand < ApplicationRecord
 
   sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
   def self.except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
+  def self.extending(*args, &block); end
 
   sig { params(args: T.untyped).returns(Wand) }
   def self.find(*args); end
@@ -444,9 +444,6 @@ class Wand::ActiveRecord_Relation < ActiveRecord::Relation
   def readonly(*args); end
 
   sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
-  def extending(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
   def or(*args); end
 
   sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
@@ -472,6 +469,9 @@ class Wand::ActiveRecord_Relation < ActiveRecord::Relation
 
   sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
   def except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
+  def extending(*args, &block); end
 
   sig { params(args: T.untyped).returns(Wand) }
   def find(*args); end
@@ -629,9 +629,6 @@ class Wand::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
   def readonly(*args); end
 
   sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def extending(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
   def or(*args); end
 
   sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
@@ -657,6 +654,9 @@ class Wand::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
 
   sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
   def except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
+  def extending(*args, &block); end
 
   sig { params(args: T.untyped).returns(Wand) }
   def find(*args); end
@@ -813,9 +813,6 @@ class Wand::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associatio
   def readonly(*args); end
 
   sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def extending(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
   def or(*args); end
 
   sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
@@ -841,6 +838,9 @@ class Wand::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associatio
 
   sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
   def except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
+  def extending(*args, &block); end
 
   sig { params(args: T.untyped).returns(Wand) }
   def find(*args); end

--- a/spec/test_data/v5.1/expected_wizard.rbi
+++ b/spec/test_data/v5.1/expected_wizard.rbi
@@ -353,86 +353,86 @@ class Wizard < ApplicationRecord
   sig { params(block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def self.unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.select(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.order(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.group(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.limit(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.offset(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.where(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.preload(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.includes(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.from(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.lock(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.extending(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.extending(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.or(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.having(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.references(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.none(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.merge(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.merge(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.except(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.except(*args); end
 
   sig { params(args: T.untyped).returns(Wizard) }
   def self.find(*args); end
@@ -572,86 +572,86 @@ class Wizard::ActiveRecord_Relation < ActiveRecord::Relation
   sig { params(block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def select(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def order(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def group(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def limit(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def offset(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def where(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def preload(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def includes(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def from(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def lock(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def extending(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def extending(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def or(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def having(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def references(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def none(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def merge(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def merge(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def except(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def except(*args); end
 
   sig { params(args: T.untyped).returns(Wizard) }
   def find(*args); end
@@ -799,86 +799,86 @@ class Wizard::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelati
   sig { params(block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
   def unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def select(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def order(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def group(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def limit(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def offset(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def where(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def preload(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def includes(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def from(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def lock(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def extending(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def or(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def having(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def references(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def none(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def merge(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def merge(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def except(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def except(*args); end
 
   sig { params(args: T.untyped).returns(Wizard) }
   def find(*args); end
@@ -1025,86 +1025,86 @@ class Wizard::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associat
   sig { params(block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
   def unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def select(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def order(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def group(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def limit(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def offset(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def where(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def preload(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def includes(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def from(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def lock(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def extending(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def or(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def having(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def references(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def none(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def merge(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def merge(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def except(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def except(*args); end
 
   sig { params(args: T.untyped).returns(Wizard) }
   def find(*args); end

--- a/spec/test_data/v5.1/expected_wizard.rbi
+++ b/spec/test_data/v5.1/expected_wizard.rbi
@@ -405,9 +405,6 @@ class Wizard < ApplicationRecord
   def self.readonly(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.extending(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
   def self.or(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
@@ -433,6 +430,9 @@ class Wizard < ApplicationRecord
 
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
   def self.except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
+  def self.extending(*args, &block); end
 
   sig { params(args: T.untyped).returns(Wizard) }
   def self.find(*args); end
@@ -624,9 +624,6 @@ class Wizard::ActiveRecord_Relation < ActiveRecord::Relation
   def readonly(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def extending(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
   def or(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
@@ -652,6 +649,9 @@ class Wizard::ActiveRecord_Relation < ActiveRecord::Relation
 
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
   def except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
+  def extending(*args, &block); end
 
   sig { params(args: T.untyped).returns(Wizard) }
   def find(*args); end
@@ -851,9 +851,6 @@ class Wizard::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelati
   def readonly(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def extending(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
   def or(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
@@ -879,6 +876,9 @@ class Wizard::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelati
 
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
   def except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def extending(*args, &block); end
 
   sig { params(args: T.untyped).returns(Wizard) }
   def find(*args); end
@@ -1077,9 +1077,6 @@ class Wizard::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associat
   def readonly(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def extending(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
   def or(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
@@ -1105,6 +1102,9 @@ class Wizard::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associat
 
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
   def except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def extending(*args, &block); end
 
   sig { params(args: T.untyped).returns(Wizard) }
   def find(*args); end

--- a/spec/test_data/v5.1/expected_wizard_wo_spellbook.rbi
+++ b/spec/test_data/v5.1/expected_wizard_wo_spellbook.rbi
@@ -353,86 +353,86 @@ class Wizard < ApplicationRecord
   sig { params(block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def self.unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.select(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.order(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.group(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.limit(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.offset(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.where(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.preload(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.includes(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.from(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.lock(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.extending(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.extending(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.or(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.having(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.references(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.none(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.merge(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.merge(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.except(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.except(*args); end
 
   sig { params(args: T.untyped).returns(Wizard) }
   def self.find(*args); end
@@ -572,86 +572,86 @@ class Wizard::ActiveRecord_Relation < ActiveRecord::Relation
   sig { params(block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def select(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def order(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def group(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def limit(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def offset(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def where(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def preload(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def includes(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def from(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def lock(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def extending(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def extending(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def or(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def having(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def references(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def none(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def merge(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def merge(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def except(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def except(*args); end
 
   sig { params(args: T.untyped).returns(Wizard) }
   def find(*args); end
@@ -799,86 +799,86 @@ class Wizard::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelati
   sig { params(block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
   def unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def select(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def order(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def group(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def limit(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def offset(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def where(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def preload(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def includes(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def from(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def lock(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def extending(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def or(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def having(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def references(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def none(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def merge(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def merge(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def except(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def except(*args); end
 
   sig { params(args: T.untyped).returns(Wizard) }
   def find(*args); end
@@ -1025,86 +1025,86 @@ class Wizard::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associat
   sig { params(block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
   def unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def select(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def order(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def group(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def limit(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def offset(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def where(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def preload(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def includes(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def from(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def lock(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def extending(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def or(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def having(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def references(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def none(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def merge(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def merge(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def except(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def except(*args); end
 
   sig { params(args: T.untyped).returns(Wizard) }
   def find(*args); end

--- a/spec/test_data/v5.1/expected_wizard_wo_spellbook.rbi
+++ b/spec/test_data/v5.1/expected_wizard_wo_spellbook.rbi
@@ -405,9 +405,6 @@ class Wizard < ApplicationRecord
   def self.readonly(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.extending(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
   def self.or(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
@@ -433,6 +430,9 @@ class Wizard < ApplicationRecord
 
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
   def self.except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
+  def self.extending(*args, &block); end
 
   sig { params(args: T.untyped).returns(Wizard) }
   def self.find(*args); end
@@ -624,9 +624,6 @@ class Wizard::ActiveRecord_Relation < ActiveRecord::Relation
   def readonly(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def extending(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
   def or(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
@@ -652,6 +649,9 @@ class Wizard::ActiveRecord_Relation < ActiveRecord::Relation
 
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
   def except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
+  def extending(*args, &block); end
 
   sig { params(args: T.untyped).returns(Wizard) }
   def find(*args); end
@@ -851,9 +851,6 @@ class Wizard::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelati
   def readonly(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def extending(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
   def or(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
@@ -879,6 +876,9 @@ class Wizard::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelati
 
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
   def except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def extending(*args, &block); end
 
   sig { params(args: T.untyped).returns(Wizard) }
   def find(*args); end
@@ -1077,9 +1077,6 @@ class Wizard::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associat
   def readonly(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def extending(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
   def or(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
@@ -1105,6 +1102,9 @@ class Wizard::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associat
 
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
   def except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def extending(*args, &block); end
 
   sig { params(args: T.untyped).returns(Wizard) }
   def find(*args); end

--- a/spec/test_data/v5.2/expected_attachment.rbi
+++ b/spec/test_data/v5.2/expected_attachment.rbi
@@ -104,9 +104,6 @@ class ActiveStorage::Attachment < ActiveRecord::Base
   def self.readonly(*args); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def self.extending(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
   def self.or(*args); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
@@ -132,6 +129,9 @@ class ActiveStorage::Attachment < ActiveRecord::Base
 
   sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
   def self.except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
+  def self.extending(*args, &block); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Attachment) }
   def self.find(*args); end
@@ -269,9 +269,6 @@ class ActiveStorage::Attachment::ActiveRecord_Relation < ActiveRecord::Relation
   def readonly(*args); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def extending(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
   def or(*args); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
@@ -297,6 +294,9 @@ class ActiveStorage::Attachment::ActiveRecord_Relation < ActiveRecord::Relation
 
   sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
   def except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
+  def extending(*args, &block); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Attachment) }
   def find(*args); end
@@ -442,9 +442,6 @@ class ActiveStorage::Attachment::ActiveRecord_AssociationRelation < ActiveRecord
   def readonly(*args); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def extending(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
   def or(*args); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
@@ -470,6 +467,9 @@ class ActiveStorage::Attachment::ActiveRecord_AssociationRelation < ActiveRecord
 
   sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
   def except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def extending(*args, &block); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Attachment) }
   def find(*args); end
@@ -614,9 +614,6 @@ class ActiveStorage::Attachment::ActiveRecord_Associations_CollectionProxy < Act
   def readonly(*args); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def extending(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
   def or(*args); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
@@ -642,6 +639,9 @@ class ActiveStorage::Attachment::ActiveRecord_Associations_CollectionProxy < Act
 
   sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
   def except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def extending(*args, &block); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Attachment) }
   def find(*args); end

--- a/spec/test_data/v5.2/expected_attachment.rbi
+++ b/spec/test_data/v5.2/expected_attachment.rbi
@@ -52,86 +52,86 @@ class ActiveStorage::Attachment < ActiveRecord::Base
   sig { params(block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
   def self.unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def self.select(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
+  def self.select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def self.order(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
+  def self.order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def self.reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
+  def self.reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def self.group(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
+  def self.group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def self.limit(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
+  def self.limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def self.offset(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
+  def self.offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def self.joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
+  def self.joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def self.left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
+  def self.left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def self.left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
+  def self.left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def self.where(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
+  def self.where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def self.rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
+  def self.rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def self.preload(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
+  def self.preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def self.eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
+  def self.eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def self.includes(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
+  def self.includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def self.from(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
+  def self.from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def self.lock(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
+  def self.lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def self.readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
+  def self.readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def self.extending(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
+  def self.extending(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def self.or(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
+  def self.or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def self.having(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
+  def self.having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def self.create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
+  def self.create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def self.distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
+  def self.distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def self.references(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
+  def self.references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def self.none(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
+  def self.none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def self.unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
+  def self.unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def self.merge(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
+  def self.merge(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def self.except(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
+  def self.except(*args); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Attachment) }
   def self.find(*args); end
@@ -217,86 +217,86 @@ class ActiveStorage::Attachment::ActiveRecord_Relation < ActiveRecord::Relation
   sig { params(block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
   def unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def select(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
+  def select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def order(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
+  def order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
+  def reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def group(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
+  def group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def limit(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
+  def limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def offset(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
+  def offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
+  def joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
+  def left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
+  def left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def where(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
+  def where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
+  def rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def preload(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
+  def preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
+  def eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def includes(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
+  def includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def from(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
+  def from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def lock(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
+  def lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
+  def readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def extending(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
+  def extending(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def or(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
+  def or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def having(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
+  def having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
+  def create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
+  def distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def references(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
+  def references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def none(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
+  def none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
+  def unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def merge(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
+  def merge(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def except(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
+  def except(*args); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Attachment) }
   def find(*args); end
@@ -390,86 +390,86 @@ class ActiveStorage::Attachment::ActiveRecord_AssociationRelation < ActiveRecord
   sig { params(block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
   def unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def select(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def order(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def group(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def limit(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def offset(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def where(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def preload(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def includes(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def from(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def lock(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def extending(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def or(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def having(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def references(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def none(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def merge(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def merge(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def except(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def except(*args); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Attachment) }
   def find(*args); end
@@ -562,86 +562,86 @@ class ActiveStorage::Attachment::ActiveRecord_Associations_CollectionProxy < Act
   sig { params(block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
   def unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def select(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def order(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def group(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def limit(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def offset(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def where(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def preload(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def includes(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def from(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def lock(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def extending(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def or(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def having(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def references(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def none(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def merge(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def merge(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def except(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def except(*args); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Attachment) }
   def find(*args); end

--- a/spec/test_data/v5.2/expected_blob.rbi
+++ b/spec/test_data/v5.2/expected_blob.rbi
@@ -116,9 +116,6 @@ class ActiveStorage::Blob < ActiveRecord::Base
   def self.readonly(*args); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def self.extending(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
   def self.or(*args); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
@@ -144,6 +141,9 @@ class ActiveStorage::Blob < ActiveRecord::Base
 
   sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
   def self.except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def self.extending(*args, &block); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Blob) }
   def self.find(*args); end
@@ -287,9 +287,6 @@ class ActiveStorage::Blob::ActiveRecord_Relation < ActiveRecord::Relation
   def readonly(*args); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def extending(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
   def or(*args); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
@@ -315,6 +312,9 @@ class ActiveStorage::Blob::ActiveRecord_Relation < ActiveRecord::Relation
 
   sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
   def except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def extending(*args, &block); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Blob) }
   def find(*args); end
@@ -466,9 +466,6 @@ class ActiveStorage::Blob::ActiveRecord_AssociationRelation < ActiveRecord::Asso
   def readonly(*args); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def extending(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
   def or(*args); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
@@ -494,6 +491,9 @@ class ActiveStorage::Blob::ActiveRecord_AssociationRelation < ActiveRecord::Asso
 
   sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
   def except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def extending(*args, &block); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Blob) }
   def find(*args); end
@@ -644,9 +644,6 @@ class ActiveStorage::Blob::ActiveRecord_Associations_CollectionProxy < ActiveRec
   def readonly(*args); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def extending(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
   def or(*args); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
@@ -672,6 +669,9 @@ class ActiveStorage::Blob::ActiveRecord_Associations_CollectionProxy < ActiveRec
 
   sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
   def except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def extending(*args, &block); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Blob) }
   def find(*args); end

--- a/spec/test_data/v5.2/expected_blob.rbi
+++ b/spec/test_data/v5.2/expected_blob.rbi
@@ -64,86 +64,86 @@ class ActiveStorage::Blob < ActiveRecord::Base
   sig { params(block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
   def self.unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def self.select(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def self.select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def self.order(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def self.order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def self.reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def self.reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def self.group(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def self.group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def self.limit(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def self.limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def self.offset(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def self.offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def self.joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def self.joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def self.left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def self.left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def self.left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def self.left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def self.where(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def self.where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def self.rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def self.rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def self.preload(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def self.preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def self.eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def self.eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def self.includes(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def self.includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def self.from(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def self.from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def self.lock(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def self.lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def self.readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def self.readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def self.extending(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def self.extending(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def self.or(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def self.or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def self.having(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def self.having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def self.create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def self.create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def self.distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def self.distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def self.references(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def self.references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def self.none(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def self.none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def self.unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def self.unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def self.merge(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def self.merge(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def self.except(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def self.except(*args); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Blob) }
   def self.find(*args); end
@@ -235,86 +235,86 @@ class ActiveStorage::Blob::ActiveRecord_Relation < ActiveRecord::Relation
   sig { params(block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
   def unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def select(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def order(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def group(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def limit(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def offset(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def where(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def preload(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def includes(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def from(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def lock(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def extending(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def extending(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def or(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def having(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def references(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def none(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def merge(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def merge(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def except(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def except(*args); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Blob) }
   def find(*args); end
@@ -414,86 +414,86 @@ class ActiveStorage::Blob::ActiveRecord_AssociationRelation < ActiveRecord::Asso
   sig { params(block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
   def unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def select(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def order(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def group(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def limit(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def offset(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def where(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def preload(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def includes(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def from(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def lock(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def extending(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def or(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def having(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def references(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def none(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def merge(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def merge(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def except(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def except(*args); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Blob) }
   def find(*args); end
@@ -592,86 +592,86 @@ class ActiveStorage::Blob::ActiveRecord_Associations_CollectionProxy < ActiveRec
   sig { params(block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
   def unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def select(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def order(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def group(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def limit(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def offset(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def where(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def preload(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def includes(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def from(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def lock(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def extending(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def or(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def having(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def references(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def none(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def merge(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def merge(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def except(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def except(*args); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Blob) }
   def find(*args); end

--- a/spec/test_data/v5.2/expected_internal_metadata.rbi
+++ b/spec/test_data/v5.2/expected_internal_metadata.rbi
@@ -76,86 +76,86 @@ class ActiveRecord::InternalMetadata < ActiveRecord::Base
   sig { params(block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
   def self.unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.select(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def self.select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.order(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def self.order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def self.reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.group(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def self.group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.limit(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def self.limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.offset(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def self.offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def self.joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def self.left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def self.left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.where(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def self.where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def self.rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.preload(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def self.preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def self.eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.includes(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def self.includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.from(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def self.from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.lock(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def self.lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def self.readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.extending(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def self.extending(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.or(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def self.or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.having(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def self.having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def self.create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def self.distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.references(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def self.references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.none(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def self.none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def self.unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.merge(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def self.merge(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.except(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def self.except(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata) }
   def self.find(*args); end
@@ -241,86 +241,86 @@ class ActiveRecord::InternalMetadata::ActiveRecord_Relation < ActiveRecord::Rela
   sig { params(block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
   def unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def select(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def order(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def group(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def limit(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def offset(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def where(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def preload(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def includes(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def from(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def lock(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def extending(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def extending(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def or(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def having(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def references(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def none(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def merge(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def merge(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def except(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def except(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata) }
   def find(*args); end
@@ -414,86 +414,86 @@ class ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation < ActiveR
   sig { params(block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
   def unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def select(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def order(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def group(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def limit(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def offset(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def where(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def preload(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def includes(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def from(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def lock(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def extending(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def or(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def having(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def references(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def none(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def merge(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def merge(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def except(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def except(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata) }
   def find(*args); end
@@ -586,86 +586,86 @@ class ActiveRecord::InternalMetadata::ActiveRecord_Associations_CollectionProxy 
   sig { params(block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
   def unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def select(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def order(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def group(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def limit(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def offset(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def where(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def preload(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def includes(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def from(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def lock(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def extending(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def or(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def having(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def references(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def none(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def merge(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def merge(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def except(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def except(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata) }
   def find(*args); end

--- a/spec/test_data/v5.2/expected_internal_metadata.rbi
+++ b/spec/test_data/v5.2/expected_internal_metadata.rbi
@@ -128,9 +128,6 @@ class ActiveRecord::InternalMetadata < ActiveRecord::Base
   def self.readonly(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.extending(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
   def self.or(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
@@ -156,6 +153,9 @@ class ActiveRecord::InternalMetadata < ActiveRecord::Base
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
   def self.except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def self.extending(*args, &block); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata) }
   def self.find(*args); end
@@ -293,9 +293,6 @@ class ActiveRecord::InternalMetadata::ActiveRecord_Relation < ActiveRecord::Rela
   def readonly(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def extending(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
   def or(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
@@ -321,6 +318,9 @@ class ActiveRecord::InternalMetadata::ActiveRecord_Relation < ActiveRecord::Rela
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
   def except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def extending(*args, &block); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata) }
   def find(*args); end
@@ -466,9 +466,6 @@ class ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation < ActiveR
   def readonly(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def extending(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
   def or(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
@@ -494,6 +491,9 @@ class ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation < ActiveR
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
   def except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def extending(*args, &block); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata) }
   def find(*args); end
@@ -638,9 +638,6 @@ class ActiveRecord::InternalMetadata::ActiveRecord_Associations_CollectionProxy 
   def readonly(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def extending(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
   def or(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
@@ -666,6 +663,9 @@ class ActiveRecord::InternalMetadata::ActiveRecord_Associations_CollectionProxy 
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
   def except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def extending(*args, &block); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata) }
   def find(*args); end

--- a/spec/test_data/v5.2/expected_potion.rbi
+++ b/spec/test_data/v5.2/expected_potion.rbi
@@ -87,9 +87,6 @@ class Potion < ApplicationRecord
   def self.readonly(*args); end
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def self.extending(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
   def self.or(*args); end
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
@@ -115,6 +112,9 @@ class Potion < ApplicationRecord
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
   def self.except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
+  def self.extending(*args, &block); end
 
   sig { params(args: T.untyped).returns(Potion) }
   def self.find(*args); end
@@ -252,9 +252,6 @@ class Potion::ActiveRecord_Relation < ActiveRecord::Relation
   def readonly(*args); end
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def extending(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
   def or(*args); end
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
@@ -280,6 +277,9 @@ class Potion::ActiveRecord_Relation < ActiveRecord::Relation
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
   def except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
+  def extending(*args, &block); end
 
   sig { params(args: T.untyped).returns(Potion) }
   def find(*args); end
@@ -425,9 +425,6 @@ class Potion::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelati
   def readonly(*args); end
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def extending(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
   def or(*args); end
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
@@ -453,6 +450,9 @@ class Potion::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelati
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
   def except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
+  def extending(*args, &block); end
 
   sig { params(args: T.untyped).returns(Potion) }
   def find(*args); end
@@ -597,9 +597,6 @@ class Potion::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associat
   def readonly(*args); end
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def extending(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
   def or(*args); end
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
@@ -625,6 +622,9 @@ class Potion::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associat
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
   def except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
+  def extending(*args, &block); end
 
   sig { params(args: T.untyped).returns(Potion) }
   def find(*args); end

--- a/spec/test_data/v5.2/expected_potion.rbi
+++ b/spec/test_data/v5.2/expected_potion.rbi
@@ -35,86 +35,86 @@ class Potion < ApplicationRecord
   sig { params(block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def self.unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def self.select(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def self.select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def self.order(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def self.order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def self.reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def self.reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def self.group(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def self.group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def self.limit(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def self.limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def self.offset(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def self.offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def self.joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def self.joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def self.left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def self.left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def self.left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def self.left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def self.where(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def self.where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def self.rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def self.rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def self.preload(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def self.preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def self.eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def self.eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def self.includes(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def self.includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def self.from(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def self.from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def self.lock(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def self.lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def self.readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def self.readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def self.extending(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def self.extending(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def self.or(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def self.or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def self.having(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def self.having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def self.create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def self.create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def self.distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def self.distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def self.references(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def self.references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def self.none(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def self.none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def self.unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def self.unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def self.merge(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def self.merge(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def self.except(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def self.except(*args); end
 
   sig { params(args: T.untyped).returns(Potion) }
   def self.find(*args); end
@@ -200,86 +200,86 @@ class Potion::ActiveRecord_Relation < ActiveRecord::Relation
   sig { params(block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def select(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def order(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def group(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def limit(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def offset(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def where(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def preload(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def includes(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def from(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def lock(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def extending(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def extending(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def or(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def having(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def references(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def none(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def merge(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def merge(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def except(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def except(*args); end
 
   sig { params(args: T.untyped).returns(Potion) }
   def find(*args); end
@@ -373,86 +373,86 @@ class Potion::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelati
   sig { params(block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
   def unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def select(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def order(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def group(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def limit(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def offset(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def where(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def preload(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def includes(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def from(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def lock(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def extending(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def or(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def having(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def references(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def none(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def merge(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def merge(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def except(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def except(*args); end
 
   sig { params(args: T.untyped).returns(Potion) }
   def find(*args); end
@@ -545,86 +545,86 @@ class Potion::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associat
   sig { params(block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
   def unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def select(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def order(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def group(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def limit(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def offset(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def where(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def preload(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def includes(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def from(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def lock(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def extending(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def or(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def having(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def references(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def none(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def merge(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def merge(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def except(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def except(*args); end
 
   sig { params(args: T.untyped).returns(Potion) }
   def find(*args); end

--- a/spec/test_data/v5.2/expected_schema_migration.rbi
+++ b/spec/test_data/v5.2/expected_schema_migration.rbi
@@ -101,9 +101,6 @@ class ActiveRecord::SchemaMigration < ActiveRecord::Base
   def self.readonly(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.extending(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
   def self.or(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
@@ -129,6 +126,9 @@ class ActiveRecord::SchemaMigration < ActiveRecord::Base
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
   def self.except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def self.extending(*args, &block); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration) }
   def self.find(*args); end
@@ -266,9 +266,6 @@ class ActiveRecord::SchemaMigration::ActiveRecord_Relation < ActiveRecord::Relat
   def readonly(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def extending(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
   def or(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
@@ -294,6 +291,9 @@ class ActiveRecord::SchemaMigration::ActiveRecord_Relation < ActiveRecord::Relat
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
   def except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def extending(*args, &block); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration) }
   def find(*args); end
@@ -439,9 +439,6 @@ class ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation < ActiveRe
   def readonly(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def extending(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
   def or(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
@@ -467,6 +464,9 @@ class ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation < ActiveRe
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
   def except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def extending(*args, &block); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration) }
   def find(*args); end
@@ -611,9 +611,6 @@ class ActiveRecord::SchemaMigration::ActiveRecord_Associations_CollectionProxy <
   def readonly(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def extending(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
   def or(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
@@ -639,6 +636,9 @@ class ActiveRecord::SchemaMigration::ActiveRecord_Associations_CollectionProxy <
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
   def except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def extending(*args, &block); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration) }
   def find(*args); end

--- a/spec/test_data/v5.2/expected_schema_migration.rbi
+++ b/spec/test_data/v5.2/expected_schema_migration.rbi
@@ -49,86 +49,86 @@ class ActiveRecord::SchemaMigration < ActiveRecord::Base
   sig { params(block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
   def self.unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.select(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def self.select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.order(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def self.order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def self.reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.group(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def self.group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.limit(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def self.limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.offset(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def self.offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def self.joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def self.left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def self.left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.where(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def self.where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def self.rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.preload(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def self.preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def self.eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.includes(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def self.includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.from(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def self.from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.lock(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def self.lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def self.readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.extending(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def self.extending(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.or(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def self.or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.having(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def self.having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def self.create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def self.distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.references(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def self.references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.none(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def self.none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def self.unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.merge(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def self.merge(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.except(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def self.except(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration) }
   def self.find(*args); end
@@ -214,86 +214,86 @@ class ActiveRecord::SchemaMigration::ActiveRecord_Relation < ActiveRecord::Relat
   sig { params(block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
   def unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def select(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def order(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def group(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def limit(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def offset(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def where(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def preload(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def includes(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def from(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def lock(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def extending(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def extending(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def or(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def having(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def references(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def none(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def merge(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def merge(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def except(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def except(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration) }
   def find(*args); end
@@ -387,86 +387,86 @@ class ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation < ActiveRe
   sig { params(block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
   def unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def select(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def order(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def group(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def limit(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def offset(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def where(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def preload(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def includes(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def from(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def lock(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def extending(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def or(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def having(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def references(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def none(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def merge(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def merge(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def except(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def except(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration) }
   def find(*args); end
@@ -559,86 +559,86 @@ class ActiveRecord::SchemaMigration::ActiveRecord_Associations_CollectionProxy <
   sig { params(block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
   def unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def select(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def order(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def group(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def limit(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def offset(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def where(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def preload(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def includes(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def from(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def lock(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def extending(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def or(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def having(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def references(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def none(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def merge(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def merge(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def except(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def except(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration) }
   def find(*args); end

--- a/spec/test_data/v5.2/expected_spell_book.rbi
+++ b/spec/test_data/v5.2/expected_spell_book.rbi
@@ -174,9 +174,6 @@ class SpellBook < ApplicationRecord
   def self.readonly(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def self.extending(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
   def self.or(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
@@ -202,6 +199,9 @@ class SpellBook < ApplicationRecord
 
   sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
   def self.except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
+  def self.extending(*args, &block); end
 
   sig { params(args: T.untyped).returns(SpellBook) }
   def self.find(*args); end
@@ -348,9 +348,6 @@ class SpellBook::ActiveRecord_Relation < ActiveRecord::Relation
   def readonly(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def extending(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
   def or(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
@@ -376,6 +373,9 @@ class SpellBook::ActiveRecord_Relation < ActiveRecord::Relation
 
   sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
   def except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
+  def extending(*args, &block); end
 
   sig { params(args: T.untyped).returns(SpellBook) }
   def find(*args); end
@@ -530,9 +530,6 @@ class SpellBook::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRel
   def readonly(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def extending(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
   def or(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
@@ -558,6 +555,9 @@ class SpellBook::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRel
 
   sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
   def except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def extending(*args, &block); end
 
   sig { params(args: T.untyped).returns(SpellBook) }
   def find(*args); end
@@ -711,9 +711,6 @@ class SpellBook::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Assoc
   def readonly(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def extending(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
   def or(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
@@ -739,6 +736,9 @@ class SpellBook::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Assoc
 
   sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
   def except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def extending(*args, &block); end
 
   sig { params(args: T.untyped).returns(SpellBook) }
   def find(*args); end

--- a/spec/test_data/v5.2/expected_spell_book.rbi
+++ b/spec/test_data/v5.2/expected_spell_book.rbi
@@ -122,86 +122,86 @@ class SpellBook < ApplicationRecord
   sig { params(block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def self.unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def self.select(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def self.select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def self.order(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def self.order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def self.reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def self.reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def self.group(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def self.group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def self.limit(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def self.limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def self.offset(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def self.offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def self.joins(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def self.joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def self.left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def self.left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def self.left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def self.left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def self.where(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def self.where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def self.rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def self.rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def self.preload(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def self.preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def self.eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def self.eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def self.includes(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def self.includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def self.from(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def self.from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def self.lock(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def self.lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def self.readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def self.readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def self.extending(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def self.extending(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def self.or(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def self.or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def self.having(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def self.having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def self.create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def self.create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def self.distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def self.distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def self.references(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def self.references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def self.none(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def self.none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def self.unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def self.unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def self.merge(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def self.merge(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def self.except(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def self.except(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook) }
   def self.find(*args); end
@@ -296,86 +296,86 @@ class SpellBook::ActiveRecord_Relation < ActiveRecord::Relation
   sig { params(block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def select(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def order(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def group(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def limit(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def offset(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def joins(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def where(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def preload(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def includes(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def from(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def lock(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def extending(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def extending(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def or(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def having(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def references(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def none(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def merge(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def merge(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def except(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def except(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook) }
   def find(*args); end
@@ -478,86 +478,86 @@ class SpellBook::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRel
   sig { params(block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
   def unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def select(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def order(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def group(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def limit(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def offset(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def joins(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def where(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def preload(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def includes(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def from(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def lock(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def extending(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def or(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def having(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def references(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def none(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def merge(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def merge(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def except(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def except(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook) }
   def find(*args); end
@@ -659,86 +659,86 @@ class SpellBook::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Assoc
   sig { params(block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
   def unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def select(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def order(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def group(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def limit(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def offset(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def joins(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def where(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def preload(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def includes(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def from(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def lock(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def extending(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def or(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def having(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def references(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def none(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def merge(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def merge(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def except(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def except(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook) }
   def find(*args); end

--- a/spec/test_data/v5.2/expected_squib.rbi
+++ b/spec/test_data/v5.2/expected_squib.rbi
@@ -435,9 +435,6 @@ class Squib < Wizard
   def self.readonly(*args); end
 
   sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.extending(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
   def self.or(*args); end
 
   sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
@@ -463,6 +460,9 @@ class Squib < Wizard
 
   sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
   def self.except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
+  def self.extending(*args, &block); end
 
   sig { params(args: T.untyped).returns(Squib) }
   def self.find(*args); end
@@ -660,9 +660,6 @@ class Squib::ActiveRecord_Relation < ActiveRecord::Relation
   def readonly(*args); end
 
   sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def extending(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
   def or(*args); end
 
   sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
@@ -688,6 +685,9 @@ class Squib::ActiveRecord_Relation < ActiveRecord::Relation
 
   sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
   def except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
+  def extending(*args, &block); end
 
   sig { params(args: T.untyped).returns(Squib) }
   def find(*args); end
@@ -893,9 +893,6 @@ class Squib::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelatio
   def readonly(*args); end
 
   sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def extending(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
   def or(*args); end
 
   sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
@@ -921,6 +918,9 @@ class Squib::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelatio
 
   sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
   def except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
+  def extending(*args, &block); end
 
   sig { params(args: T.untyped).returns(Squib) }
   def find(*args); end
@@ -1125,9 +1125,6 @@ class Squib::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associati
   def readonly(*args); end
 
   sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def extending(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
   def or(*args); end
 
   sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
@@ -1153,6 +1150,9 @@ class Squib::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associati
 
   sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
   def except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
+  def extending(*args, &block); end
 
   sig { params(args: T.untyped).returns(Squib) }
   def find(*args); end

--- a/spec/test_data/v5.2/expected_squib.rbi
+++ b/spec/test_data/v5.2/expected_squib.rbi
@@ -383,86 +383,86 @@ class Squib < Wizard
   sig { params(block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
   def self.unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def self.select(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def self.order(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def self.reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def self.group(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def self.limit(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def self.offset(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def self.joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def self.left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def self.left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def self.where(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def self.rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def self.preload(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def self.eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def self.includes(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def self.from(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def self.lock(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def self.readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def self.extending(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.extending(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def self.or(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def self.having(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def self.create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def self.distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def self.references(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def self.none(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def self.unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def self.merge(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.merge(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def self.except(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.except(*args); end
 
   sig { params(args: T.untyped).returns(Squib) }
   def self.find(*args); end
@@ -608,86 +608,86 @@ class Squib::ActiveRecord_Relation < ActiveRecord::Relation
   sig { params(block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
   def unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def select(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def order(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def group(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def limit(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def offset(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def where(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def preload(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def includes(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def from(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def lock(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def extending(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def extending(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def or(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def having(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def references(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def none(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def merge(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def merge(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def except(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def except(*args); end
 
   sig { params(args: T.untyped).returns(Squib) }
   def find(*args); end
@@ -841,86 +841,86 @@ class Squib::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelatio
   sig { params(block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
   def unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def select(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def order(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def group(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def limit(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def offset(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def where(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def preload(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def includes(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def from(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def lock(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def extending(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def or(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def having(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def references(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def none(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def merge(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def merge(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def except(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def except(*args); end
 
   sig { params(args: T.untyped).returns(Squib) }
   def find(*args); end
@@ -1073,86 +1073,86 @@ class Squib::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associati
   sig { params(block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
   def unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def select(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def order(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def group(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def limit(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def offset(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def where(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def preload(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def includes(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def from(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def lock(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def extending(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def or(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def having(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def references(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def none(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def merge(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def merge(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def except(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def except(*args); end
 
   sig { params(args: T.untyped).returns(Squib) }
   def find(*args); end

--- a/spec/test_data/v5.2/expected_wand.rbi
+++ b/spec/test_data/v5.2/expected_wand.rbi
@@ -282,9 +282,6 @@ class Wand < ApplicationRecord
   def self.readonly(*args); end
 
   sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
-  def self.extending(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
   def self.or(*args); end
 
   sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
@@ -310,6 +307,9 @@ class Wand < ApplicationRecord
 
   sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
   def self.except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
+  def self.extending(*args, &block); end
 
   sig { params(args: T.untyped).returns(Wand) }
   def self.find(*args); end
@@ -462,9 +462,6 @@ class Wand::ActiveRecord_Relation < ActiveRecord::Relation
   def readonly(*args); end
 
   sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
-  def extending(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
   def or(*args); end
 
   sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
@@ -490,6 +487,9 @@ class Wand::ActiveRecord_Relation < ActiveRecord::Relation
 
   sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
   def except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
+  def extending(*args, &block); end
 
   sig { params(args: T.untyped).returns(Wand) }
   def find(*args); end
@@ -647,9 +647,6 @@ class Wand::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
   def readonly(*args); end
 
   sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def extending(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
   def or(*args); end
 
   sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
@@ -675,6 +672,9 @@ class Wand::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
 
   sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
   def except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
+  def extending(*args, &block); end
 
   sig { params(args: T.untyped).returns(Wand) }
   def find(*args); end
@@ -831,9 +831,6 @@ class Wand::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associatio
   def readonly(*args); end
 
   sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def extending(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
   def or(*args); end
 
   sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
@@ -859,6 +856,9 @@ class Wand::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associatio
 
   sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
   def except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
+  def extending(*args, &block); end
 
   sig { params(args: T.untyped).returns(Wand) }
   def find(*args); end

--- a/spec/test_data/v5.2/expected_wand.rbi
+++ b/spec/test_data/v5.2/expected_wand.rbi
@@ -230,86 +230,86 @@ class Wand < ApplicationRecord
   sig { params(block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def self.unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def self.select(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def self.order(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def self.reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def self.group(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def self.limit(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def self.offset(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def self.joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def self.left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def self.left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def self.where(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def self.rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def self.preload(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def self.eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def self.includes(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def self.from(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def self.lock(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def self.readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def self.extending(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.extending(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def self.or(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def self.having(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def self.create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def self.distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def self.references(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def self.none(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def self.unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def self.merge(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.merge(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def self.except(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.except(*args); end
 
   sig { params(args: T.untyped).returns(Wand) }
   def self.find(*args); end
@@ -410,86 +410,86 @@ class Wand::ActiveRecord_Relation < ActiveRecord::Relation
   sig { params(block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def select(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def order(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def group(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def limit(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def offset(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def where(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def preload(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def includes(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def from(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def lock(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def extending(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def extending(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def or(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def having(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def references(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def none(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def merge(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def merge(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def except(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def except(*args); end
 
   sig { params(args: T.untyped).returns(Wand) }
   def find(*args); end
@@ -595,86 +595,86 @@ class Wand::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
   sig { params(block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
   def unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def select(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def order(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def group(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def limit(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def offset(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def where(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def preload(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def includes(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def from(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def lock(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def extending(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def or(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def having(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def references(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def none(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def merge(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def merge(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def except(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def except(*args); end
 
   sig { params(args: T.untyped).returns(Wand) }
   def find(*args); end
@@ -779,86 +779,86 @@ class Wand::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associatio
   sig { params(block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
   def unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def select(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def order(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def group(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def limit(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def offset(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def where(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def preload(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def includes(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def from(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def lock(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def extending(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def or(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def having(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def references(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def none(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def merge(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def merge(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def except(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def except(*args); end
 
   sig { params(args: T.untyped).returns(Wand) }
   def find(*args); end

--- a/spec/test_data/v5.2/expected_wizard.rbi
+++ b/spec/test_data/v5.2/expected_wizard.rbi
@@ -435,9 +435,6 @@ class Wizard < ApplicationRecord
   def self.readonly(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.extending(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
   def self.or(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
@@ -463,6 +460,9 @@ class Wizard < ApplicationRecord
 
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
   def self.except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
+  def self.extending(*args, &block); end
 
   sig { params(args: T.untyped).returns(Wizard) }
   def self.find(*args); end
@@ -660,9 +660,6 @@ class Wizard::ActiveRecord_Relation < ActiveRecord::Relation
   def readonly(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def extending(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
   def or(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
@@ -688,6 +685,9 @@ class Wizard::ActiveRecord_Relation < ActiveRecord::Relation
 
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
   def except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
+  def extending(*args, &block); end
 
   sig { params(args: T.untyped).returns(Wizard) }
   def find(*args); end
@@ -893,9 +893,6 @@ class Wizard::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelati
   def readonly(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def extending(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
   def or(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
@@ -921,6 +918,9 @@ class Wizard::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelati
 
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
   def except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def extending(*args, &block); end
 
   sig { params(args: T.untyped).returns(Wizard) }
   def find(*args); end
@@ -1125,9 +1125,6 @@ class Wizard::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associat
   def readonly(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def extending(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
   def or(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
@@ -1153,6 +1150,9 @@ class Wizard::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associat
 
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
   def except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def extending(*args, &block); end
 
   sig { params(args: T.untyped).returns(Wizard) }
   def find(*args); end

--- a/spec/test_data/v5.2/expected_wizard.rbi
+++ b/spec/test_data/v5.2/expected_wizard.rbi
@@ -383,86 +383,86 @@ class Wizard < ApplicationRecord
   sig { params(block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def self.unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.select(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.order(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.group(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.limit(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.offset(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.where(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.preload(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.includes(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.from(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.lock(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.extending(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.extending(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.or(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.having(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.references(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.none(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.merge(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.merge(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.except(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.except(*args); end
 
   sig { params(args: T.untyped).returns(Wizard) }
   def self.find(*args); end
@@ -608,86 +608,86 @@ class Wizard::ActiveRecord_Relation < ActiveRecord::Relation
   sig { params(block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def select(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def order(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def group(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def limit(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def offset(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def where(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def preload(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def includes(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def from(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def lock(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def extending(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def extending(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def or(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def having(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def references(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def none(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def merge(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def merge(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def except(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def except(*args); end
 
   sig { params(args: T.untyped).returns(Wizard) }
   def find(*args); end
@@ -841,86 +841,86 @@ class Wizard::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelati
   sig { params(block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
   def unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def select(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def order(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def group(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def limit(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def offset(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def where(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def preload(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def includes(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def from(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def lock(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def extending(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def or(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def having(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def references(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def none(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def merge(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def merge(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def except(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def except(*args); end
 
   sig { params(args: T.untyped).returns(Wizard) }
   def find(*args); end
@@ -1073,86 +1073,86 @@ class Wizard::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associat
   sig { params(block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
   def unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def select(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def order(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def group(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def limit(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def offset(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def where(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def preload(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def includes(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def from(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def lock(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def extending(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def or(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def having(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def references(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def none(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def merge(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def merge(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def except(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def except(*args); end
 
   sig { params(args: T.untyped).returns(Wizard) }
   def find(*args); end

--- a/spec/test_data/v5.2/expected_wizard_wo_spellbook.rbi
+++ b/spec/test_data/v5.2/expected_wizard_wo_spellbook.rbi
@@ -435,9 +435,6 @@ class Wizard < ApplicationRecord
   def self.readonly(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.extending(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
   def self.or(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
@@ -463,6 +460,9 @@ class Wizard < ApplicationRecord
 
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
   def self.except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
+  def self.extending(*args, &block); end
 
   sig { params(args: T.untyped).returns(Wizard) }
   def self.find(*args); end
@@ -660,9 +660,6 @@ class Wizard::ActiveRecord_Relation < ActiveRecord::Relation
   def readonly(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def extending(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
   def or(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
@@ -688,6 +685,9 @@ class Wizard::ActiveRecord_Relation < ActiveRecord::Relation
 
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
   def except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
+  def extending(*args, &block); end
 
   sig { params(args: T.untyped).returns(Wizard) }
   def find(*args); end
@@ -893,9 +893,6 @@ class Wizard::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelati
   def readonly(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def extending(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
   def or(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
@@ -921,6 +918,9 @@ class Wizard::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelati
 
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
   def except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def extending(*args, &block); end
 
   sig { params(args: T.untyped).returns(Wizard) }
   def find(*args); end
@@ -1125,9 +1125,6 @@ class Wizard::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associat
   def readonly(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def extending(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
   def or(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
@@ -1153,6 +1150,9 @@ class Wizard::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associat
 
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
   def except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def extending(*args, &block); end
 
   sig { params(args: T.untyped).returns(Wizard) }
   def find(*args); end

--- a/spec/test_data/v5.2/expected_wizard_wo_spellbook.rbi
+++ b/spec/test_data/v5.2/expected_wizard_wo_spellbook.rbi
@@ -383,86 +383,86 @@ class Wizard < ApplicationRecord
   sig { params(block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def self.unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.select(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.order(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.group(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.limit(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.offset(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.where(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.preload(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.includes(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.from(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.lock(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.extending(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.extending(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.or(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.having(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.references(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.none(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.merge(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.merge(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.except(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.except(*args); end
 
   sig { params(args: T.untyped).returns(Wizard) }
   def self.find(*args); end
@@ -608,86 +608,86 @@ class Wizard::ActiveRecord_Relation < ActiveRecord::Relation
   sig { params(block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def select(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def order(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def group(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def limit(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def offset(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def where(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def preload(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def includes(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def from(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def lock(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def extending(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def extending(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def or(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def having(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def references(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def none(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def merge(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def merge(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def except(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def except(*args); end
 
   sig { params(args: T.untyped).returns(Wizard) }
   def find(*args); end
@@ -841,86 +841,86 @@ class Wizard::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelati
   sig { params(block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
   def unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def select(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def order(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def group(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def limit(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def offset(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def where(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def preload(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def includes(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def from(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def lock(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def extending(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def or(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def having(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def references(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def none(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def merge(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def merge(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def except(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def except(*args); end
 
   sig { params(args: T.untyped).returns(Wizard) }
   def find(*args); end
@@ -1073,86 +1073,86 @@ class Wizard::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associat
   sig { params(block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
   def unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def select(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def order(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def group(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def limit(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def offset(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def where(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def preload(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def includes(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def from(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def lock(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def extending(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def or(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def having(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def references(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def none(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def merge(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def merge(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def except(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def except(*args); end
 
   sig { params(args: T.untyped).returns(Wizard) }
   def find(*args); end

--- a/spec/test_data/v6.0/expected_attachment.rbi
+++ b/spec/test_data/v6.0/expected_attachment.rbi
@@ -110,9 +110,6 @@ class ActiveStorage::Attachment < ActiveRecord::Base
   def self.readonly(*args); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def self.extending(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
   def self.or(*args); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
@@ -144,6 +141,9 @@ class ActiveStorage::Attachment < ActiveRecord::Base
 
   sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
   def self.only(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
+  def self.extending(*args, &block); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Attachment) }
   def self.find(*args); end
@@ -287,9 +287,6 @@ class ActiveStorage::Attachment::ActiveRecord_Relation < ActiveRecord::Relation
   def readonly(*args); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def extending(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
   def or(*args); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
@@ -321,6 +318,9 @@ class ActiveStorage::Attachment::ActiveRecord_Relation < ActiveRecord::Relation
 
   sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
   def only(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
+  def extending(*args, &block); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Attachment) }
   def find(*args); end
@@ -472,9 +472,6 @@ class ActiveStorage::Attachment::ActiveRecord_AssociationRelation < ActiveRecord
   def readonly(*args); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def extending(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
   def or(*args); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
@@ -506,6 +503,9 @@ class ActiveStorage::Attachment::ActiveRecord_AssociationRelation < ActiveRecord
 
   sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
   def only(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def extending(*args, &block); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Attachment) }
   def find(*args); end
@@ -656,9 +656,6 @@ class ActiveStorage::Attachment::ActiveRecord_Associations_CollectionProxy < Act
   def readonly(*args); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def extending(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
   def or(*args); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
@@ -690,6 +687,9 @@ class ActiveStorage::Attachment::ActiveRecord_Associations_CollectionProxy < Act
 
   sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
   def only(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def extending(*args, &block); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Attachment) }
   def find(*args); end

--- a/spec/test_data/v6.0/expected_attachment.rbi
+++ b/spec/test_data/v6.0/expected_attachment.rbi
@@ -52,98 +52,98 @@ class ActiveStorage::Attachment < ActiveRecord::Base
   sig { params(block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
   def self.unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def self.select(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
+  def self.select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def self.reselect(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
+  def self.reselect(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def self.order(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
+  def self.order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def self.reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
+  def self.reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def self.group(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
+  def self.group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def self.limit(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
+  def self.limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def self.offset(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
+  def self.offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def self.joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
+  def self.joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def self.left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
+  def self.left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def self.left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
+  def self.left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def self.where(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
+  def self.where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def self.rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
+  def self.rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def self.preload(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
+  def self.preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def self.extract_associated(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
+  def self.extract_associated(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def self.eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
+  def self.eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def self.includes(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
+  def self.includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def self.from(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
+  def self.from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def self.lock(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
+  def self.lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def self.readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
+  def self.readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def self.extending(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
+  def self.extending(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def self.or(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
+  def self.or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def self.having(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
+  def self.having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def self.create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
+  def self.create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def self.distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
+  def self.distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def self.references(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
+  def self.references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def self.none(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
+  def self.none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def self.unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
+  def self.unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def self.optimizer_hints(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
+  def self.optimizer_hints(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def self.merge(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
+  def self.merge(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def self.except(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
+  def self.except(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def self.only(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
+  def self.only(*args); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Attachment) }
   def self.find(*args); end
@@ -229,98 +229,98 @@ class ActiveStorage::Attachment::ActiveRecord_Relation < ActiveRecord::Relation
   sig { params(block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
   def unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def select(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
+  def select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def reselect(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
+  def reselect(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def order(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
+  def order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
+  def reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def group(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
+  def group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def limit(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
+  def limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def offset(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
+  def offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
+  def joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
+  def left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
+  def left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def where(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
+  def where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
+  def rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def preload(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
+  def preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def extract_associated(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
+  def extract_associated(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
+  def eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def includes(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
+  def includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def from(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
+  def from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def lock(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
+  def lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
+  def readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def extending(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
+  def extending(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def or(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
+  def or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def having(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
+  def having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
+  def create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
+  def distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def references(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
+  def references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def none(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
+  def none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
+  def unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def optimizer_hints(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
+  def optimizer_hints(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def merge(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
+  def merge(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def except(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
+  def except(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def only(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
+  def only(*args); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Attachment) }
   def find(*args); end
@@ -414,98 +414,98 @@ class ActiveStorage::Attachment::ActiveRecord_AssociationRelation < ActiveRecord
   sig { params(block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
   def unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def select(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def reselect(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def reselect(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def order(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def group(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def limit(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def offset(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def where(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def preload(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def extract_associated(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def extract_associated(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def includes(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def from(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def lock(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def extending(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def or(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def having(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def references(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def none(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def optimizer_hints(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def optimizer_hints(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def merge(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def merge(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def except(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def except(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def only(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def only(*args); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Attachment) }
   def find(*args); end
@@ -598,98 +598,98 @@ class ActiveStorage::Attachment::ActiveRecord_Associations_CollectionProxy < Act
   sig { params(block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
   def unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def select(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def reselect(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def reselect(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def order(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def group(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def limit(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def offset(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def where(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def preload(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def extract_associated(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def extract_associated(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def includes(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def from(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def lock(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def extending(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def or(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def having(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def references(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def none(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def optimizer_hints(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def optimizer_hints(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def merge(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def merge(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def except(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def except(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def only(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def only(*args); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Attachment) }
   def find(*args); end

--- a/spec/test_data/v6.0/expected_blob.rbi
+++ b/spec/test_data/v6.0/expected_blob.rbi
@@ -42,98 +42,98 @@ class ActiveStorage::Blob < ActiveRecord::Base
   sig { params(block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
   def self.unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def self.select(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def self.select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def self.reselect(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def self.reselect(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def self.order(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def self.order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def self.reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def self.reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def self.group(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def self.group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def self.limit(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def self.limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def self.offset(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def self.offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def self.joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def self.joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def self.left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def self.left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def self.left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def self.left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def self.where(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def self.where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def self.rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def self.rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def self.preload(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def self.preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def self.extract_associated(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def self.extract_associated(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def self.eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def self.eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def self.includes(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def self.includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def self.from(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def self.from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def self.lock(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def self.lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def self.readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def self.readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def self.extending(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def self.extending(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def self.or(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def self.or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def self.having(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def self.having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def self.create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def self.create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def self.distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def self.distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def self.references(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def self.references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def self.none(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def self.none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def self.unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def self.unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def self.optimizer_hints(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def self.optimizer_hints(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def self.merge(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def self.merge(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def self.except(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def self.except(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def self.only(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def self.only(*args); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Blob) }
   def self.find(*args); end
@@ -225,98 +225,98 @@ class ActiveStorage::Blob::ActiveRecord_Relation < ActiveRecord::Relation
   sig { params(block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
   def unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def select(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def reselect(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def reselect(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def order(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def group(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def limit(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def offset(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def where(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def preload(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def extract_associated(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def extract_associated(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def includes(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def from(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def lock(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def extending(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def extending(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def or(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def having(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def references(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def none(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def optimizer_hints(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def optimizer_hints(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def merge(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def merge(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def except(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def except(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def only(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def only(*args); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Blob) }
   def find(*args); end
@@ -416,98 +416,98 @@ class ActiveStorage::Blob::ActiveRecord_AssociationRelation < ActiveRecord::Asso
   sig { params(block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
   def unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def select(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def reselect(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def reselect(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def order(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def group(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def limit(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def offset(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def where(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def preload(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def extract_associated(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def extract_associated(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def includes(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def from(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def lock(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def extending(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def or(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def having(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def references(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def none(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def optimizer_hints(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def optimizer_hints(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def merge(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def merge(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def except(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def except(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def only(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def only(*args); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Blob) }
   def find(*args); end
@@ -606,98 +606,98 @@ class ActiveStorage::Blob::ActiveRecord_Associations_CollectionProxy < ActiveRec
   sig { params(block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
   def unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def select(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def reselect(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def reselect(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def order(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def group(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def limit(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def offset(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def where(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def preload(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def extract_associated(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def extract_associated(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def includes(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def from(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def lock(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def extending(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def or(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def having(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def references(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def none(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def optimizer_hints(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def optimizer_hints(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def merge(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def merge(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def except(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def except(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def only(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def only(*args); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Blob) }
   def find(*args); end

--- a/spec/test_data/v6.0/expected_blob.rbi
+++ b/spec/test_data/v6.0/expected_blob.rbi
@@ -100,9 +100,6 @@ class ActiveStorage::Blob < ActiveRecord::Base
   def self.readonly(*args); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def self.extending(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
   def self.or(*args); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
@@ -134,6 +131,9 @@ class ActiveStorage::Blob < ActiveRecord::Base
 
   sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
   def self.only(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def self.extending(*args, &block); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Blob) }
   def self.find(*args); end
@@ -283,9 +283,6 @@ class ActiveStorage::Blob::ActiveRecord_Relation < ActiveRecord::Relation
   def readonly(*args); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def extending(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
   def or(*args); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
@@ -317,6 +314,9 @@ class ActiveStorage::Blob::ActiveRecord_Relation < ActiveRecord::Relation
 
   sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
   def only(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def extending(*args, &block); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Blob) }
   def find(*args); end
@@ -474,9 +474,6 @@ class ActiveStorage::Blob::ActiveRecord_AssociationRelation < ActiveRecord::Asso
   def readonly(*args); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def extending(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
   def or(*args); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
@@ -508,6 +505,9 @@ class ActiveStorage::Blob::ActiveRecord_AssociationRelation < ActiveRecord::Asso
 
   sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
   def only(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def extending(*args, &block); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Blob) }
   def find(*args); end
@@ -664,9 +664,6 @@ class ActiveStorage::Blob::ActiveRecord_Associations_CollectionProxy < ActiveRec
   def readonly(*args); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def extending(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
   def or(*args); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
@@ -698,6 +695,9 @@ class ActiveStorage::Blob::ActiveRecord_Associations_CollectionProxy < ActiveRec
 
   sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
   def only(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def extending(*args, &block); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Blob) }
   def find(*args); end

--- a/spec/test_data/v6.0/expected_internal_metadata.rbi
+++ b/spec/test_data/v6.0/expected_internal_metadata.rbi
@@ -76,98 +76,98 @@ class ActiveRecord::InternalMetadata < ActiveRecord::Base
   sig { params(block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
   def self.unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.select(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def self.select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.reselect(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def self.reselect(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.order(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def self.order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def self.reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.group(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def self.group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.limit(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def self.limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.offset(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def self.offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def self.joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def self.left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def self.left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.where(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def self.where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def self.rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.preload(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def self.preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.extract_associated(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def self.extract_associated(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def self.eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.includes(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def self.includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.from(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def self.from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.lock(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def self.lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def self.readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.extending(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def self.extending(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.or(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def self.or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.having(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def self.having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def self.create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def self.distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.references(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def self.references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.none(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def self.none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def self.unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.optimizer_hints(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def self.optimizer_hints(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.merge(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def self.merge(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.except(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def self.except(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.only(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def self.only(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata) }
   def self.find(*args); end
@@ -253,98 +253,98 @@ class ActiveRecord::InternalMetadata::ActiveRecord_Relation < ActiveRecord::Rela
   sig { params(block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
   def unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def select(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def reselect(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def reselect(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def order(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def group(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def limit(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def offset(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def where(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def preload(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def extract_associated(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def extract_associated(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def includes(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def from(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def lock(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def extending(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def extending(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def or(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def having(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def references(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def none(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def optimizer_hints(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def optimizer_hints(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def merge(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def merge(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def except(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def except(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def only(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def only(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata) }
   def find(*args); end
@@ -438,98 +438,98 @@ class ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation < ActiveR
   sig { params(block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
   def unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def select(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def reselect(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def reselect(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def order(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def group(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def limit(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def offset(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def where(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def preload(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def extract_associated(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def extract_associated(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def includes(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def from(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def lock(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def extending(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def or(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def having(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def references(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def none(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def optimizer_hints(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def optimizer_hints(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def merge(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def merge(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def except(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def except(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def only(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def only(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata) }
   def find(*args); end
@@ -622,98 +622,98 @@ class ActiveRecord::InternalMetadata::ActiveRecord_Associations_CollectionProxy 
   sig { params(block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
   def unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def select(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def reselect(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def reselect(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def order(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def group(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def limit(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def offset(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def where(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def preload(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def extract_associated(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def extract_associated(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def includes(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def from(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def lock(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def extending(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def or(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def having(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def references(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def none(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def optimizer_hints(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def optimizer_hints(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def merge(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def merge(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def except(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def except(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def only(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def only(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata) }
   def find(*args); end

--- a/spec/test_data/v6.0/expected_internal_metadata.rbi
+++ b/spec/test_data/v6.0/expected_internal_metadata.rbi
@@ -134,9 +134,6 @@ class ActiveRecord::InternalMetadata < ActiveRecord::Base
   def self.readonly(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.extending(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
   def self.or(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
@@ -168,6 +165,9 @@ class ActiveRecord::InternalMetadata < ActiveRecord::Base
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
   def self.only(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def self.extending(*args, &block); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata) }
   def self.find(*args); end
@@ -311,9 +311,6 @@ class ActiveRecord::InternalMetadata::ActiveRecord_Relation < ActiveRecord::Rela
   def readonly(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def extending(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
   def or(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
@@ -345,6 +342,9 @@ class ActiveRecord::InternalMetadata::ActiveRecord_Relation < ActiveRecord::Rela
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
   def only(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def extending(*args, &block); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata) }
   def find(*args); end
@@ -496,9 +496,6 @@ class ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation < ActiveR
   def readonly(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def extending(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
   def or(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
@@ -530,6 +527,9 @@ class ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation < ActiveR
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
   def only(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def extending(*args, &block); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata) }
   def find(*args); end
@@ -680,9 +680,6 @@ class ActiveRecord::InternalMetadata::ActiveRecord_Associations_CollectionProxy 
   def readonly(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def extending(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
   def or(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
@@ -714,6 +711,9 @@ class ActiveRecord::InternalMetadata::ActiveRecord_Associations_CollectionProxy 
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
   def only(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def extending(*args, &block); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata) }
   def find(*args); end

--- a/spec/test_data/v6.0/expected_potion.rbi
+++ b/spec/test_data/v6.0/expected_potion.rbi
@@ -35,98 +35,98 @@ class Potion < ApplicationRecord
   sig { params(block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def self.unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def self.select(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def self.select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def self.reselect(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def self.reselect(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def self.order(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def self.order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def self.reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def self.reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def self.group(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def self.group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def self.limit(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def self.limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def self.offset(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def self.offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def self.joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def self.joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def self.left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def self.left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def self.left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def self.left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def self.where(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def self.where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def self.rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def self.rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def self.preload(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def self.preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def self.extract_associated(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def self.extract_associated(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def self.eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def self.eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def self.includes(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def self.includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def self.from(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def self.from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def self.lock(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def self.lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def self.readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def self.readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def self.extending(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def self.extending(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def self.or(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def self.or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def self.having(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def self.having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def self.create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def self.create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def self.distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def self.distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def self.references(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def self.references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def self.none(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def self.none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def self.unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def self.unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def self.optimizer_hints(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def self.optimizer_hints(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def self.merge(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def self.merge(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def self.except(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def self.except(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def self.only(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def self.only(*args); end
 
   sig { params(args: T.untyped).returns(Potion) }
   def self.find(*args); end
@@ -212,98 +212,98 @@ class Potion::ActiveRecord_Relation < ActiveRecord::Relation
   sig { params(block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def select(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def reselect(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def reselect(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def order(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def group(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def limit(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def offset(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def where(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def preload(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def extract_associated(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def extract_associated(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def includes(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def from(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def lock(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def extending(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def extending(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def or(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def having(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def references(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def none(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def optimizer_hints(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def optimizer_hints(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def merge(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def merge(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def except(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def except(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def only(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
+  def only(*args); end
 
   sig { params(args: T.untyped).returns(Potion) }
   def find(*args); end
@@ -397,98 +397,98 @@ class Potion::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelati
   sig { params(block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
   def unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def select(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def reselect(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def reselect(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def order(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def group(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def limit(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def offset(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def where(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def preload(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def extract_associated(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def extract_associated(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def includes(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def from(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def lock(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def extending(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def or(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def having(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def references(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def none(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def optimizer_hints(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def optimizer_hints(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def merge(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def merge(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def except(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def except(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def only(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def only(*args); end
 
   sig { params(args: T.untyped).returns(Potion) }
   def find(*args); end
@@ -581,98 +581,98 @@ class Potion::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associat
   sig { params(block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
   def unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def select(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def reselect(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def reselect(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def order(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def group(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def limit(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def offset(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def where(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def preload(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def extract_associated(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def extract_associated(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def includes(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def from(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def lock(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def extending(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def or(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def having(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def references(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def none(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def optimizer_hints(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def optimizer_hints(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def merge(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def merge(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def except(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def except(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def only(*args, &block); end
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def only(*args); end
 
   sig { params(args: T.untyped).returns(Potion) }
   def find(*args); end

--- a/spec/test_data/v6.0/expected_potion.rbi
+++ b/spec/test_data/v6.0/expected_potion.rbi
@@ -93,9 +93,6 @@ class Potion < ApplicationRecord
   def self.readonly(*args); end
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def self.extending(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
   def self.or(*args); end
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
@@ -127,6 +124,9 @@ class Potion < ApplicationRecord
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
   def self.only(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
+  def self.extending(*args, &block); end
 
   sig { params(args: T.untyped).returns(Potion) }
   def self.find(*args); end
@@ -270,9 +270,6 @@ class Potion::ActiveRecord_Relation < ActiveRecord::Relation
   def readonly(*args); end
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def extending(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
   def or(*args); end
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
@@ -304,6 +301,9 @@ class Potion::ActiveRecord_Relation < ActiveRecord::Relation
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
   def only(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
+  def extending(*args, &block); end
 
   sig { params(args: T.untyped).returns(Potion) }
   def find(*args); end
@@ -455,9 +455,6 @@ class Potion::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelati
   def readonly(*args); end
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def extending(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
   def or(*args); end
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
@@ -489,6 +486,9 @@ class Potion::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelati
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
   def only(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
+  def extending(*args, &block); end
 
   sig { params(args: T.untyped).returns(Potion) }
   def find(*args); end
@@ -639,9 +639,6 @@ class Potion::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associat
   def readonly(*args); end
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def extending(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
   def or(*args); end
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
@@ -673,6 +670,9 @@ class Potion::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associat
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
   def only(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
+  def extending(*args, &block); end
 
   sig { params(args: T.untyped).returns(Potion) }
   def find(*args); end

--- a/spec/test_data/v6.0/expected_schema_migration.rbi
+++ b/spec/test_data/v6.0/expected_schema_migration.rbi
@@ -107,9 +107,6 @@ class ActiveRecord::SchemaMigration < ActiveRecord::Base
   def self.readonly(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.extending(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
   def self.or(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
@@ -141,6 +138,9 @@ class ActiveRecord::SchemaMigration < ActiveRecord::Base
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
   def self.only(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def self.extending(*args, &block); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration) }
   def self.find(*args); end
@@ -284,9 +284,6 @@ class ActiveRecord::SchemaMigration::ActiveRecord_Relation < ActiveRecord::Relat
   def readonly(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def extending(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
   def or(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
@@ -318,6 +315,9 @@ class ActiveRecord::SchemaMigration::ActiveRecord_Relation < ActiveRecord::Relat
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
   def only(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def extending(*args, &block); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration) }
   def find(*args); end
@@ -469,9 +469,6 @@ class ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation < ActiveRe
   def readonly(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def extending(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
   def or(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
@@ -503,6 +500,9 @@ class ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation < ActiveRe
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
   def only(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def extending(*args, &block); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration) }
   def find(*args); end
@@ -653,9 +653,6 @@ class ActiveRecord::SchemaMigration::ActiveRecord_Associations_CollectionProxy <
   def readonly(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def extending(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
   def or(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
@@ -687,6 +684,9 @@ class ActiveRecord::SchemaMigration::ActiveRecord_Associations_CollectionProxy <
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
   def only(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def extending(*args, &block); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration) }
   def find(*args); end

--- a/spec/test_data/v6.0/expected_schema_migration.rbi
+++ b/spec/test_data/v6.0/expected_schema_migration.rbi
@@ -49,98 +49,98 @@ class ActiveRecord::SchemaMigration < ActiveRecord::Base
   sig { params(block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
   def self.unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.select(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def self.select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.reselect(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def self.reselect(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.order(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def self.order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def self.reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.group(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def self.group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.limit(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def self.limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.offset(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def self.offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def self.joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def self.left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def self.left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.where(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def self.where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def self.rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.preload(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def self.preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.extract_associated(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def self.extract_associated(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def self.eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.includes(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def self.includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.from(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def self.from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.lock(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def self.lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def self.readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.extending(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def self.extending(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.or(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def self.or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.having(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def self.having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def self.create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def self.distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.references(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def self.references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.none(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def self.none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def self.unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.optimizer_hints(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def self.optimizer_hints(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.merge(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def self.merge(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.except(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def self.except(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.only(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def self.only(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration) }
   def self.find(*args); end
@@ -226,98 +226,98 @@ class ActiveRecord::SchemaMigration::ActiveRecord_Relation < ActiveRecord::Relat
   sig { params(block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
   def unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def select(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def reselect(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def reselect(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def order(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def group(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def limit(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def offset(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def where(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def preload(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def extract_associated(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def extract_associated(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def includes(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def from(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def lock(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def extending(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def extending(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def or(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def having(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def references(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def none(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def optimizer_hints(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def optimizer_hints(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def merge(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def merge(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def except(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def except(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def only(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def only(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration) }
   def find(*args); end
@@ -411,98 +411,98 @@ class ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation < ActiveRe
   sig { params(block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
   def unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def select(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def reselect(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def reselect(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def order(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def group(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def limit(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def offset(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def where(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def preload(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def extract_associated(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def extract_associated(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def includes(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def from(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def lock(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def extending(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def or(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def having(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def references(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def none(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def optimizer_hints(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def optimizer_hints(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def merge(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def merge(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def except(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def except(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def only(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def only(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration) }
   def find(*args); end
@@ -595,98 +595,98 @@ class ActiveRecord::SchemaMigration::ActiveRecord_Associations_CollectionProxy <
   sig { params(block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
   def unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def select(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def reselect(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def reselect(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def order(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def group(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def limit(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def offset(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def where(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def preload(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def extract_associated(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def extract_associated(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def includes(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def from(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def lock(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def extending(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def or(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def having(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def references(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def none(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def optimizer_hints(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def optimizer_hints(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def merge(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def merge(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def except(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def except(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def only(*args, &block); end
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def only(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration) }
   def find(*args); end

--- a/spec/test_data/v6.0/expected_spell_book.rbi
+++ b/spec/test_data/v6.0/expected_spell_book.rbi
@@ -131,98 +131,98 @@ class SpellBook < ApplicationRecord
   sig { params(block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def self.unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def self.select(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def self.select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def self.reselect(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def self.reselect(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def self.order(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def self.order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def self.reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def self.reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def self.group(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def self.group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def self.limit(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def self.limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def self.offset(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def self.offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def self.joins(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def self.joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def self.left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def self.left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def self.left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def self.left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def self.where(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def self.where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def self.rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def self.rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def self.preload(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def self.preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def self.extract_associated(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def self.extract_associated(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def self.eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def self.eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def self.includes(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def self.includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def self.from(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def self.from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def self.lock(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def self.lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def self.readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def self.readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def self.extending(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def self.extending(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def self.or(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def self.or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def self.having(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def self.having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def self.create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def self.create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def self.distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def self.distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def self.references(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def self.references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def self.none(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def self.none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def self.unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def self.unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def self.optimizer_hints(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def self.optimizer_hints(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def self.merge(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def self.merge(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def self.except(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def self.except(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def self.only(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def self.only(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook) }
   def self.find(*args); end
@@ -326,98 +326,98 @@ class SpellBook::ActiveRecord_Relation < ActiveRecord::Relation
   sig { params(block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def select(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def reselect(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def reselect(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def order(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def group(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def limit(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def offset(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def joins(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def where(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def preload(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def extract_associated(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def extract_associated(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def includes(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def from(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def lock(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def extending(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def extending(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def or(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def having(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def references(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def none(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def optimizer_hints(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def optimizer_hints(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def merge(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def merge(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def except(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def except(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def only(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def only(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook) }
   def find(*args); end
@@ -529,98 +529,98 @@ class SpellBook::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRel
   sig { params(block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
   def unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def select(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def reselect(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def reselect(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def order(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def group(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def limit(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def offset(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def joins(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def where(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def preload(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def extract_associated(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def extract_associated(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def includes(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def from(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def lock(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def extending(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def or(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def having(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def references(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def none(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def optimizer_hints(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def optimizer_hints(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def merge(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def merge(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def except(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def except(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def only(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def only(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook) }
   def find(*args); end
@@ -731,98 +731,98 @@ class SpellBook::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Assoc
   sig { params(block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
   def unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def select(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def reselect(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def reselect(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def order(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def group(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def limit(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def offset(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def joins(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def where(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def preload(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def extract_associated(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def extract_associated(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def includes(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def from(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def lock(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def extending(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def or(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def having(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def references(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def none(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def optimizer_hints(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def optimizer_hints(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def merge(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def merge(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def except(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def except(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def only(*args, &block); end
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def only(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook) }
   def find(*args); end

--- a/spec/test_data/v6.0/expected_spell_book.rbi
+++ b/spec/test_data/v6.0/expected_spell_book.rbi
@@ -189,9 +189,6 @@ class SpellBook < ApplicationRecord
   def self.readonly(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def self.extending(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
   def self.or(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
@@ -223,6 +220,9 @@ class SpellBook < ApplicationRecord
 
   sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
   def self.only(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
+  def self.extending(*args, &block); end
 
   sig { params(args: T.untyped).returns(SpellBook) }
   def self.find(*args); end
@@ -384,9 +384,6 @@ class SpellBook::ActiveRecord_Relation < ActiveRecord::Relation
   def readonly(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def extending(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
   def or(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
@@ -418,6 +415,9 @@ class SpellBook::ActiveRecord_Relation < ActiveRecord::Relation
 
   sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
   def only(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
+  def extending(*args, &block); end
 
   sig { params(args: T.untyped).returns(SpellBook) }
   def find(*args); end
@@ -587,9 +587,6 @@ class SpellBook::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRel
   def readonly(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def extending(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
   def or(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
@@ -621,6 +618,9 @@ class SpellBook::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRel
 
   sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
   def only(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def extending(*args, &block); end
 
   sig { params(args: T.untyped).returns(SpellBook) }
   def find(*args); end
@@ -789,9 +789,6 @@ class SpellBook::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Assoc
   def readonly(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def extending(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
   def or(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
@@ -823,6 +820,9 @@ class SpellBook::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Assoc
 
   sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
   def only(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def extending(*args, &block); end
 
   sig { params(args: T.untyped).returns(SpellBook) }
   def find(*args); end

--- a/spec/test_data/v6.0/expected_squib.rbi
+++ b/spec/test_data/v6.0/expected_squib.rbi
@@ -452,9 +452,6 @@ class Squib < Wizard
   def self.readonly(*args); end
 
   sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.extending(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
   def self.or(*args); end
 
   sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
@@ -486,6 +483,9 @@ class Squib < Wizard
 
   sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
   def self.only(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
+  def self.extending(*args, &block); end
 
   sig { params(args: T.untyped).returns(Squib) }
   def self.find(*args); end
@@ -740,9 +740,6 @@ class Squib::ActiveRecord_Relation < ActiveRecord::Relation
   def readonly(*args); end
 
   sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def extending(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
   def or(*args); end
 
   sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
@@ -774,6 +771,9 @@ class Squib::ActiveRecord_Relation < ActiveRecord::Relation
 
   sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
   def only(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
+  def extending(*args, &block); end
 
   sig { params(args: T.untyped).returns(Squib) }
   def find(*args); end
@@ -1036,9 +1036,6 @@ class Squib::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelatio
   def readonly(*args); end
 
   sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def extending(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
   def or(*args); end
 
   sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
@@ -1070,6 +1067,9 @@ class Squib::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelatio
 
   sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
   def only(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
+  def extending(*args, &block); end
 
   sig { params(args: T.untyped).returns(Squib) }
   def find(*args); end
@@ -1331,9 +1331,6 @@ class Squib::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associati
   def readonly(*args); end
 
   sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def extending(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
   def or(*args); end
 
   sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
@@ -1365,6 +1362,9 @@ class Squib::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associati
 
   sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
   def only(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
+  def extending(*args, &block); end
 
   sig { params(args: T.untyped).returns(Squib) }
   def find(*args); end

--- a/spec/test_data/v6.0/expected_squib.rbi
+++ b/spec/test_data/v6.0/expected_squib.rbi
@@ -394,98 +394,98 @@ class Squib < Wizard
   sig { params(block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
   def self.unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def self.select(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def self.reselect(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.reselect(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def self.order(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def self.reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def self.group(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def self.limit(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def self.offset(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def self.joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def self.left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def self.left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def self.where(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def self.rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def self.preload(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def self.extract_associated(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.extract_associated(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def self.eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def self.includes(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def self.from(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def self.lock(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def self.readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def self.extending(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.extending(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def self.or(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def self.having(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def self.create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def self.distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def self.references(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def self.none(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def self.unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def self.optimizer_hints(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.optimizer_hints(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def self.merge(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.merge(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def self.except(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.except(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def self.only(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.only(*args); end
 
   sig { params(args: T.untyped).returns(Squib) }
   def self.find(*args); end
@@ -682,98 +682,98 @@ class Squib::ActiveRecord_Relation < ActiveRecord::Relation
   sig { params(block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
   def unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def select(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def reselect(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def reselect(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def order(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def group(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def limit(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def offset(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def where(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def preload(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def extract_associated(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def extract_associated(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def includes(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def from(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def lock(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def extending(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def extending(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def or(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def having(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def references(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def none(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def optimizer_hints(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def optimizer_hints(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def merge(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def merge(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def except(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def except(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def only(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def only(*args); end
 
   sig { params(args: T.untyped).returns(Squib) }
   def find(*args); end
@@ -978,98 +978,98 @@ class Squib::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelatio
   sig { params(block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
   def unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def select(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def reselect(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def reselect(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def order(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def group(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def limit(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def offset(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def where(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def preload(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def extract_associated(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def extract_associated(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def includes(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def from(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def lock(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def extending(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def or(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def having(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def references(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def none(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def optimizer_hints(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def optimizer_hints(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def merge(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def merge(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def except(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def except(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def only(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def only(*args); end
 
   sig { params(args: T.untyped).returns(Squib) }
   def find(*args); end
@@ -1273,98 +1273,98 @@ class Squib::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associati
   sig { params(block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
   def unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def select(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def reselect(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def reselect(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def order(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def group(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def limit(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def offset(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def where(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def preload(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def extract_associated(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def extract_associated(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def includes(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def from(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def lock(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def extending(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def or(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def having(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def references(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def none(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def optimizer_hints(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def optimizer_hints(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def merge(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def merge(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def except(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def except(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def only(*args, &block); end
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def only(*args); end
 
   sig { params(args: T.untyped).returns(Squib) }
   def find(*args); end

--- a/spec/test_data/v6.0/expected_wand.rbi
+++ b/spec/test_data/v6.0/expected_wand.rbi
@@ -300,9 +300,6 @@ class Wand < ApplicationRecord
   def self.readonly(*args); end
 
   sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
-  def self.extending(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
   def self.or(*args); end
 
   sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
@@ -334,6 +331,9 @@ class Wand < ApplicationRecord
 
   sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
   def self.only(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
+  def self.extending(*args, &block); end
 
   sig { params(args: T.untyped).returns(Wand) }
   def self.find(*args); end
@@ -504,9 +504,6 @@ class Wand::ActiveRecord_Relation < ActiveRecord::Relation
   def readonly(*args); end
 
   sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
-  def extending(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
   def or(*args); end
 
   sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
@@ -538,6 +535,9 @@ class Wand::ActiveRecord_Relation < ActiveRecord::Relation
 
   sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
   def only(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
+  def extending(*args, &block); end
 
   sig { params(args: T.untyped).returns(Wand) }
   def find(*args); end
@@ -713,9 +713,6 @@ class Wand::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
   def readonly(*args); end
 
   sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def extending(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
   def or(*args); end
 
   sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
@@ -747,6 +744,9 @@ class Wand::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
 
   sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
   def only(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
+  def extending(*args, &block); end
 
   sig { params(args: T.untyped).returns(Wand) }
   def find(*args); end
@@ -921,9 +921,6 @@ class Wand::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associatio
   def readonly(*args); end
 
   sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def extending(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
   def or(*args); end
 
   sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
@@ -955,6 +952,9 @@ class Wand::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associatio
 
   sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
   def only(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
+  def extending(*args, &block); end
 
   sig { params(args: T.untyped).returns(Wand) }
   def find(*args); end

--- a/spec/test_data/v6.0/expected_wand.rbi
+++ b/spec/test_data/v6.0/expected_wand.rbi
@@ -242,98 +242,98 @@ class Wand < ApplicationRecord
   sig { params(block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def self.unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def self.select(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def self.reselect(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.reselect(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def self.order(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def self.reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def self.group(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def self.limit(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def self.offset(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def self.joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def self.left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def self.left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def self.where(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def self.rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def self.preload(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def self.extract_associated(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.extract_associated(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def self.eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def self.includes(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def self.from(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def self.lock(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def self.readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def self.extending(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.extending(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def self.or(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def self.having(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def self.create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def self.distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def self.references(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def self.none(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def self.unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def self.optimizer_hints(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.optimizer_hints(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def self.merge(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.merge(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def self.except(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.except(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def self.only(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.only(*args); end
 
   sig { params(args: T.untyped).returns(Wand) }
   def self.find(*args); end
@@ -446,98 +446,98 @@ class Wand::ActiveRecord_Relation < ActiveRecord::Relation
   sig { params(block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def select(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def reselect(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def reselect(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def order(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def group(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def limit(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def offset(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def where(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def preload(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def extract_associated(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def extract_associated(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def includes(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def from(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def lock(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def extending(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def extending(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def or(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def having(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def references(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def none(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def optimizer_hints(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def optimizer_hints(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def merge(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def merge(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def except(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def except(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def only(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def only(*args); end
 
   sig { params(args: T.untyped).returns(Wand) }
   def find(*args); end
@@ -655,98 +655,98 @@ class Wand::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
   sig { params(block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
   def unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def select(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def reselect(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def reselect(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def order(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def group(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def limit(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def offset(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def where(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def preload(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def extract_associated(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def extract_associated(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def includes(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def from(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def lock(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def extending(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def or(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def having(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def references(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def none(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def optimizer_hints(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def optimizer_hints(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def merge(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def merge(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def except(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def except(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def only(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def only(*args); end
 
   sig { params(args: T.untyped).returns(Wand) }
   def find(*args); end
@@ -863,98 +863,98 @@ class Wand::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associatio
   sig { params(block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
   def unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def select(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def reselect(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def reselect(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def order(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def group(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def limit(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def offset(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def where(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def preload(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def extract_associated(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def extract_associated(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def includes(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def from(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def lock(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def extending(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def or(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def having(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def references(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def none(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def optimizer_hints(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def optimizer_hints(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def merge(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def merge(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def except(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def except(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def only(*args, &block); end
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def only(*args); end
 
   sig { params(args: T.untyped).returns(Wand) }
   def find(*args); end

--- a/spec/test_data/v6.0/expected_wizard.rbi
+++ b/spec/test_data/v6.0/expected_wizard.rbi
@@ -394,98 +394,98 @@ class Wizard < ApplicationRecord
   sig { params(block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def self.unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.select(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.reselect(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.reselect(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.order(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.group(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.limit(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.offset(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.where(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.preload(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.extract_associated(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.extract_associated(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.includes(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.from(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.lock(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.extending(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.extending(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.or(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.having(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.references(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.none(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.optimizer_hints(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.optimizer_hints(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.merge(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.merge(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.except(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.except(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.only(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.only(*args); end
 
   sig { params(args: T.untyped).returns(Wizard) }
   def self.find(*args); end
@@ -682,98 +682,98 @@ class Wizard::ActiveRecord_Relation < ActiveRecord::Relation
   sig { params(block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def select(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def reselect(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def reselect(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def order(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def group(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def limit(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def offset(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def where(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def preload(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def extract_associated(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def extract_associated(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def includes(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def from(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def lock(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def extending(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def extending(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def or(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def having(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def references(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def none(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def optimizer_hints(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def optimizer_hints(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def merge(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def merge(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def except(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def except(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def only(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def only(*args); end
 
   sig { params(args: T.untyped).returns(Wizard) }
   def find(*args); end
@@ -978,98 +978,98 @@ class Wizard::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelati
   sig { params(block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
   def unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def select(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def reselect(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def reselect(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def order(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def group(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def limit(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def offset(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def where(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def preload(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def extract_associated(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def extract_associated(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def includes(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def from(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def lock(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def extending(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def or(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def having(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def references(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def none(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def optimizer_hints(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def optimizer_hints(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def merge(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def merge(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def except(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def except(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def only(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def only(*args); end
 
   sig { params(args: T.untyped).returns(Wizard) }
   def find(*args); end
@@ -1273,98 +1273,98 @@ class Wizard::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associat
   sig { params(block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
   def unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def select(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def reselect(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def reselect(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def order(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def group(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def limit(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def offset(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def where(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def preload(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def extract_associated(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def extract_associated(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def includes(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def from(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def lock(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def extending(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def or(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def having(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def references(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def none(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def optimizer_hints(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def optimizer_hints(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def merge(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def merge(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def except(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def except(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def only(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def only(*args); end
 
   sig { params(args: T.untyped).returns(Wizard) }
   def find(*args); end

--- a/spec/test_data/v6.0/expected_wizard.rbi
+++ b/spec/test_data/v6.0/expected_wizard.rbi
@@ -452,9 +452,6 @@ class Wizard < ApplicationRecord
   def self.readonly(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.extending(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
   def self.or(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
@@ -486,6 +483,9 @@ class Wizard < ApplicationRecord
 
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
   def self.only(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
+  def self.extending(*args, &block); end
 
   sig { params(args: T.untyped).returns(Wizard) }
   def self.find(*args); end
@@ -740,9 +740,6 @@ class Wizard::ActiveRecord_Relation < ActiveRecord::Relation
   def readonly(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def extending(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
   def or(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
@@ -774,6 +771,9 @@ class Wizard::ActiveRecord_Relation < ActiveRecord::Relation
 
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
   def only(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
+  def extending(*args, &block); end
 
   sig { params(args: T.untyped).returns(Wizard) }
   def find(*args); end
@@ -1036,9 +1036,6 @@ class Wizard::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelati
   def readonly(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def extending(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
   def or(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
@@ -1070,6 +1067,9 @@ class Wizard::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelati
 
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
   def only(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def extending(*args, &block); end
 
   sig { params(args: T.untyped).returns(Wizard) }
   def find(*args); end
@@ -1331,9 +1331,6 @@ class Wizard::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associat
   def readonly(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def extending(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
   def or(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
@@ -1365,6 +1362,9 @@ class Wizard::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associat
 
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
   def only(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def extending(*args, &block); end
 
   sig { params(args: T.untyped).returns(Wizard) }
   def find(*args); end

--- a/spec/test_data/v6.0/expected_wizard_wo_spellbook.rbi
+++ b/spec/test_data/v6.0/expected_wizard_wo_spellbook.rbi
@@ -394,98 +394,98 @@ class Wizard < ApplicationRecord
   sig { params(block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def self.unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.select(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.reselect(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.reselect(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.order(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.group(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.limit(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.offset(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.where(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.preload(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.extract_associated(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.extract_associated(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.includes(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.from(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.lock(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.extending(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.extending(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.or(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.having(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.references(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.none(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.optimizer_hints(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.optimizer_hints(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.merge(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.merge(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.except(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.except(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.only(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.only(*args); end
 
   sig { params(args: T.untyped).returns(Wizard) }
   def self.find(*args); end
@@ -682,98 +682,98 @@ class Wizard::ActiveRecord_Relation < ActiveRecord::Relation
   sig { params(block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def select(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def reselect(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def reselect(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def order(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def group(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def limit(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def offset(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def where(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def preload(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def extract_associated(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def extract_associated(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def includes(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def from(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def lock(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def extending(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def extending(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def or(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def having(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def references(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def none(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def optimizer_hints(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def optimizer_hints(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def merge(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def merge(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def except(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def except(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def only(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def only(*args); end
 
   sig { params(args: T.untyped).returns(Wizard) }
   def find(*args); end
@@ -978,98 +978,98 @@ class Wizard::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelati
   sig { params(block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
   def unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def select(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def reselect(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def reselect(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def order(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def group(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def limit(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def offset(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def where(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def preload(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def extract_associated(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def extract_associated(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def includes(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def from(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def lock(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def extending(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def or(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def having(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def references(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def none(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def optimizer_hints(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def optimizer_hints(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def merge(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def merge(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def except(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def except(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def only(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def only(*args); end
 
   sig { params(args: T.untyped).returns(Wizard) }
   def find(*args); end
@@ -1273,98 +1273,98 @@ class Wizard::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associat
   sig { params(block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
   def unscoped(&block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def select(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def select(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def reselect(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def reselect(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def order(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def order(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def reorder(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def reorder(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def group(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def group(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def limit(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def limit(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def offset(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def offset(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def left_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def left_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def left_outer_joins(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def where(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def where(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def rewhere(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def rewhere(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def preload(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def preload(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def extract_associated(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def extract_associated(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def eager_load(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def eager_load(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def includes(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def includes(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def from(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def from(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def lock(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def lock(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def readonly(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def readonly(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def extending(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def or(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def or(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def having(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def having(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def create_with(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def create_with(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def distinct(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def distinct(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def references(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def references(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def none(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def none(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def unscope(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def unscope(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def optimizer_hints(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def optimizer_hints(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def merge(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def merge(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def except(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def except(*args); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def only(*args, &block); end
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def only(*args); end
 
   sig { params(args: T.untyped).returns(Wizard) }
   def find(*args); end

--- a/spec/test_data/v6.0/expected_wizard_wo_spellbook.rbi
+++ b/spec/test_data/v6.0/expected_wizard_wo_spellbook.rbi
@@ -452,9 +452,6 @@ class Wizard < ApplicationRecord
   def self.readonly(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.extending(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
   def self.or(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
@@ -486,6 +483,9 @@ class Wizard < ApplicationRecord
 
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
   def self.only(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
+  def self.extending(*args, &block); end
 
   sig { params(args: T.untyped).returns(Wizard) }
   def self.find(*args); end
@@ -740,9 +740,6 @@ class Wizard::ActiveRecord_Relation < ActiveRecord::Relation
   def readonly(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def extending(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
   def or(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
@@ -774,6 +771,9 @@ class Wizard::ActiveRecord_Relation < ActiveRecord::Relation
 
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
   def only(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
+  def extending(*args, &block); end
 
   sig { params(args: T.untyped).returns(Wizard) }
   def find(*args); end
@@ -1036,9 +1036,6 @@ class Wizard::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelati
   def readonly(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def extending(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
   def or(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
@@ -1070,6 +1067,9 @@ class Wizard::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelati
 
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
   def only(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def extending(*args, &block); end
 
   sig { params(args: T.untyped).returns(Wizard) }
   def find(*args); end
@@ -1331,9 +1331,6 @@ class Wizard::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associat
   def readonly(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def extending(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
   def or(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
@@ -1365,6 +1362,9 @@ class Wizard::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associat
 
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
   def only(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def extending(*args, &block); end
 
   sig { params(args: T.untyped).returns(Wizard) }
   def find(*args); end


### PR DESCRIPTION
Some of these methods (e.g. `left_joins`) do not take a block at all. Others (e.g. `select`) can take a block, but `sorbet` is not expressive enough to [properly typecheck](https://github.com/chanzuckerberg/sorbet-rails/issues/152) calls where a block is passed in.

I checked all of these functions and think it's correct that either of those two conditions are true for all of them, but checking was fairly repetitive so it would be great if someone could check my work.

