### PR TITLE
Add warning about using with `sorbet-runtime`

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ gem 'sorbet-rails'
 ❯ bundle install
 ```
 
-Warning: if you're using `sorbet-runtime`, make sure you add `sorbet-rails` to the same environments as `sorbet-runtime`. (In other words, don't run `sorbet-runtime` in production, and `sorbet-rails` only in development.) This is because `sorbet-rails` modifies some Rails internals to make type checking simpler, and these will blow up at runtime if you aren't running this gem. See [`SorbetRails::Railtie`](https://github.com/chanzuckerberg/sorbet-rails/blob/master/lib/sorbet-rails/railtie.rb).
+Warning: *don't* add `sorbet-rails` to a specific environment group (eg. `development` only). `sorbet-rails` adds a bunch of helper methods to your Rails runtime as well as generators for RBI files. You'll want to run the gem in all environments.
 
 3. Generate RBI files for your routes, models, etc
 ```sh

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ gem 'sorbet-rails'
 ❯ bundle install
 ```
 
+Warning: if you're using `sorbet-runtime`, make sure you add `sorbet-rails` to the same environments as `sorbet-runtime`. (In other words, don't run `sorbet-runtime` in production, and `sorbet-rails` only in development.) This is because `sorbet-rails` modifies some Rails internals to make type checking simpler, and these will blow up at runtime if you aren't running this gem. See [`SorbetRails::Railtie`](https://github.com/chanzuckerberg/sorbet-rails/blob/master/lib/sorbet-rails/railtie.rb).
+
 3. Generate RBI files for your routes, models, etc
 ```sh
 ❯ rake rails_rbi:routes


### PR DESCRIPTION
Maybe this is overzealous, but we got really burned by it. We were using `sorbet-rails` in development only, but `sorbet-runtime` in all environments. This meant we were able to access `X::ActiveRecord_Relation` in development, and thus someone used that in a method signature. When we deployed this code it failed in production because [this railtie](https://github.com/chanzuckerberg/sorbet-rails/blob/master/lib/sorbet-rails/railtie.rb#L30) didn't run, so the constant was still private.

Adding a warning so it doesn't happen to other people.