### PR TITLE
fix sorbet_util: extract params when param doesn't have name

### DIFF
--- a/lib/sorbet-rails/sorbet_utils.rb
+++ b/lib/sorbet-rails/sorbet_utils.rb
@@ -11,7 +11,10 @@ module SorbetRails::SorbetUtils
     signature = T::Private::Methods.signature_for_method(method_def)
 
     parameters_with_type = signature.nil? ?
-      method_def.parameters.map { |p| p + ['T.untyped'] } : # append untyped to each
+      method_def.parameters.map { |p|
+        p1 = p.size == 1 ? p + ['_'] : p # give param without name default name _
+        p1 + ['T.untyped'] # append untyped as type of each param
+      } :
       get_ordered_parameters_with_type(signature)
 
     parameters_with_type.map do |param_def|

--- a/spec/sorbet_utils_spec.rb
+++ b/spec/sorbet_utils_spec.rb
@@ -33,6 +33,13 @@ class SorbetUtilsExampleClass
   def method_with_block_return(&p1); end
 
   def method_without_sig(p1, p2, *p3, p4:, **p5, &p6); end
+
+  sig { params(p1: String, p2: String, p3: Integer).void }
+  def method_with_default(p1, p2='abc', p3: 123); end
+
+  def method_with_missing_args_name(p1, *); end
+
+  def method_with_missing_kwargs_name(p1, **); end
 end
 
 RSpec.describe SorbetRails::SorbetUtils do
@@ -121,6 +128,36 @@ RSpec.describe SorbetRails::SorbetUtils do
       Parameter.new('p4', type: 'T.untyped'),
       Parameter.new('**p5', type: 'T.untyped'),
       Parameter.new('&p6', type: 'T.untyped'),
+    ])
+  end
+
+  # TODO it doesn't know how to extract default values from method yet
+  # Would have to rely on reading & parsing the source code :(
+  # it 'works when method arguments have default' do
+  #   method_def = SorbetUtilsExampleClass.instance_method(:method_with_default)
+  #   parameters = SorbetRails::SorbetUtils.parameters_from_method_def(method_def)
+  #   expect(parameters).to match_array([
+  #     Parameter.new('p1', type: 'T.untyped'),
+  #     Parameter.new('p2', type: 'T.untyped', default: '"abc"'),
+  #     Parameter.new('p3:', type: 'T.untyped', default: '123'),
+  #   ])
+  # end
+
+  it 'works when method args doesnt have name' do
+    method_def = SorbetUtilsExampleClass.instance_method(:method_with_missing_args_name)
+    parameters = SorbetRails::SorbetUtils.parameters_from_method_def(method_def)
+    expect(parameters).to match_array([
+      Parameter.new('p1', type: 'T.untyped'),
+      Parameter.new('*_', type: 'T.untyped'),
+    ])
+  end
+
+  it 'works when method kwargs doesnt have name' do
+    method_def = SorbetUtilsExampleClass.instance_method(:method_with_missing_kwargs_name)
+    parameters = SorbetRails::SorbetUtils.parameters_from_method_def(method_def)
+    expect(parameters).to match_array([
+      Parameter.new('p1', type: 'T.untyped'),
+      Parameter.new('**_', type: 'T.untyped'),
     ])
   end
 end


### PR DESCRIPTION
This fixes it when there are method with missing parameter name:
```
  def method_with_missing_args_name(p1, *); end

  def method_with_missing_kwargs_name(p1, **); end
```