### PR TITLE
Fix bug with usage of `present?`

### DIFF
--- a/lib/sorbet-rails/model_plugins/active_record_assoc.rb
+++ b/lib/sorbet-rails/model_plugins/active_record_assoc.rb
@@ -56,9 +56,9 @@ class SorbetRails::ModelPlugins::ActiveRecordAssoc < SorbetRails::ModelPlugins::
     # optional (via `optional` or `!required` or `!belongs_to_required_by_default`)
     return false if !reflection.belongs_to?
 
-    if reflection.options[:required].present?
+    if reflection.options.key?(:required)
       !!reflection.options[:required]
-    elsif reflection.options[:optional].present?
+    elsif reflection.options.key?(:optional)
       !reflection.options[:optional]
     else
       !!reflection.active_record.belongs_to_required_by_default


### PR DESCRIPTION
Follow-up to https://github.com/chanzuckerberg/sorbet-rails/pull/206

```
> reflection.options
=> {:inverse_of=>:payment_intents, :optional=>false}
```

```
> reflection.options[:optional].present?
=> false
```

```
> reflection.options.key?(:optional)
=> true
```