### PR TITLE
Include Routes in Mailers

### DIFF
--- a/lib/sorbet-rails/routes_rbi_formatter.rb
+++ b/lib/sorbet-rails/routes_rbi_formatter.rb
@@ -31,6 +31,10 @@ class SorbetRails::RoutesRbiFormatter
     @parlour.root.create_module('ActionView::Helpers') do |mod|
       mod.create_include('GeneratedUrlHelpers')
     end
+
+    @parlour.root.create_class('ActionMailer::Base') do |mod|
+      mod.create_include('GeneratedUrlHelpers')
+    end
   end
 
   sig { params(routes: T.untyped, filter: T.untyped).void }

--- a/spec/test_data/v5.0/expected_routes.rbi
+++ b/spec/test_data/v5.0/expected_routes.rbi
@@ -9,6 +9,10 @@ module ActionView::Helpers
   include GeneratedUrlHelpers
 end
 
+class ActionMailer::Base
+  include GeneratedUrlHelpers
+end
+
 module GeneratedUrlHelpers
   # Sigs for route /test/index(.:format)
   sig { params(args: T.untyped, kwargs: T.untyped).returns(String) }

--- a/spec/test_data/v5.1/expected_routes.rbi
+++ b/spec/test_data/v5.1/expected_routes.rbi
@@ -9,6 +9,10 @@ module ActionView::Helpers
   include GeneratedUrlHelpers
 end
 
+class ActionMailer::Base
+  include GeneratedUrlHelpers
+end
+
 module GeneratedUrlHelpers
   # Sigs for route /test/index(.:format)
   sig { params(args: T.untyped, kwargs: T.untyped).returns(String) }

--- a/spec/test_data/v5.2/expected_routes.rbi
+++ b/spec/test_data/v5.2/expected_routes.rbi
@@ -9,6 +9,10 @@ module ActionView::Helpers
   include GeneratedUrlHelpers
 end
 
+class ActionMailer::Base
+  include GeneratedUrlHelpers
+end
+
 module GeneratedUrlHelpers
   # Sigs for route /test/index(.:format)
   sig { params(args: T.untyped, kwargs: T.untyped).returns(String) }

--- a/spec/test_data/v6.0/expected_routes.rbi
+++ b/spec/test_data/v6.0/expected_routes.rbi
@@ -9,6 +9,10 @@ module ActionView::Helpers
   include GeneratedUrlHelpers
 end
 
+class ActionMailer::Base
+  include GeneratedUrlHelpers
+end
+
 module GeneratedUrlHelpers
   # Sigs for route /test/index(.:format)
   sig { params(args: T.untyped, kwargs: T.untyped).returns(String) }


### PR DESCRIPTION
Routes are accessible in Mailers by default (both the Mailer class and the relevant view).

https://guides.rubyonrails.org/action_mailer_basics.html#generating-urls-in-action-mailer-views doesn't explicitly confirm this, but I tested in a brand new Rails app and it worked as expected.