### PR TITLE
Handle NotImplementedError raises

### DIFF
--- a/lib/sorbet-rails/tasks/rails_rbi.rake
+++ b/lib/sorbet-rails/tasks/rails_rbi.rake
@@ -113,7 +113,7 @@ namespace :rails_rbi do
       begin
         formatter = SorbetRails::ModelRbiFormatter.new(model_class, available_class_names)
         [model_class.name, formatter.generate_rbi]
-      rescue StandardError => ex
+      rescue StandardError, NotImplementedError => ex
         puts "---"
         puts "Error when handling model #{model_class.name}: #{ex}"
         nil


### PR DESCRIPTION
Dearest Reviewer,

I hope all is well this November.  It as been a long month for me and I look forward to the amazing things sorbet will help me with. I have interface classes that raise NotImplementedError and the model process is dying on it. I have found locally this to be an acceptable change. I hope that you agree. 

Changes
Add NotImplementedError to the model processing exception handling for interface like classes.

To reproduce add a method that raises NotImplementedError. 

Becker