### PR TITLE
Fix belongs to and required returns nil

### DIFF
--- a/lib/sorbet-rails/model_plugins/active_record_assoc.rb
+++ b/lib/sorbet-rails/model_plugins/active_record_assoc.rb
@@ -66,7 +66,7 @@ class SorbetRails::ModelPlugins::ActiveRecordAssoc < SorbetRails::ModelPlugins::
       end
 
     column_def = @columns_hash[reflection.foreign_key.to_s]
-    db_required_config = column_def && !column_def.null
+    db_required_config = column_def.present? && !column_def.null
 
     if rails_required_config && !db_required_config
       puts "Warning: belongs_to association #{reflection.name} is required at the application

--- a/spec/generators/rails-template.rb
+++ b/spec/generators/rails-template.rb
@@ -95,6 +95,7 @@ def create_models
     # an abstract class that has no table
     class Potion < ApplicationRecord
       self.abstract_class = true
+      belongs_to :wizard, required: false
     end
   RUBY
 

--- a/spec/model_rbi_formatter_spec.rb
+++ b/spec/model_rbi_formatter_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe SorbetRails::ModelRbiFormatter do
   end
 
   it 'does not throw an error when given an abstract class' do
-    formatter = SorbetRails::ModelRbiFormatter.new(Potion, Set.new(['Potion']))
+    formatter = SorbetRails::ModelRbiFormatter.new(Potion, Set.new(['Potion', 'Wizard']))
     expect_match_file(
       formatter.generate_rbi,
       'expected_potion.rbi',

--- a/spec/support/v5.0/Gemfile
+++ b/spec/support/v5.0/Gemfile
@@ -11,7 +11,7 @@ gem 'rails', '~> 5.0.7'
 # Use sqlite3 as the database for Active Record
 gem 'sqlite3', '~> 1.3.6'
 # Use Puma as the app server
-gem 'puma', '~> 3.12'
+gem 'puma', '~> 3.0'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem 'jbuilder', '~> 2.5'
 # Use ActiveModel has_secure_password

--- a/spec/support/v5.0/Gemfile.lock
+++ b/spec/support/v5.0/Gemfile.lock
@@ -104,10 +104,10 @@ GEM
       thor (>= 0.18.1, < 2.0)
     rainbow (3.0.0)
     rake (13.0.1)
-    sorbet (0.4.5135)
-      sorbet-static (= 0.4.5135)
-    sorbet-runtime (0.4.5135)
-    sorbet-static (0.4.5135-universal-darwin-14)
+    sorbet (0.4.5136)
+      sorbet-static (= 0.4.5136)
+    sorbet-runtime (0.4.5136)
+    sorbet-static (0.4.5136-universal-darwin-14)
     sprockets (4.0.0)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -130,7 +130,7 @@ PLATFORMS
 DEPENDENCIES
   byebug
   jbuilder (~> 2.5)
-  puma (~> 3.12)
+  puma (~> 3.0)
   rails (~> 5.0.7)
   sorbet
   sorbet-rails!

--- a/spec/support/v5.0/app/models/potion.rb
+++ b/spec/support/v5.0/app/models/potion.rb
@@ -2,4 +2,5 @@
 # an abstract class that has no table
 class Potion < ApplicationRecord
   self.abstract_class = true
+  belongs_to :wizard, required: false
 end

--- a/spec/support/v5.1/Gemfile
+++ b/spec/support/v5.1/Gemfile
@@ -11,7 +11,7 @@ gem 'rails', '~> 5.1.7'
 # Use sqlite3 as the database for Active Record
 gem 'sqlite3'
 # Use Puma as the app server
-gem 'puma', '~> 3.12'
+gem 'puma', '~> 3.7'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem 'jbuilder', '~> 2.5'
 # Use ActiveModel has_secure_password

--- a/spec/support/v5.1/Gemfile.lock
+++ b/spec/support/v5.1/Gemfile.lock
@@ -105,10 +105,10 @@ GEM
       thor (>= 0.18.1, < 2.0)
     rainbow (3.0.0)
     rake (13.0.1)
-    sorbet (0.4.5135)
-      sorbet-static (= 0.4.5135)
-    sorbet-runtime (0.4.5135)
-    sorbet-static (0.4.5135-universal-darwin-14)
+    sorbet (0.4.5136)
+      sorbet-static (= 0.4.5136)
+    sorbet-runtime (0.4.5136)
+    sorbet-static (0.4.5136-universal-darwin-14)
     sprockets (4.0.0)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -136,7 +136,7 @@ PLATFORMS
 DEPENDENCIES
   byebug
   jbuilder (~> 2.5)
-  puma (~> 3.12)
+  puma (~> 3.7)
   rails (~> 5.1.7)
   sorbet
   sorbet-rails!

--- a/spec/support/v5.1/app/models/potion.rb
+++ b/spec/support/v5.1/app/models/potion.rb
@@ -2,4 +2,5 @@
 # an abstract class that has no table
 class Potion < ApplicationRecord
   self.abstract_class = true
+  belongs_to :wizard, required: false
 end

--- a/spec/support/v5.2/Gemfile
+++ b/spec/support/v5.2/Gemfile
@@ -8,7 +8,7 @@ gem 'rails', '~> 5.2.3'
 # Use sqlite3 as the database for Active Record
 gem 'sqlite3'
 # Use Puma as the app server
-gem 'puma', '~> 3.12'
+gem 'puma', '~> 3.11'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem 'jbuilder', '~> 2.5'
 # Use ActiveModel has_secure_password

--- a/spec/support/v5.2/Gemfile.lock
+++ b/spec/support/v5.2/Gemfile.lock
@@ -113,10 +113,10 @@ GEM
       thor (>= 0.19.0, < 2.0)
     rainbow (3.0.0)
     rake (13.0.1)
-    sorbet (0.4.5135)
-      sorbet-static (= 0.4.5135)
-    sorbet-runtime (0.4.5135)
-    sorbet-static (0.4.5135-universal-darwin-14)
+    sorbet (0.4.5136)
+      sorbet-static (= 0.4.5136)
+    sorbet-runtime (0.4.5136)
+    sorbet-static (0.4.5136-universal-darwin-14)
     sprockets (4.0.0)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -144,7 +144,7 @@ PLATFORMS
 DEPENDENCIES
   byebug
   jbuilder (~> 2.5)
-  puma (~> 3.12)
+  puma (~> 3.11)
   rails (~> 5.2.3)
   sorbet
   sorbet-rails!

--- a/spec/support/v5.2/app/models/potion.rb
+++ b/spec/support/v5.2/app/models/potion.rb
@@ -2,4 +2,5 @@
 # an abstract class that has no table
 class Potion < ApplicationRecord
   self.abstract_class = true
+  belongs_to :wizard, required: false
 end

--- a/spec/support/v6.0/Gemfile
+++ b/spec/support/v6.0/Gemfile
@@ -8,7 +8,7 @@ gem 'rails', '~> 6.0.0'
 # Use sqlite3 as the database for Active Record
 gem 'sqlite3', '~> 1.4'
 # Use Puma as the app server
-gem 'puma', '~> 3.12'
+gem 'puma', '~> 3.11'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem 'jbuilder', '~> 2.7'
 # Use Active Model has_secure_password

--- a/spec/support/v6.0/Gemfile.lock
+++ b/spec/support/v6.0/Gemfile.lock
@@ -128,10 +128,10 @@ GEM
       thor (>= 0.20.3, < 2.0)
     rainbow (3.0.0)
     rake (13.0.1)
-    sorbet (0.4.5135)
-      sorbet-static (= 0.4.5135)
-    sorbet-runtime (0.4.5135)
-    sorbet-static (0.4.5135-universal-darwin-14)
+    sorbet (0.4.5136)
+      sorbet-static (= 0.4.5136)
+    sorbet-runtime (0.4.5136)
+    sorbet-static (0.4.5136-universal-darwin-14)
     sprockets (4.0.0)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -160,7 +160,7 @@ PLATFORMS
 DEPENDENCIES
   byebug
   jbuilder (~> 2.7)
-  puma (~> 3.12)
+  puma (~> 3.11)
   rails (~> 6.0.0)
   sorbet
   sorbet-rails!

--- a/spec/support/v6.0/app/models/potion.rb
+++ b/spec/support/v6.0/app/models/potion.rb
@@ -2,4 +2,5 @@
 # an abstract class that has no table
 class Potion < ApplicationRecord
   self.abstract_class = true
+  belongs_to :wizard, required: false
 end

--- a/spec/test_data/v5.0/expected_potion.rbi
+++ b/spec/test_data/v5.0/expected_potion.rbi
@@ -7,6 +7,16 @@ module Potion::ActiveRelation_WhereNot
   def not(opts, *rest); end
 end
 
+module Potion::GeneratedAssociationMethods
+  extend T::Sig
+
+  sig { returns(T.nilable(::Wizard)) }
+  def wizard; end
+
+  sig { params(value: T.nilable(::Wizard)).void }
+  def wizard=(value); end
+end
+
 module Potion::CustomFinderMethods
   sig { params(limit: Integer).returns(T::Array[Potion]) }
   def first_n(limit); end
@@ -25,6 +35,7 @@ module Potion::CustomFinderMethods
 end
 
 class Potion < ApplicationRecord
+  include Potion::GeneratedAssociationMethods
   extend Potion::CustomFinderMethods
   extend T::Sig
   extend T::Generic

--- a/spec/test_data/v5.1/expected_potion.rbi
+++ b/spec/test_data/v5.1/expected_potion.rbi
@@ -7,6 +7,16 @@ module Potion::ActiveRelation_WhereNot
   def not(opts, *rest); end
 end
 
+module Potion::GeneratedAssociationMethods
+  extend T::Sig
+
+  sig { returns(T.nilable(::Wizard)) }
+  def wizard; end
+
+  sig { params(value: T.nilable(::Wizard)).void }
+  def wizard=(value); end
+end
+
 module Potion::CustomFinderMethods
   sig { params(limit: Integer).returns(T::Array[Potion]) }
   def first_n(limit); end
@@ -25,6 +35,7 @@ module Potion::CustomFinderMethods
 end
 
 class Potion < ApplicationRecord
+  include Potion::GeneratedAssociationMethods
   extend Potion::CustomFinderMethods
   extend T::Sig
   extend T::Generic

--- a/spec/test_data/v5.2/expected_potion.rbi
+++ b/spec/test_data/v5.2/expected_potion.rbi
@@ -7,6 +7,16 @@ module Potion::ActiveRelation_WhereNot
   def not(opts, *rest); end
 end
 
+module Potion::GeneratedAssociationMethods
+  extend T::Sig
+
+  sig { returns(T.nilable(::Wizard)) }
+  def wizard; end
+
+  sig { params(value: T.nilable(::Wizard)).void }
+  def wizard=(value); end
+end
+
 module Potion::CustomFinderMethods
   sig { params(limit: Integer).returns(T::Array[Potion]) }
   def first_n(limit); end
@@ -25,6 +35,7 @@ module Potion::CustomFinderMethods
 end
 
 class Potion < ApplicationRecord
+  include Potion::GeneratedAssociationMethods
   extend Potion::CustomFinderMethods
   extend T::Sig
   extend T::Generic

--- a/spec/test_data/v6.0/expected_potion.rbi
+++ b/spec/test_data/v6.0/expected_potion.rbi
@@ -7,6 +7,16 @@ module Potion::ActiveRelation_WhereNot
   def not(opts, *rest); end
 end
 
+module Potion::GeneratedAssociationMethods
+  extend T::Sig
+
+  sig { returns(T.nilable(::Wizard)) }
+  def wizard; end
+
+  sig { params(value: T.nilable(::Wizard)).void }
+  def wizard=(value); end
+end
+
 module Potion::CustomFinderMethods
   sig { params(limit: Integer).returns(T::Array[Potion]) }
   def first_n(limit); end
@@ -25,6 +35,7 @@ module Potion::CustomFinderMethods
 end
 
 class Potion < ApplicationRecord
+  include Potion::GeneratedAssociationMethods
   extend Potion::CustomFinderMethods
   extend T::Sig
   extend T::Generic


### PR DESCRIPTION
@ghiculescu found a bug related to `belongs_to_and_required` return `nil` instead of T::Boolean. I fix it, but I also feel that this method, or methods that return T::Boolean should probably return T.nilable(T::Boolean), because it's very common in ruby/rails to return `nil` for boolean-y functions. Mmmm