### PR TITLE
Add ActiveRecord::Relation#empty?

### DIFF
--- a/lib/bundled_rbi/active_record_relation.rbi
+++ b/lib/bundled_rbi/active_record_relation.rbi
@@ -69,6 +69,9 @@ class ActiveRecord::Relation
   def any?; end
 
   sig { returns(T::Boolean) }
+  def empty?; end
+
+  sig { returns(T::Boolean) }
   def many?; end
 
   sig { returns(T::Boolean) }


### PR DESCRIPTION
`any?` is the opposite of ... https://github.com/rails/rails/blob/6-0-stable/activerecord/lib/active_record/relation.rb#L265-L268