### PR TITLE
Use Rails.autoloaders to eagerload more stuff in Rails 6

### DIFF
--- a/lib/sorbet-rails/utils.rb
+++ b/lib/sorbet-rails/utils.rb
@@ -11,6 +11,11 @@ module SorbetRails::Utils
     # https://github.com/rails/rails/blob/master/railties/lib/rails/application/finisher.rb#L116
     # But this is not applied to Rails.application.eager_load! method
     Zeitwerk::Loader.eager_load_all if defined?(Zeitwerk)
+    # Let's eager_load more stuff so that we have the full picture of the runtime environment.
+    # Also only applicable to Rails 6.
+    if Rails.respond_to?(:autoloaders)
+      Rails.autoloaders.each(&:eager_load)
+    end
   end
 
   sig { params(method_name: String).returns(T::Boolean) }


### PR DESCRIPTION
Ufuk recommended it here. It seems to apply to Rails 6 only, but seems like a useful addition

https://sorbet-ruby.slack.com/archives/CJL5B3CEN/p1579907256019200?thread_ts=1579233124.001100&cid=CJL5B3CEN