### PR TITLE
Add generated url helpers implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,9 +192,9 @@ end
 
 When using url helpers like _url or _path methods outside of a controller,
 we usually have to add `include Rails.application.routes.url_helpers`. However,
-Sorbet does not allow [including dynamic module](https://sorbet.org/docs/error-reference#4002). Sorbet Rails provides a drop-in replacement module for
-the dynamic url_helpers module, called `GeneratedUrlHelpers`. Following code
-should resolve the sorbet type-check error:
+Sorbet does not allow [including dynamic module](https://sorbet.org/docs/error-reference#4002).
+Sorbet Rails provides a drop-in replacement module for the dynamic url_helpers module, called `GeneratedUrlHelpers`.
+Following code change should resolve the sorbet type-check error:
 
 ```ruby
 class MyClass

--- a/README.md
+++ b/README.md
@@ -188,6 +188,21 @@ class ModelName
 end
 ```
 
+### Replace `Rails.application.routes.url_helpers`
+
+When using url helpers like _url or _path methods outside of a controller,
+we usually have to add `include Rails.application.routes.url_helpers`. However,
+Sorbet does not allow [including dynamic module](https://sorbet.org/docs/error-reference#4002). Sorbet Rails provides a drop-in replacement module for
+the dynamic url_helpers module, called `GeneratedUrlHelpers`. Following code
+should resolve the sorbet type-check error:
+
+```ruby
+class MyClass
+-  include Rails.application.routes.url_helpers
++  include GeneratedUrlHelpers
+end
+```
+
 ### `find`, `first` and `last`
 
 These 3 methods can either return a single nilable record or an array of records. Sorbet does not allow us to define multiple signatures for a function ([except stdlib](https://github.com/chanzuckerberg/sorbet-rails/issues/18)). It doesn't support defining one function signature that has varying returning value depending on the input parameter type. We opt to define the most commonly used signature for these methods, and monkey-patch new functions for the secondary use case.

--- a/README.md
+++ b/README.md
@@ -191,8 +191,9 @@ end
 ### Replace `Rails.application.routes.url_helpers`
 
 When using url helpers like _url or _path methods outside of a controller,
-we usually have to add `include Rails.application.routes.url_helpers`. However,
-Sorbet does not allow [including dynamic module](https://sorbet.org/docs/error-reference#4002).
+we usually have to add `include Rails.application.routes.url_helpers` in the class.
+However, Sorbet does not allow code that
+[includes dynamic module](https://sorbet.org/docs/error-reference#4002).
 Sorbet Rails provides a drop-in replacement module for the dynamic url_helpers module, called `GeneratedUrlHelpers`.
 Following code change should resolve the sorbet type-check error:
 

--- a/lib/sorbet-rails/rails_mixins/generated_url_helpers.rb
+++ b/lib/sorbet-rails/rails_mixins/generated_url_helpers.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: ignore
 
 # Sorbet does not allow dynamic includes like `url_helpers`
 # This module is a drop-in replacement for the dynamic include, and should

--- a/lib/sorbet-rails/rails_mixins/generated_url_helpers.rb
+++ b/lib/sorbet-rails/rails_mixins/generated_url_helpers.rb
@@ -1,0 +1,16 @@
+# typed: false
+
+# Sorbet does not allow dynamic includes like `url_helpers`
+# This module is a drop-in replacement for the dynamic include, and should
+# contains all _url, _path methods as defined in the URL helpers.
+#
+# eg:
+#
+# class MyClass
+# - include Rails.application.routes.url_helpers
+# + include GeneratedUrlHelpers
+# end
+#
+module GeneratedUrlHelpers
+  include Rails.application.routes.url_helpers
+end

--- a/lib/sorbet-rails/railtie.rb
+++ b/lib/sorbet-rails/railtie.rb
@@ -41,6 +41,7 @@ class SorbetRails::Railtie < Rails::Railtie
 
     ActiveSupport.on_load(:action_controller) do
       require "sorbet-rails/rails_mixins/custom_params_methods"
+      require "sorbet-rails/rails_mixins/generated_url_helpers"
       ActionController::Parameters.include SorbetRails::CustomParamsMethods
     end
 

--- a/spec/generators/sorbet_test_cases.rb
+++ b/spec/generators/sorbet_test_cases.rb
@@ -251,3 +251,14 @@ end
 Wizard.all.pluck_to_tstruct(TA[WizardStruct].new).each do |row|
   T.assert_type!(row, WizardStruct)
 end
+
+
+# -- GeneratedUrlHelpers
+class TestHelper
+  include GeneratedUrlHelpers
+
+  def test_url_helper
+    T.assert_type!(test_index_url, String)
+  end
+end
+TestHelper.new.test_url_helper

--- a/spec/generators/sorbet_test_cases.rb
+++ b/spec/generators/sorbet_test_cases.rb
@@ -257,7 +257,17 @@ end
 class TestHelper
   include GeneratedUrlHelpers
 
+  # need to implement this for the url
+  def default_url_options
+    {
+      protocol: 'http',
+      host: 'localhost',
+      port: 3000,
+    }
+  end
+
   def test_url_helper
+    T.assert_type!(test_index_path, String)
     T.assert_type!(test_index_url, String)
   end
 end

--- a/spec/support/v5.0/sorbet_test_cases.rb
+++ b/spec/support/v5.0/sorbet_test_cases.rb
@@ -257,8 +257,17 @@ end
 class TestHelper
   include GeneratedUrlHelpers
 
+  # need to implement this for the url
+  def default_url_options
+    {
+      protocol: 'http',
+      host: 'localhost',
+      port: 3000,
+    }
+  end
+
   def test_url_helper
-    T.assert_type!(test_index_url, String)
+    T.assert_type!(test_index_path, String)
   end
 end
 TestHelper.new.test_url_helper

--- a/spec/support/v5.0/sorbet_test_cases.rb
+++ b/spec/support/v5.0/sorbet_test_cases.rb
@@ -251,3 +251,14 @@ end
 Wizard.all.pluck_to_tstruct(TA[WizardStruct].new).each do |row|
   T.assert_type!(row, WizardStruct)
 end
+
+
+# -- GeneratedUrlHelpers
+class TestHelper
+  include GeneratedUrlHelpers
+
+  def test_url_helper
+    T.assert_type!(test_index_url, String)
+  end
+end
+TestHelper.new.test_url_helper

--- a/spec/support/v5.1/sorbet_test_cases.rb
+++ b/spec/support/v5.1/sorbet_test_cases.rb
@@ -257,8 +257,17 @@ end
 class TestHelper
   include GeneratedUrlHelpers
 
+  # need to implement this for the url
+  def default_url_options
+    {
+      protocol: 'http',
+      host: 'localhost',
+      port: 3000,
+    }
+  end
+
   def test_url_helper
-    T.assert_type!(test_index_url, String)
+    T.assert_type!(test_index_path, String)
   end
 end
 TestHelper.new.test_url_helper

--- a/spec/support/v5.1/sorbet_test_cases.rb
+++ b/spec/support/v5.1/sorbet_test_cases.rb
@@ -251,3 +251,14 @@ end
 Wizard.all.pluck_to_tstruct(TA[WizardStruct].new).each do |row|
   T.assert_type!(row, WizardStruct)
 end
+
+
+# -- GeneratedUrlHelpers
+class TestHelper
+  include GeneratedUrlHelpers
+
+  def test_url_helper
+    T.assert_type!(test_index_url, String)
+  end
+end
+TestHelper.new.test_url_helper

--- a/spec/support/v5.2/sorbet_test_cases.rb
+++ b/spec/support/v5.2/sorbet_test_cases.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 require 'sorbet-runtime'
 
 wand = Wand.first!
@@ -257,8 +257,17 @@ end
 class TestHelper
   include GeneratedUrlHelpers
 
+  # need to implement this for the url
+  def default_url_options
+    {
+      protocol: 'http',
+      host: 'localhost',
+      port: 3000,
+    }
+  end
+
   def test_url_helper
-    T.assert_type!(test_index_url, String)
+    T.assert_type!(test_index_path, String)
   end
 end
 TestHelper.new.test_url_helper

--- a/spec/support/v5.2/sorbet_test_cases.rb
+++ b/spec/support/v5.2/sorbet_test_cases.rb
@@ -251,3 +251,14 @@ end
 Wizard.all.pluck_to_tstruct(TA[WizardStruct].new).each do |row|
   T.assert_type!(row, WizardStruct)
 end
+
+
+# -- GeneratedUrlHelpers
+class TestHelper
+  include GeneratedUrlHelpers
+
+  def test_url_helper
+    T.assert_type!(test_index_url, String)
+  end
+end
+TestHelper.new.test_url_helper

--- a/spec/support/v6.0/sorbet_test_cases.rb
+++ b/spec/support/v6.0/sorbet_test_cases.rb
@@ -257,8 +257,17 @@ end
 class TestHelper
   include GeneratedUrlHelpers
 
+  # need to implement this for the url
+  def default_url_options
+    {
+      protocol: 'http',
+      host: 'localhost',
+      port: 3000,
+    }
+  end
+
   def test_url_helper
-    T.assert_type!(test_index_url, String)
+    T.assert_type!(test_index_path, String)
   end
 end
 TestHelper.new.test_url_helper

--- a/spec/support/v6.0/sorbet_test_cases.rb
+++ b/spec/support/v6.0/sorbet_test_cases.rb
@@ -251,3 +251,14 @@ end
 Wizard.all.pluck_to_tstruct(TA[WizardStruct].new).each do |row|
   T.assert_type!(row, WizardStruct)
 end
+
+
+# -- GeneratedUrlHelpers
+class TestHelper
+  include GeneratedUrlHelpers
+
+  def test_url_helper
+    T.assert_type!(test_index_url, String)
+  end
+end
+TestHelper.new.test_url_helper


### PR DESCRIPTION
It is a common problem for adopters to run into 4002 issue with 
```
include Rails.application.routes.url_helpers
```
We already have GeneratedUrlHelpers that encapsulate the signature for url_helper methods. It's easy to add implementation and make it a replacement for the dynamic module.