### PR TITLE
Add find_by_or_initalize/create/create!_by sigs

### DIFF
--- a/lib/bundled_rbi/active_record_base.rbi
+++ b/lib/bundled_rbi/active_record_base.rbi
@@ -9,6 +9,15 @@ class ActiveRecord::Base
   sig { params(args: T.untyped).returns(T.attached_class) }
   def self.find_by!(*args); end
 
+  sig { params(args: T.untyped).returns(T.attached_class) }
+  def find_or_initialize_by(*args); end
+
+  sig { params(args: T.untyped).returns(T.attached_class) }
+  def find_or_create_by(*args); end
+
+  sig { params(args: T.untyped).returns(T.attached_class) }
+  def find_or_create_by!(*args); end
+
   sig { returns(T.nilable(T.attached_class)) }
   def self.first; end
 

--- a/lib/bundled_rbi/active_record_base.rbi
+++ b/lib/bundled_rbi/active_record_base.rbi
@@ -9,14 +9,32 @@ class ActiveRecord::Base
   sig { params(args: T.untyped).returns(T.attached_class) }
   def self.find_by!(*args); end
 
-  sig { params(args: T.untyped).returns(T.attached_class) }
-  def find_or_initialize_by(*args); end
+  sig {
+    params(
+      attributes: T.untyped,
+      block: T.proc.params(object: T.attached_class).void
+    ).
+    returns(Elem)
+  }
+  def self.find_or_initialize_by(attributes, &block); end
 
-  sig { params(args: T.untyped).returns(T.attached_class) }
-  def find_or_create_by(*args); end
+  sig {
+    params(
+      attributes: T.untyped,
+      block: T.proc.params(object: T.attached_class).void
+    ).
+    returns(Elem)
+  }
+  def self.find_or_create_by(attributes, &block); end
 
-  sig { params(args: T.untyped).returns(T.attached_class) }
-  def find_or_create_by!(*args); end
+  sig {
+    params(
+      attributes: T.untyped,
+      block: T.proc.params(object: T.attached_class).void
+    ).
+    returns(Elem)
+  }
+  def self.find_or_create_by!(attributes, &block); end
 
   sig { returns(T.nilable(T.attached_class)) }
   def self.first; end

--- a/lib/bundled_rbi/active_record_relation.rbi
+++ b/lib/bundled_rbi/active_record_relation.rbi
@@ -9,14 +9,32 @@ class ActiveRecord::Relation
   sig { params(args: T.untyped).returns(Elem) }
   def find_by!(*args); end
 
-  sig { params(args: T.untyped).returns(Elem) }
-  def find_or_initialize_by(*args); end
+  sig {
+    params(
+      attributes: T.untyped,
+      block: T.proc.params(object: Elem).void
+    ).
+    returns(Elem)
+  }
+  def find_or_initialize_by(attributes, &block); end
 
-  sig { params(args: T.untyped).returns(Elem) }
-  def find_or_create_by(*args); end
+  sig {
+    params(
+      attributes: T.untyped,
+      block: T.proc.params(object: Elem).void
+    ).
+    returns(Elem)
+  }
+  def find_or_create_by(attributes, &block); end
 
-  sig { params(args: T.untyped).returns(Elem) }
-  def find_or_create_by!(*args); end
+  sig {
+    params(
+      attributes: T.untyped,
+      block: T.proc.params(object: Elem).void
+    ).
+    returns(Elem)
+  }
+  def find_or_create_by!(attributes, &block); end
 
   sig { returns(T.nilable(Elem)) }
   def first; end

--- a/lib/bundled_rbi/active_record_relation.rbi
+++ b/lib/bundled_rbi/active_record_relation.rbi
@@ -9,6 +9,15 @@ class ActiveRecord::Relation
   sig { params(args: T.untyped).returns(Elem) }
   def find_by!(*args); end
 
+  sig { params(args: T.untyped).returns(Elem) }
+  def find_or_initialize_by(*args); end
+
+  sig { params(args: T.untyped).returns(Elem) }
+  def find_or_create_by(*args); end
+
+  sig { params(args: T.untyped).returns(Elem) }
+  def find_or_create_by!(*args); end
+
   sig { returns(T.nilable(Elem)) }
   def first; end
 

--- a/lib/sorbet-rails/model_plugins/active_record_finder_methods.rb
+++ b/lib/sorbet-rails/model_plugins/active_record_finder_methods.rb
@@ -47,6 +47,24 @@ class SorbetRails::ModelPlugins::ActiveRecordFinderMethods < SorbetRails::ModelP
         return_type: self.model_class_name,
         class_method: class_method
       )
+      class_rbi.create_method(
+        "find_or_initialize_by",
+        parameters: [ Parameter.new("*args", type: "T.untyped") ],
+        return_type: self.model_class_name,
+        class_method: class_method
+      )
+      class_rbi.create_method(
+        "find_or_create_by",
+        parameters: [ Parameter.new("*args", type: "T.untyped") ],
+        return_type: self.model_class_name,
+        class_method: class_method
+      )
+      class_rbi.create_method(
+        "find_or_create_by!",
+        parameters: [ Parameter.new("*args", type: "T.untyped") ],
+        return_type: self.model_class_name,
+        class_method: class_method
+      )
 
       ["first", "second", "third", "third_to_last", "second_to_last", "last"].
         each do |method_name|

--- a/lib/sorbet-rails/model_plugins/active_record_finder_methods.rb
+++ b/lib/sorbet-rails/model_plugins/active_record_finder_methods.rb
@@ -49,19 +49,28 @@ class SorbetRails::ModelPlugins::ActiveRecordFinderMethods < SorbetRails::ModelP
       )
       class_rbi.create_method(
         "find_or_initialize_by",
-        parameters: [ Parameter.new("*args", type: "T.untyped") ],
+        parameters: [
+          Parameter.new("attributes", type: "T.untyped") ,
+          Parameter.new("&block", type: "T.proc.params(object: #{self.model_class_name}).void"),
+        ],
         return_type: self.model_class_name,
         class_method: class_method
       )
       class_rbi.create_method(
         "find_or_create_by",
-        parameters: [ Parameter.new("*args", type: "T.untyped") ],
+        parameters: [
+          Parameter.new("attributes", type: "T.untyped") ,
+          Parameter.new("&block", type: "T.proc.params(object: #{self.model_class_name}).void"),
+        ],
         return_type: self.model_class_name,
         class_method: class_method
       )
       class_rbi.create_method(
         "find_or_create_by!",
-        parameters: [ Parameter.new("*args", type: "T.untyped") ],
+        parameters: [
+          Parameter.new("attributes", type: "T.untyped") ,
+          Parameter.new("&block", type: "T.proc.params(object: #{self.model_class_name}).void"),
+        ],
         return_type: self.model_class_name,
         class_method: class_method
       )

--- a/spec/test_data/v5.0/expected_internal_metadata.rbi
+++ b/spec/test_data/v5.0/expected_internal_metadata.rbi
@@ -379,6 +379,15 @@ class ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation < ActiveR
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata) }
   def find_by!(*args); end
 
+  sig { params(attributes: T.untyped, block: T.proc.params(object: ActiveRecord::InternalMetadata).void).returns(ActiveRecord::InternalMetadata) }
+  def find_or_initialize_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: ActiveRecord::InternalMetadata).void).returns(ActiveRecord::InternalMetadata) }
+  def find_or_create_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: ActiveRecord::InternalMetadata).void).returns(ActiveRecord::InternalMetadata) }
+  def find_or_create_by!(attributes, &block); end
+
   sig { returns(T.nilable(ActiveRecord::InternalMetadata)) }
   def first; end
 
@@ -547,6 +556,15 @@ class ActiveRecord::InternalMetadata::ActiveRecord_Associations_CollectionProxy 
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata) }
   def find_by!(*args); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: ActiveRecord::InternalMetadata).void).returns(ActiveRecord::InternalMetadata) }
+  def find_or_initialize_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: ActiveRecord::InternalMetadata).void).returns(ActiveRecord::InternalMetadata) }
+  def find_or_create_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: ActiveRecord::InternalMetadata).void).returns(ActiveRecord::InternalMetadata) }
+  def find_or_create_by!(attributes, &block); end
 
   sig { returns(T.nilable(ActiveRecord::InternalMetadata)) }
   def first; end

--- a/spec/test_data/v5.0/expected_potion.rbi
+++ b/spec/test_data/v5.0/expected_potion.rbi
@@ -349,6 +349,15 @@ class Potion::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelati
   sig { params(args: T.untyped).returns(Potion) }
   def find_by!(*args); end
 
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Potion).void).returns(Potion) }
+  def find_or_initialize_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Potion).void).returns(Potion) }
+  def find_or_create_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Potion).void).returns(Potion) }
+  def find_or_create_by!(attributes, &block); end
+
   sig { returns(T.nilable(Potion)) }
   def first; end
 
@@ -517,6 +526,15 @@ class Potion::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associat
 
   sig { params(args: T.untyped).returns(Potion) }
   def find_by!(*args); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Potion).void).returns(Potion) }
+  def find_or_initialize_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Potion).void).returns(Potion) }
+  def find_or_create_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Potion).void).returns(Potion) }
+  def find_or_create_by!(attributes, &block); end
 
   sig { returns(T.nilable(Potion)) }
   def first; end

--- a/spec/test_data/v5.0/expected_robe.rbi
+++ b/spec/test_data/v5.0/expected_robe.rbi
@@ -372,6 +372,15 @@ class Robe::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
   sig { params(args: T.untyped).returns(Robe) }
   def find_by!(*args); end
 
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Robe).void).returns(Robe) }
+  def find_or_initialize_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Robe).void).returns(Robe) }
+  def find_or_create_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Robe).void).returns(Robe) }
+  def find_or_create_by!(attributes, &block); end
+
   sig { returns(T.nilable(Robe)) }
   def first; end
 
@@ -540,6 +549,15 @@ class Robe::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associatio
 
   sig { params(args: T.untyped).returns(Robe) }
   def find_by!(*args); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Robe).void).returns(Robe) }
+  def find_or_initialize_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Robe).void).returns(Robe) }
+  def find_or_create_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Robe).void).returns(Robe) }
+  def find_or_create_by!(attributes, &block); end
 
   sig { returns(T.nilable(Robe)) }
   def first; end

--- a/spec/test_data/v5.0/expected_schema_migration.rbi
+++ b/spec/test_data/v5.0/expected_schema_migration.rbi
@@ -352,6 +352,15 @@ class ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation < ActiveRe
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration) }
   def find_by!(*args); end
 
+  sig { params(attributes: T.untyped, block: T.proc.params(object: ActiveRecord::SchemaMigration).void).returns(ActiveRecord::SchemaMigration) }
+  def find_or_initialize_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: ActiveRecord::SchemaMigration).void).returns(ActiveRecord::SchemaMigration) }
+  def find_or_create_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: ActiveRecord::SchemaMigration).void).returns(ActiveRecord::SchemaMigration) }
+  def find_or_create_by!(attributes, &block); end
+
   sig { returns(T.nilable(ActiveRecord::SchemaMigration)) }
   def first; end
 
@@ -520,6 +529,15 @@ class ActiveRecord::SchemaMigration::ActiveRecord_Associations_CollectionProxy <
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration) }
   def find_by!(*args); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: ActiveRecord::SchemaMigration).void).returns(ActiveRecord::SchemaMigration) }
+  def find_or_initialize_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: ActiveRecord::SchemaMigration).void).returns(ActiveRecord::SchemaMigration) }
+  def find_or_create_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: ActiveRecord::SchemaMigration).void).returns(ActiveRecord::SchemaMigration) }
+  def find_or_create_by!(attributes, &block); end
 
   sig { returns(T.nilable(ActiveRecord::SchemaMigration)) }
   def first; end

--- a/spec/test_data/v5.0/expected_school.rbi
+++ b/spec/test_data/v5.0/expected_school.rbi
@@ -361,6 +361,15 @@ class School::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelati
   sig { params(args: T.untyped).returns(School) }
   def find_by!(*args); end
 
+  sig { params(attributes: T.untyped, block: T.proc.params(object: School).void).returns(School) }
+  def find_or_initialize_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: School).void).returns(School) }
+  def find_or_create_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: School).void).returns(School) }
+  def find_or_create_by!(attributes, &block); end
+
   sig { returns(T.nilable(School)) }
   def first; end
 
@@ -529,6 +538,15 @@ class School::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associat
 
   sig { params(args: T.untyped).returns(School) }
   def find_by!(*args); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: School).void).returns(School) }
+  def find_or_initialize_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: School).void).returns(School) }
+  def find_or_create_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: School).void).returns(School) }
+  def find_or_create_by!(attributes, &block); end
 
   sig { returns(T.nilable(School)) }
   def first; end

--- a/spec/test_data/v5.0/expected_spell_book.rbi
+++ b/spec/test_data/v5.0/expected_spell_book.rbi
@@ -458,6 +458,15 @@ class SpellBook::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRel
   sig { params(args: T.untyped).returns(SpellBook) }
   def find_by!(*args); end
 
+  sig { params(attributes: T.untyped, block: T.proc.params(object: SpellBook).void).returns(SpellBook) }
+  def find_or_initialize_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: SpellBook).void).returns(SpellBook) }
+  def find_or_create_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: SpellBook).void).returns(SpellBook) }
+  def find_or_create_by!(attributes, &block); end
+
   sig { returns(T.nilable(SpellBook)) }
   def first; end
 
@@ -635,6 +644,15 @@ class SpellBook::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Assoc
 
   sig { params(args: T.untyped).returns(SpellBook) }
   def find_by!(*args); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: SpellBook).void).returns(SpellBook) }
+  def find_or_initialize_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: SpellBook).void).returns(SpellBook) }
+  def find_or_create_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: SpellBook).void).returns(SpellBook) }
+  def find_or_create_by!(attributes, &block); end
 
   sig { returns(T.nilable(SpellBook)) }
   def first; end

--- a/spec/test_data/v5.0/expected_squib.rbi
+++ b/spec/test_data/v5.0/expected_squib.rbi
@@ -788,6 +788,15 @@ class Squib::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelatio
   sig { params(args: T.untyped).returns(Squib) }
   def find_by!(*args); end
 
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Squib).void).returns(Squib) }
+  def find_or_initialize_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Squib).void).returns(Squib) }
+  def find_or_create_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Squib).void).returns(Squib) }
+  def find_or_create_by!(attributes, &block); end
+
   sig { returns(T.nilable(Squib)) }
   def first; end
 
@@ -1010,6 +1019,15 @@ class Squib::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associati
 
   sig { params(args: T.untyped).returns(Squib) }
   def find_by!(*args); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Squib).void).returns(Squib) }
+  def find_or_initialize_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Squib).void).returns(Squib) }
+  def find_or_create_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Squib).void).returns(Squib) }
+  def find_or_create_by!(attributes, &block); end
 
   sig { returns(T.nilable(Squib)) }
   def first; end

--- a/spec/test_data/v5.0/expected_wand.rbi
+++ b/spec/test_data/v5.0/expected_wand.rbi
@@ -558,6 +558,15 @@ class Wand::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
   sig { params(args: T.untyped).returns(Wand) }
   def find_by!(*args); end
 
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Wand).void).returns(Wand) }
+  def find_or_initialize_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Wand).void).returns(Wand) }
+  def find_or_create_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Wand).void).returns(Wand) }
+  def find_or_create_by!(attributes, &block); end
+
   sig { returns(T.nilable(Wand)) }
   def first; end
 
@@ -738,6 +747,15 @@ class Wand::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associatio
 
   sig { params(args: T.untyped).returns(Wand) }
   def find_by!(*args); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Wand).void).returns(Wand) }
+  def find_or_initialize_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Wand).void).returns(Wand) }
+  def find_or_create_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Wand).void).returns(Wand) }
+  def find_or_create_by!(attributes, &block); end
 
   sig { returns(T.nilable(Wand)) }
   def first; end

--- a/spec/test_data/v5.0/expected_wizard.rbi
+++ b/spec/test_data/v5.0/expected_wizard.rbi
@@ -863,6 +863,15 @@ class Wizard::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelati
   sig { params(args: T.untyped).returns(Wizard) }
   def find_by!(*args); end
 
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Wizard).void).returns(Wizard) }
+  def find_or_initialize_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Wizard).void).returns(Wizard) }
+  def find_or_create_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Wizard).void).returns(Wizard) }
+  def find_or_create_by!(attributes, &block); end
+
   sig { returns(T.nilable(Wizard)) }
   def first; end
 
@@ -1085,6 +1094,15 @@ class Wizard::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associat
 
   sig { params(args: T.untyped).returns(Wizard) }
   def find_by!(*args); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Wizard).void).returns(Wizard) }
+  def find_or_initialize_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Wizard).void).returns(Wizard) }
+  def find_or_create_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Wizard).void).returns(Wizard) }
+  def find_or_create_by!(attributes, &block); end
 
   sig { returns(T.nilable(Wizard)) }
   def first; end

--- a/spec/test_data/v5.0/expected_wizard_wo_spellbook.rbi
+++ b/spec/test_data/v5.0/expected_wizard_wo_spellbook.rbi
@@ -863,6 +863,15 @@ class Wizard::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelati
   sig { params(args: T.untyped).returns(Wizard) }
   def find_by!(*args); end
 
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Wizard).void).returns(Wizard) }
+  def find_or_initialize_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Wizard).void).returns(Wizard) }
+  def find_or_create_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Wizard).void).returns(Wizard) }
+  def find_or_create_by!(attributes, &block); end
+
   sig { returns(T.nilable(Wizard)) }
   def first; end
 
@@ -1085,6 +1094,15 @@ class Wizard::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associat
 
   sig { params(args: T.untyped).returns(Wizard) }
   def find_by!(*args); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Wizard).void).returns(Wizard) }
+  def find_or_initialize_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Wizard).void).returns(Wizard) }
+  def find_or_create_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Wizard).void).returns(Wizard) }
+  def find_or_create_by!(attributes, &block); end
 
   sig { returns(T.nilable(Wizard)) }
   def first; end

--- a/spec/test_data/v5.1/expected_internal_metadata.rbi
+++ b/spec/test_data/v5.1/expected_internal_metadata.rbi
@@ -388,6 +388,15 @@ class ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation < ActiveR
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata) }
   def find_by!(*args); end
 
+  sig { params(attributes: T.untyped, block: T.proc.params(object: ActiveRecord::InternalMetadata).void).returns(ActiveRecord::InternalMetadata) }
+  def find_or_initialize_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: ActiveRecord::InternalMetadata).void).returns(ActiveRecord::InternalMetadata) }
+  def find_or_create_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: ActiveRecord::InternalMetadata).void).returns(ActiveRecord::InternalMetadata) }
+  def find_or_create_by!(attributes, &block); end
+
   sig { returns(T.nilable(ActiveRecord::InternalMetadata)) }
   def first; end
 
@@ -559,6 +568,15 @@ class ActiveRecord::InternalMetadata::ActiveRecord_Associations_CollectionProxy 
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata) }
   def find_by!(*args); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: ActiveRecord::InternalMetadata).void).returns(ActiveRecord::InternalMetadata) }
+  def find_or_initialize_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: ActiveRecord::InternalMetadata).void).returns(ActiveRecord::InternalMetadata) }
+  def find_or_create_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: ActiveRecord::InternalMetadata).void).returns(ActiveRecord::InternalMetadata) }
+  def find_or_create_by!(attributes, &block); end
 
   sig { returns(T.nilable(ActiveRecord::InternalMetadata)) }
   def first; end

--- a/spec/test_data/v5.1/expected_potion.rbi
+++ b/spec/test_data/v5.1/expected_potion.rbi
@@ -358,6 +358,15 @@ class Potion::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelati
   sig { params(args: T.untyped).returns(Potion) }
   def find_by!(*args); end
 
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Potion).void).returns(Potion) }
+  def find_or_initialize_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Potion).void).returns(Potion) }
+  def find_or_create_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Potion).void).returns(Potion) }
+  def find_or_create_by!(attributes, &block); end
+
   sig { returns(T.nilable(Potion)) }
   def first; end
 
@@ -529,6 +538,15 @@ class Potion::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associat
 
   sig { params(args: T.untyped).returns(Potion) }
   def find_by!(*args); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Potion).void).returns(Potion) }
+  def find_or_initialize_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Potion).void).returns(Potion) }
+  def find_or_create_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Potion).void).returns(Potion) }
+  def find_or_create_by!(attributes, &block); end
 
   sig { returns(T.nilable(Potion)) }
   def first; end

--- a/spec/test_data/v5.1/expected_robe.rbi
+++ b/spec/test_data/v5.1/expected_robe.rbi
@@ -381,6 +381,15 @@ class Robe::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
   sig { params(args: T.untyped).returns(Robe) }
   def find_by!(*args); end
 
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Robe).void).returns(Robe) }
+  def find_or_initialize_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Robe).void).returns(Robe) }
+  def find_or_create_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Robe).void).returns(Robe) }
+  def find_or_create_by!(attributes, &block); end
+
   sig { returns(T.nilable(Robe)) }
   def first; end
 
@@ -552,6 +561,15 @@ class Robe::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associatio
 
   sig { params(args: T.untyped).returns(Robe) }
   def find_by!(*args); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Robe).void).returns(Robe) }
+  def find_or_initialize_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Robe).void).returns(Robe) }
+  def find_or_create_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Robe).void).returns(Robe) }
+  def find_or_create_by!(attributes, &block); end
 
   sig { returns(T.nilable(Robe)) }
   def first; end

--- a/spec/test_data/v5.1/expected_schema_migration.rbi
+++ b/spec/test_data/v5.1/expected_schema_migration.rbi
@@ -361,6 +361,15 @@ class ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation < ActiveRe
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration) }
   def find_by!(*args); end
 
+  sig { params(attributes: T.untyped, block: T.proc.params(object: ActiveRecord::SchemaMigration).void).returns(ActiveRecord::SchemaMigration) }
+  def find_or_initialize_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: ActiveRecord::SchemaMigration).void).returns(ActiveRecord::SchemaMigration) }
+  def find_or_create_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: ActiveRecord::SchemaMigration).void).returns(ActiveRecord::SchemaMigration) }
+  def find_or_create_by!(attributes, &block); end
+
   sig { returns(T.nilable(ActiveRecord::SchemaMigration)) }
   def first; end
 
@@ -532,6 +541,15 @@ class ActiveRecord::SchemaMigration::ActiveRecord_Associations_CollectionProxy <
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration) }
   def find_by!(*args); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: ActiveRecord::SchemaMigration).void).returns(ActiveRecord::SchemaMigration) }
+  def find_or_initialize_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: ActiveRecord::SchemaMigration).void).returns(ActiveRecord::SchemaMigration) }
+  def find_or_create_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: ActiveRecord::SchemaMigration).void).returns(ActiveRecord::SchemaMigration) }
+  def find_or_create_by!(attributes, &block); end
 
   sig { returns(T.nilable(ActiveRecord::SchemaMigration)) }
   def first; end

--- a/spec/test_data/v5.1/expected_school.rbi
+++ b/spec/test_data/v5.1/expected_school.rbi
@@ -370,6 +370,15 @@ class School::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelati
   sig { params(args: T.untyped).returns(School) }
   def find_by!(*args); end
 
+  sig { params(attributes: T.untyped, block: T.proc.params(object: School).void).returns(School) }
+  def find_or_initialize_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: School).void).returns(School) }
+  def find_or_create_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: School).void).returns(School) }
+  def find_or_create_by!(attributes, &block); end
+
   sig { returns(T.nilable(School)) }
   def first; end
 
@@ -541,6 +550,15 @@ class School::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associat
 
   sig { params(args: T.untyped).returns(School) }
   def find_by!(*args); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: School).void).returns(School) }
+  def find_or_initialize_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: School).void).returns(School) }
+  def find_or_create_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: School).void).returns(School) }
+  def find_or_create_by!(attributes, &block); end
 
   sig { returns(T.nilable(School)) }
   def first; end

--- a/spec/test_data/v5.1/expected_spell_book.rbi
+++ b/spec/test_data/v5.1/expected_spell_book.rbi
@@ -467,6 +467,15 @@ class SpellBook::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRel
   sig { params(args: T.untyped).returns(SpellBook) }
   def find_by!(*args); end
 
+  sig { params(attributes: T.untyped, block: T.proc.params(object: SpellBook).void).returns(SpellBook) }
+  def find_or_initialize_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: SpellBook).void).returns(SpellBook) }
+  def find_or_create_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: SpellBook).void).returns(SpellBook) }
+  def find_or_create_by!(attributes, &block); end
+
   sig { returns(T.nilable(SpellBook)) }
   def first; end
 
@@ -647,6 +656,15 @@ class SpellBook::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Assoc
 
   sig { params(args: T.untyped).returns(SpellBook) }
   def find_by!(*args); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: SpellBook).void).returns(SpellBook) }
+  def find_or_initialize_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: SpellBook).void).returns(SpellBook) }
+  def find_or_create_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: SpellBook).void).returns(SpellBook) }
+  def find_or_create_by!(attributes, &block); end
 
   sig { returns(T.nilable(SpellBook)) }
   def first; end

--- a/spec/test_data/v5.1/expected_squib.rbi
+++ b/spec/test_data/v5.1/expected_squib.rbi
@@ -797,6 +797,15 @@ class Squib::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelatio
   sig { params(args: T.untyped).returns(Squib) }
   def find_by!(*args); end
 
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Squib).void).returns(Squib) }
+  def find_or_initialize_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Squib).void).returns(Squib) }
+  def find_or_create_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Squib).void).returns(Squib) }
+  def find_or_create_by!(attributes, &block); end
+
   sig { returns(T.nilable(Squib)) }
   def first; end
 
@@ -1022,6 +1031,15 @@ class Squib::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associati
 
   sig { params(args: T.untyped).returns(Squib) }
   def find_by!(*args); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Squib).void).returns(Squib) }
+  def find_or_initialize_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Squib).void).returns(Squib) }
+  def find_or_create_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Squib).void).returns(Squib) }
+  def find_or_create_by!(attributes, &block); end
 
   sig { returns(T.nilable(Squib)) }
   def first; end

--- a/spec/test_data/v5.1/expected_wand.rbi
+++ b/spec/test_data/v5.1/expected_wand.rbi
@@ -567,6 +567,15 @@ class Wand::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
   sig { params(args: T.untyped).returns(Wand) }
   def find_by!(*args); end
 
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Wand).void).returns(Wand) }
+  def find_or_initialize_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Wand).void).returns(Wand) }
+  def find_or_create_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Wand).void).returns(Wand) }
+  def find_or_create_by!(attributes, &block); end
+
   sig { returns(T.nilable(Wand)) }
   def first; end
 
@@ -750,6 +759,15 @@ class Wand::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associatio
 
   sig { params(args: T.untyped).returns(Wand) }
   def find_by!(*args); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Wand).void).returns(Wand) }
+  def find_or_initialize_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Wand).void).returns(Wand) }
+  def find_or_create_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Wand).void).returns(Wand) }
+  def find_or_create_by!(attributes, &block); end
 
   sig { returns(T.nilable(Wand)) }
   def first; end

--- a/spec/test_data/v5.1/expected_wizard.rbi
+++ b/spec/test_data/v5.1/expected_wizard.rbi
@@ -872,6 +872,15 @@ class Wizard::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelati
   sig { params(args: T.untyped).returns(Wizard) }
   def find_by!(*args); end
 
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Wizard).void).returns(Wizard) }
+  def find_or_initialize_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Wizard).void).returns(Wizard) }
+  def find_or_create_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Wizard).void).returns(Wizard) }
+  def find_or_create_by!(attributes, &block); end
+
   sig { returns(T.nilable(Wizard)) }
   def first; end
 
@@ -1097,6 +1106,15 @@ class Wizard::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associat
 
   sig { params(args: T.untyped).returns(Wizard) }
   def find_by!(*args); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Wizard).void).returns(Wizard) }
+  def find_or_initialize_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Wizard).void).returns(Wizard) }
+  def find_or_create_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Wizard).void).returns(Wizard) }
+  def find_or_create_by!(attributes, &block); end
 
   sig { returns(T.nilable(Wizard)) }
   def first; end

--- a/spec/test_data/v5.1/expected_wizard_wo_spellbook.rbi
+++ b/spec/test_data/v5.1/expected_wizard_wo_spellbook.rbi
@@ -872,6 +872,15 @@ class Wizard::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelati
   sig { params(args: T.untyped).returns(Wizard) }
   def find_by!(*args); end
 
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Wizard).void).returns(Wizard) }
+  def find_or_initialize_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Wizard).void).returns(Wizard) }
+  def find_or_create_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Wizard).void).returns(Wizard) }
+  def find_or_create_by!(attributes, &block); end
+
   sig { returns(T.nilable(Wizard)) }
   def first; end
 
@@ -1097,6 +1106,15 @@ class Wizard::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associat
 
   sig { params(args: T.untyped).returns(Wizard) }
   def find_by!(*args); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Wizard).void).returns(Wizard) }
+  def find_or_initialize_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Wizard).void).returns(Wizard) }
+  def find_or_create_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Wizard).void).returns(Wizard) }
+  def find_or_create_by!(attributes, &block); end
 
   sig { returns(T.nilable(Wizard)) }
   def first; end

--- a/spec/test_data/v5.2/expected_attachment.rbi
+++ b/spec/test_data/v5.2/expected_attachment.rbi
@@ -364,6 +364,15 @@ class ActiveStorage::Attachment::ActiveRecord_AssociationRelation < ActiveRecord
   sig { params(args: T.untyped).returns(ActiveStorage::Attachment) }
   def find_by!(*args); end
 
+  sig { params(attributes: T.untyped, block: T.proc.params(object: ActiveStorage::Attachment).void).returns(ActiveStorage::Attachment) }
+  def find_or_initialize_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: ActiveStorage::Attachment).void).returns(ActiveStorage::Attachment) }
+  def find_or_create_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: ActiveStorage::Attachment).void).returns(ActiveStorage::Attachment) }
+  def find_or_create_by!(attributes, &block); end
+
   sig { returns(T.nilable(ActiveStorage::Attachment)) }
   def first; end
 
@@ -535,6 +544,15 @@ class ActiveStorage::Attachment::ActiveRecord_Associations_CollectionProxy < Act
 
   sig { params(args: T.untyped).returns(ActiveStorage::Attachment) }
   def find_by!(*args); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: ActiveStorage::Attachment).void).returns(ActiveStorage::Attachment) }
+  def find_or_initialize_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: ActiveStorage::Attachment).void).returns(ActiveStorage::Attachment) }
+  def find_or_create_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: ActiveStorage::Attachment).void).returns(ActiveStorage::Attachment) }
+  def find_or_create_by!(attributes, &block); end
 
   sig { returns(T.nilable(ActiveStorage::Attachment)) }
   def first; end

--- a/spec/test_data/v5.2/expected_blob.rbi
+++ b/spec/test_data/v5.2/expected_blob.rbi
@@ -388,6 +388,15 @@ class ActiveStorage::Blob::ActiveRecord_AssociationRelation < ActiveRecord::Asso
   sig { params(args: T.untyped).returns(ActiveStorage::Blob) }
   def find_by!(*args); end
 
+  sig { params(attributes: T.untyped, block: T.proc.params(object: ActiveStorage::Blob).void).returns(ActiveStorage::Blob) }
+  def find_or_initialize_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: ActiveStorage::Blob).void).returns(ActiveStorage::Blob) }
+  def find_or_create_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: ActiveStorage::Blob).void).returns(ActiveStorage::Blob) }
+  def find_or_create_by!(attributes, &block); end
+
   sig { returns(T.nilable(ActiveStorage::Blob)) }
   def first; end
 
@@ -565,6 +574,15 @@ class ActiveStorage::Blob::ActiveRecord_Associations_CollectionProxy < ActiveRec
 
   sig { params(args: T.untyped).returns(ActiveStorage::Blob) }
   def find_by!(*args); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: ActiveStorage::Blob).void).returns(ActiveStorage::Blob) }
+  def find_or_initialize_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: ActiveStorage::Blob).void).returns(ActiveStorage::Blob) }
+  def find_or_create_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: ActiveStorage::Blob).void).returns(ActiveStorage::Blob) }
+  def find_or_create_by!(attributes, &block); end
 
   sig { returns(T.nilable(ActiveStorage::Blob)) }
   def first; end

--- a/spec/test_data/v5.2/expected_internal_metadata.rbi
+++ b/spec/test_data/v5.2/expected_internal_metadata.rbi
@@ -388,6 +388,15 @@ class ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation < ActiveR
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata) }
   def find_by!(*args); end
 
+  sig { params(attributes: T.untyped, block: T.proc.params(object: ActiveRecord::InternalMetadata).void).returns(ActiveRecord::InternalMetadata) }
+  def find_or_initialize_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: ActiveRecord::InternalMetadata).void).returns(ActiveRecord::InternalMetadata) }
+  def find_or_create_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: ActiveRecord::InternalMetadata).void).returns(ActiveRecord::InternalMetadata) }
+  def find_or_create_by!(attributes, &block); end
+
   sig { returns(T.nilable(ActiveRecord::InternalMetadata)) }
   def first; end
 
@@ -559,6 +568,15 @@ class ActiveRecord::InternalMetadata::ActiveRecord_Associations_CollectionProxy 
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata) }
   def find_by!(*args); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: ActiveRecord::InternalMetadata).void).returns(ActiveRecord::InternalMetadata) }
+  def find_or_initialize_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: ActiveRecord::InternalMetadata).void).returns(ActiveRecord::InternalMetadata) }
+  def find_or_create_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: ActiveRecord::InternalMetadata).void).returns(ActiveRecord::InternalMetadata) }
+  def find_or_create_by!(attributes, &block); end
 
   sig { returns(T.nilable(ActiveRecord::InternalMetadata)) }
   def first; end

--- a/spec/test_data/v5.2/expected_potion.rbi
+++ b/spec/test_data/v5.2/expected_potion.rbi
@@ -358,6 +358,15 @@ class Potion::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelati
   sig { params(args: T.untyped).returns(Potion) }
   def find_by!(*args); end
 
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Potion).void).returns(Potion) }
+  def find_or_initialize_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Potion).void).returns(Potion) }
+  def find_or_create_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Potion).void).returns(Potion) }
+  def find_or_create_by!(attributes, &block); end
+
   sig { returns(T.nilable(Potion)) }
   def first; end
 
@@ -529,6 +538,15 @@ class Potion::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associat
 
   sig { params(args: T.untyped).returns(Potion) }
   def find_by!(*args); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Potion).void).returns(Potion) }
+  def find_or_initialize_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Potion).void).returns(Potion) }
+  def find_or_create_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Potion).void).returns(Potion) }
+  def find_or_create_by!(attributes, &block); end
 
   sig { returns(T.nilable(Potion)) }
   def first; end

--- a/spec/test_data/v5.2/expected_robe.rbi
+++ b/spec/test_data/v5.2/expected_robe.rbi
@@ -381,6 +381,15 @@ class Robe::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
   sig { params(args: T.untyped).returns(Robe) }
   def find_by!(*args); end
 
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Robe).void).returns(Robe) }
+  def find_or_initialize_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Robe).void).returns(Robe) }
+  def find_or_create_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Robe).void).returns(Robe) }
+  def find_or_create_by!(attributes, &block); end
+
   sig { returns(T.nilable(Robe)) }
   def first; end
 
@@ -552,6 +561,15 @@ class Robe::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associatio
 
   sig { params(args: T.untyped).returns(Robe) }
   def find_by!(*args); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Robe).void).returns(Robe) }
+  def find_or_initialize_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Robe).void).returns(Robe) }
+  def find_or_create_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Robe).void).returns(Robe) }
+  def find_or_create_by!(attributes, &block); end
 
   sig { returns(T.nilable(Robe)) }
   def first; end

--- a/spec/test_data/v5.2/expected_schema_migration.rbi
+++ b/spec/test_data/v5.2/expected_schema_migration.rbi
@@ -361,6 +361,15 @@ class ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation < ActiveRe
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration) }
   def find_by!(*args); end
 
+  sig { params(attributes: T.untyped, block: T.proc.params(object: ActiveRecord::SchemaMigration).void).returns(ActiveRecord::SchemaMigration) }
+  def find_or_initialize_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: ActiveRecord::SchemaMigration).void).returns(ActiveRecord::SchemaMigration) }
+  def find_or_create_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: ActiveRecord::SchemaMigration).void).returns(ActiveRecord::SchemaMigration) }
+  def find_or_create_by!(attributes, &block); end
+
   sig { returns(T.nilable(ActiveRecord::SchemaMigration)) }
   def first; end
 
@@ -532,6 +541,15 @@ class ActiveRecord::SchemaMigration::ActiveRecord_Associations_CollectionProxy <
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration) }
   def find_by!(*args); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: ActiveRecord::SchemaMigration).void).returns(ActiveRecord::SchemaMigration) }
+  def find_or_initialize_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: ActiveRecord::SchemaMigration).void).returns(ActiveRecord::SchemaMigration) }
+  def find_or_create_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: ActiveRecord::SchemaMigration).void).returns(ActiveRecord::SchemaMigration) }
+  def find_or_create_by!(attributes, &block); end
 
   sig { returns(T.nilable(ActiveRecord::SchemaMigration)) }
   def first; end

--- a/spec/test_data/v5.2/expected_school.rbi
+++ b/spec/test_data/v5.2/expected_school.rbi
@@ -370,6 +370,15 @@ class School::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelati
   sig { params(args: T.untyped).returns(School) }
   def find_by!(*args); end
 
+  sig { params(attributes: T.untyped, block: T.proc.params(object: School).void).returns(School) }
+  def find_or_initialize_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: School).void).returns(School) }
+  def find_or_create_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: School).void).returns(School) }
+  def find_or_create_by!(attributes, &block); end
+
   sig { returns(T.nilable(School)) }
   def first; end
 
@@ -541,6 +550,15 @@ class School::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associat
 
   sig { params(args: T.untyped).returns(School) }
   def find_by!(*args); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: School).void).returns(School) }
+  def find_or_initialize_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: School).void).returns(School) }
+  def find_or_create_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: School).void).returns(School) }
+  def find_or_create_by!(attributes, &block); end
 
   sig { returns(T.nilable(School)) }
   def first; end

--- a/spec/test_data/v5.2/expected_spell_book.rbi
+++ b/spec/test_data/v5.2/expected_spell_book.rbi
@@ -467,6 +467,15 @@ class SpellBook::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRel
   sig { params(args: T.untyped).returns(SpellBook) }
   def find_by!(*args); end
 
+  sig { params(attributes: T.untyped, block: T.proc.params(object: SpellBook).void).returns(SpellBook) }
+  def find_or_initialize_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: SpellBook).void).returns(SpellBook) }
+  def find_or_create_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: SpellBook).void).returns(SpellBook) }
+  def find_or_create_by!(attributes, &block); end
+
   sig { returns(T.nilable(SpellBook)) }
   def first; end
 
@@ -647,6 +656,15 @@ class SpellBook::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Assoc
 
   sig { params(args: T.untyped).returns(SpellBook) }
   def find_by!(*args); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: SpellBook).void).returns(SpellBook) }
+  def find_or_initialize_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: SpellBook).void).returns(SpellBook) }
+  def find_or_create_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: SpellBook).void).returns(SpellBook) }
+  def find_or_create_by!(attributes, &block); end
 
   sig { returns(T.nilable(SpellBook)) }
   def first; end

--- a/spec/test_data/v5.2/expected_squib.rbi
+++ b/spec/test_data/v5.2/expected_squib.rbi
@@ -839,6 +839,15 @@ class Squib::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelatio
   sig { params(args: T.untyped).returns(Squib) }
   def find_by!(*args); end
 
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Squib).void).returns(Squib) }
+  def find_or_initialize_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Squib).void).returns(Squib) }
+  def find_or_create_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Squib).void).returns(Squib) }
+  def find_or_create_by!(attributes, &block); end
+
   sig { returns(T.nilable(Squib)) }
   def first; end
 
@@ -1070,6 +1079,15 @@ class Squib::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associati
 
   sig { params(args: T.untyped).returns(Squib) }
   def find_by!(*args); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Squib).void).returns(Squib) }
+  def find_or_initialize_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Squib).void).returns(Squib) }
+  def find_or_create_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Squib).void).returns(Squib) }
+  def find_or_create_by!(attributes, &block); end
 
   sig { returns(T.nilable(Squib)) }
   def first; end

--- a/spec/test_data/v5.2/expected_wand.rbi
+++ b/spec/test_data/v5.2/expected_wand.rbi
@@ -585,6 +585,15 @@ class Wand::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
   sig { params(args: T.untyped).returns(Wand) }
   def find_by!(*args); end
 
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Wand).void).returns(Wand) }
+  def find_or_initialize_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Wand).void).returns(Wand) }
+  def find_or_create_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Wand).void).returns(Wand) }
+  def find_or_create_by!(attributes, &block); end
+
   sig { returns(T.nilable(Wand)) }
   def first; end
 
@@ -768,6 +777,15 @@ class Wand::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associatio
 
   sig { params(args: T.untyped).returns(Wand) }
   def find_by!(*args); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Wand).void).returns(Wand) }
+  def find_or_initialize_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Wand).void).returns(Wand) }
+  def find_or_create_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Wand).void).returns(Wand) }
+  def find_or_create_by!(attributes, &block); end
 
   sig { returns(T.nilable(Wand)) }
   def first; end

--- a/spec/test_data/v5.2/expected_wizard.rbi
+++ b/spec/test_data/v5.2/expected_wizard.rbi
@@ -914,6 +914,15 @@ class Wizard::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelati
   sig { params(args: T.untyped).returns(Wizard) }
   def find_by!(*args); end
 
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Wizard).void).returns(Wizard) }
+  def find_or_initialize_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Wizard).void).returns(Wizard) }
+  def find_or_create_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Wizard).void).returns(Wizard) }
+  def find_or_create_by!(attributes, &block); end
+
   sig { returns(T.nilable(Wizard)) }
   def first; end
 
@@ -1145,6 +1154,15 @@ class Wizard::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associat
 
   sig { params(args: T.untyped).returns(Wizard) }
   def find_by!(*args); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Wizard).void).returns(Wizard) }
+  def find_or_initialize_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Wizard).void).returns(Wizard) }
+  def find_or_create_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Wizard).void).returns(Wizard) }
+  def find_or_create_by!(attributes, &block); end
 
   sig { returns(T.nilable(Wizard)) }
   def first; end

--- a/spec/test_data/v5.2/expected_wizard_wo_spellbook.rbi
+++ b/spec/test_data/v5.2/expected_wizard_wo_spellbook.rbi
@@ -914,6 +914,15 @@ class Wizard::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelati
   sig { params(args: T.untyped).returns(Wizard) }
   def find_by!(*args); end
 
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Wizard).void).returns(Wizard) }
+  def find_or_initialize_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Wizard).void).returns(Wizard) }
+  def find_or_create_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Wizard).void).returns(Wizard) }
+  def find_or_create_by!(attributes, &block); end
+
   sig { returns(T.nilable(Wizard)) }
   def first; end
 
@@ -1145,6 +1154,15 @@ class Wizard::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associat
 
   sig { params(args: T.untyped).returns(Wizard) }
   def find_by!(*args); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Wizard).void).returns(Wizard) }
+  def find_or_initialize_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Wizard).void).returns(Wizard) }
+  def find_or_create_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Wizard).void).returns(Wizard) }
+  def find_or_create_by!(attributes, &block); end
 
   sig { returns(T.nilable(Wizard)) }
   def first; end

--- a/spec/test_data/v6.0/expected_attachment.rbi
+++ b/spec/test_data/v6.0/expected_attachment.rbi
@@ -400,6 +400,15 @@ class ActiveStorage::Attachment::ActiveRecord_AssociationRelation < ActiveRecord
   sig { params(args: T.untyped).returns(ActiveStorage::Attachment) }
   def find_by!(*args); end
 
+  sig { params(attributes: T.untyped, block: T.proc.params(object: ActiveStorage::Attachment).void).returns(ActiveStorage::Attachment) }
+  def find_or_initialize_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: ActiveStorage::Attachment).void).returns(ActiveStorage::Attachment) }
+  def find_or_create_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: ActiveStorage::Attachment).void).returns(ActiveStorage::Attachment) }
+  def find_or_create_by!(attributes, &block); end
+
   sig { returns(T.nilable(ActiveStorage::Attachment)) }
   def first; end
 
@@ -583,6 +592,15 @@ class ActiveStorage::Attachment::ActiveRecord_Associations_CollectionProxy < Act
 
   sig { params(args: T.untyped).returns(ActiveStorage::Attachment) }
   def find_by!(*args); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: ActiveStorage::Attachment).void).returns(ActiveStorage::Attachment) }
+  def find_or_initialize_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: ActiveStorage::Attachment).void).returns(ActiveStorage::Attachment) }
+  def find_or_create_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: ActiveStorage::Attachment).void).returns(ActiveStorage::Attachment) }
+  def find_or_create_by!(attributes, &block); end
 
   sig { returns(T.nilable(ActiveStorage::Attachment)) }
   def first; end

--- a/spec/test_data/v6.0/expected_blob.rbi
+++ b/spec/test_data/v6.0/expected_blob.rbi
@@ -402,6 +402,15 @@ class ActiveStorage::Blob::ActiveRecord_AssociationRelation < ActiveRecord::Asso
   sig { params(args: T.untyped).returns(ActiveStorage::Blob) }
   def find_by!(*args); end
 
+  sig { params(attributes: T.untyped, block: T.proc.params(object: ActiveStorage::Blob).void).returns(ActiveStorage::Blob) }
+  def find_or_initialize_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: ActiveStorage::Blob).void).returns(ActiveStorage::Blob) }
+  def find_or_create_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: ActiveStorage::Blob).void).returns(ActiveStorage::Blob) }
+  def find_or_create_by!(attributes, &block); end
+
   sig { returns(T.nilable(ActiveStorage::Blob)) }
   def first; end
 
@@ -591,6 +600,15 @@ class ActiveStorage::Blob::ActiveRecord_Associations_CollectionProxy < ActiveRec
 
   sig { params(args: T.untyped).returns(ActiveStorage::Blob) }
   def find_by!(*args); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: ActiveStorage::Blob).void).returns(ActiveStorage::Blob) }
+  def find_or_initialize_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: ActiveStorage::Blob).void).returns(ActiveStorage::Blob) }
+  def find_or_create_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: ActiveStorage::Blob).void).returns(ActiveStorage::Blob) }
+  def find_or_create_by!(attributes, &block); end
 
   sig { returns(T.nilable(ActiveStorage::Blob)) }
   def first; end

--- a/spec/test_data/v6.0/expected_internal_metadata.rbi
+++ b/spec/test_data/v6.0/expected_internal_metadata.rbi
@@ -424,6 +424,15 @@ class ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation < ActiveR
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata) }
   def find_by!(*args); end
 
+  sig { params(attributes: T.untyped, block: T.proc.params(object: ActiveRecord::InternalMetadata).void).returns(ActiveRecord::InternalMetadata) }
+  def find_or_initialize_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: ActiveRecord::InternalMetadata).void).returns(ActiveRecord::InternalMetadata) }
+  def find_or_create_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: ActiveRecord::InternalMetadata).void).returns(ActiveRecord::InternalMetadata) }
+  def find_or_create_by!(attributes, &block); end
+
   sig { returns(T.nilable(ActiveRecord::InternalMetadata)) }
   def first; end
 
@@ -607,6 +616,15 @@ class ActiveRecord::InternalMetadata::ActiveRecord_Associations_CollectionProxy 
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata) }
   def find_by!(*args); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: ActiveRecord::InternalMetadata).void).returns(ActiveRecord::InternalMetadata) }
+  def find_or_initialize_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: ActiveRecord::InternalMetadata).void).returns(ActiveRecord::InternalMetadata) }
+  def find_or_create_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: ActiveRecord::InternalMetadata).void).returns(ActiveRecord::InternalMetadata) }
+  def find_or_create_by!(attributes, &block); end
 
   sig { returns(T.nilable(ActiveRecord::InternalMetadata)) }
   def first; end

--- a/spec/test_data/v6.0/expected_potion.rbi
+++ b/spec/test_data/v6.0/expected_potion.rbi
@@ -394,6 +394,15 @@ class Potion::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelati
   sig { params(args: T.untyped).returns(Potion) }
   def find_by!(*args); end
 
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Potion).void).returns(Potion) }
+  def find_or_initialize_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Potion).void).returns(Potion) }
+  def find_or_create_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Potion).void).returns(Potion) }
+  def find_or_create_by!(attributes, &block); end
+
   sig { returns(T.nilable(Potion)) }
   def first; end
 
@@ -577,6 +586,15 @@ class Potion::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associat
 
   sig { params(args: T.untyped).returns(Potion) }
   def find_by!(*args); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Potion).void).returns(Potion) }
+  def find_or_initialize_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Potion).void).returns(Potion) }
+  def find_or_create_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Potion).void).returns(Potion) }
+  def find_or_create_by!(attributes, &block); end
 
   sig { returns(T.nilable(Potion)) }
   def first; end

--- a/spec/test_data/v6.0/expected_robe.rbi
+++ b/spec/test_data/v6.0/expected_robe.rbi
@@ -417,6 +417,15 @@ class Robe::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
   sig { params(args: T.untyped).returns(Robe) }
   def find_by!(*args); end
 
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Robe).void).returns(Robe) }
+  def find_or_initialize_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Robe).void).returns(Robe) }
+  def find_or_create_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Robe).void).returns(Robe) }
+  def find_or_create_by!(attributes, &block); end
+
   sig { returns(T.nilable(Robe)) }
   def first; end
 
@@ -600,6 +609,15 @@ class Robe::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associatio
 
   sig { params(args: T.untyped).returns(Robe) }
   def find_by!(*args); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Robe).void).returns(Robe) }
+  def find_or_initialize_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Robe).void).returns(Robe) }
+  def find_or_create_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Robe).void).returns(Robe) }
+  def find_or_create_by!(attributes, &block); end
 
   sig { returns(T.nilable(Robe)) }
   def first; end

--- a/spec/test_data/v6.0/expected_schema_migration.rbi
+++ b/spec/test_data/v6.0/expected_schema_migration.rbi
@@ -397,6 +397,15 @@ class ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation < ActiveRe
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration) }
   def find_by!(*args); end
 
+  sig { params(attributes: T.untyped, block: T.proc.params(object: ActiveRecord::SchemaMigration).void).returns(ActiveRecord::SchemaMigration) }
+  def find_or_initialize_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: ActiveRecord::SchemaMigration).void).returns(ActiveRecord::SchemaMigration) }
+  def find_or_create_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: ActiveRecord::SchemaMigration).void).returns(ActiveRecord::SchemaMigration) }
+  def find_or_create_by!(attributes, &block); end
+
   sig { returns(T.nilable(ActiveRecord::SchemaMigration)) }
   def first; end
 
@@ -580,6 +589,15 @@ class ActiveRecord::SchemaMigration::ActiveRecord_Associations_CollectionProxy <
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration) }
   def find_by!(*args); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: ActiveRecord::SchemaMigration).void).returns(ActiveRecord::SchemaMigration) }
+  def find_or_initialize_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: ActiveRecord::SchemaMigration).void).returns(ActiveRecord::SchemaMigration) }
+  def find_or_create_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: ActiveRecord::SchemaMigration).void).returns(ActiveRecord::SchemaMigration) }
+  def find_or_create_by!(attributes, &block); end
 
   sig { returns(T.nilable(ActiveRecord::SchemaMigration)) }
   def first; end

--- a/spec/test_data/v6.0/expected_school.rbi
+++ b/spec/test_data/v6.0/expected_school.rbi
@@ -406,6 +406,15 @@ class School::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelati
   sig { params(args: T.untyped).returns(School) }
   def find_by!(*args); end
 
+  sig { params(attributes: T.untyped, block: T.proc.params(object: School).void).returns(School) }
+  def find_or_initialize_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: School).void).returns(School) }
+  def find_or_create_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: School).void).returns(School) }
+  def find_or_create_by!(attributes, &block); end
+
   sig { returns(T.nilable(School)) }
   def first; end
 
@@ -589,6 +598,15 @@ class School::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associat
 
   sig { params(args: T.untyped).returns(School) }
   def find_by!(*args); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: School).void).returns(School) }
+  def find_or_initialize_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: School).void).returns(School) }
+  def find_or_create_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: School).void).returns(School) }
+  def find_or_create_by!(attributes, &block); end
 
   sig { returns(T.nilable(School)) }
   def first; end

--- a/spec/test_data/v6.0/expected_spell_book.rbi
+++ b/spec/test_data/v6.0/expected_spell_book.rbi
@@ -530,6 +530,15 @@ class SpellBook::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRel
   sig { params(args: T.untyped).returns(SpellBook) }
   def find_by!(*args); end
 
+  sig { params(attributes: T.untyped, block: T.proc.params(object: SpellBook).void).returns(SpellBook) }
+  def find_or_initialize_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: SpellBook).void).returns(SpellBook) }
+  def find_or_create_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: SpellBook).void).returns(SpellBook) }
+  def find_or_create_by!(attributes, &block); end
+
   sig { returns(T.nilable(SpellBook)) }
   def first; end
 
@@ -731,6 +740,15 @@ class SpellBook::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Assoc
 
   sig { params(args: T.untyped).returns(SpellBook) }
   def find_by!(*args); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: SpellBook).void).returns(SpellBook) }
+  def find_or_initialize_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: SpellBook).void).returns(SpellBook) }
+  def find_or_create_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: SpellBook).void).returns(SpellBook) }
+  def find_or_create_by!(attributes, &block); end
 
   sig { returns(T.nilable(SpellBook)) }
   def first; end

--- a/spec/test_data/v6.0/expected_squib.rbi
+++ b/spec/test_data/v6.0/expected_squib.rbi
@@ -982,6 +982,15 @@ class Squib::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelatio
   sig { params(args: T.untyped).returns(Squib) }
   def find_by!(*args); end
 
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Squib).void).returns(Squib) }
+  def find_or_initialize_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Squib).void).returns(Squib) }
+  def find_or_create_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Squib).void).returns(Squib) }
+  def find_or_create_by!(attributes, &block); end
+
   sig { returns(T.nilable(Squib)) }
   def first; end
 
@@ -1276,6 +1285,15 @@ class Squib::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associati
 
   sig { params(args: T.untyped).returns(Squib) }
   def find_by!(*args); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Squib).void).returns(Squib) }
+  def find_or_initialize_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Squib).void).returns(Squib) }
+  def find_or_create_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Squib).void).returns(Squib) }
+  def find_or_create_by!(attributes, &block); end
 
   sig { returns(T.nilable(Squib)) }
   def first; end

--- a/spec/test_data/v6.0/expected_wand.rbi
+++ b/spec/test_data/v6.0/expected_wand.rbi
@@ -657,6 +657,15 @@ class Wand::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
   sig { params(args: T.untyped).returns(Wand) }
   def find_by!(*args); end
 
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Wand).void).returns(Wand) }
+  def find_or_initialize_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Wand).void).returns(Wand) }
+  def find_or_create_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Wand).void).returns(Wand) }
+  def find_or_create_by!(attributes, &block); end
+
   sig { returns(T.nilable(Wand)) }
   def first; end
 
@@ -864,6 +873,15 @@ class Wand::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associatio
 
   sig { params(args: T.untyped).returns(Wand) }
   def find_by!(*args); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Wand).void).returns(Wand) }
+  def find_or_initialize_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Wand).void).returns(Wand) }
+  def find_or_create_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Wand).void).returns(Wand) }
+  def find_or_create_by!(attributes, &block); end
 
   sig { returns(T.nilable(Wand)) }
   def first; end

--- a/spec/test_data/v6.0/expected_wizard.rbi
+++ b/spec/test_data/v6.0/expected_wizard.rbi
@@ -1057,6 +1057,15 @@ class Wizard::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelati
   sig { params(args: T.untyped).returns(Wizard) }
   def find_by!(*args); end
 
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Wizard).void).returns(Wizard) }
+  def find_or_initialize_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Wizard).void).returns(Wizard) }
+  def find_or_create_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Wizard).void).returns(Wizard) }
+  def find_or_create_by!(attributes, &block); end
+
   sig { returns(T.nilable(Wizard)) }
   def first; end
 
@@ -1351,6 +1360,15 @@ class Wizard::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associat
 
   sig { params(args: T.untyped).returns(Wizard) }
   def find_by!(*args); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Wizard).void).returns(Wizard) }
+  def find_or_initialize_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Wizard).void).returns(Wizard) }
+  def find_or_create_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Wizard).void).returns(Wizard) }
+  def find_or_create_by!(attributes, &block); end
 
   sig { returns(T.nilable(Wizard)) }
   def first; end

--- a/spec/test_data/v6.0/expected_wizard_wo_spellbook.rbi
+++ b/spec/test_data/v6.0/expected_wizard_wo_spellbook.rbi
@@ -1057,6 +1057,15 @@ class Wizard::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelati
   sig { params(args: T.untyped).returns(Wizard) }
   def find_by!(*args); end
 
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Wizard).void).returns(Wizard) }
+  def find_or_initialize_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Wizard).void).returns(Wizard) }
+  def find_or_create_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Wizard).void).returns(Wizard) }
+  def find_or_create_by!(attributes, &block); end
+
   sig { returns(T.nilable(Wizard)) }
   def first; end
 
@@ -1351,6 +1360,15 @@ class Wizard::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associat
 
   sig { params(args: T.untyped).returns(Wizard) }
   def find_by!(*args); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Wizard).void).returns(Wizard) }
+  def find_or_initialize_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Wizard).void).returns(Wizard) }
+  def find_or_create_by(attributes, &block); end
+
+  sig { params(attributes: T.untyped, block: T.proc.params(object: Wizard).void).returns(Wizard) }
+  def find_or_create_by!(attributes, &block); end
 
   sig { returns(T.nilable(Wizard)) }
   def first; end


### PR DESCRIPTION
Looking at my team's repository I realized we were missing out on some typing due to the fact that there wasn't any typing for the return values `find_or_initialize_by`, `find_or_create_by` and `find_or_create_by!`. Was simple enough to just add these in and they appear to be working fine in our repo.