### PR TITLE
Fix Elem to T.untyped in ActiveRecord::Relation 

### DIFF
--- a/lib/bundled_rbi/active_record_relation.rbi
+++ b/lib/bundled_rbi/active_record_relation.rbi
@@ -1,5 +1,7 @@
 # typed: strong
 class ActiveRecord::Relation
+  Elem = type_member(fixed: T.untyped)
+
   sig { params(args: T.untyped).returns(Elem) }
   def find(*args); end
 

--- a/lib/bundled_rbi/pluck_to_tstruct.rbi
+++ b/lib/bundled_rbi/pluck_to_tstruct.rbi
@@ -17,6 +17,5 @@ class ActiveRecord::Base
 end
 
 class ActiveRecord::Relation
-  Elem = type_member
   include SorbetRails::PluckToTStruct
 end


### PR DESCRIPTION
Let's test if we need to define Elem in ActiveRecord::Relation. We already set a fixed one in every subclass we generate.