### PR TITLE
[test] Print srb lsp outputs

### DIFF
--- a/spec/sorbet_spec.rb
+++ b/spec/sorbet_spec.rb
@@ -88,6 +88,9 @@ RSpec.describe 'sorbet' do
       'bundle', 'exec', 'srb', 'tc', '--lsp',
       chdir: Rails.root.to_path,
     )
+    puts "rails root: #{Rails.root.to_path}"
+    puts stdout
+    puts stderr
     expect(status.exitstatus).to eql(10)
   end
 end

--- a/spec/sorbet_spec.rb
+++ b/spec/sorbet_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe 'sorbet' do
 
   it 'runs with srb tc --lsp' do
     stdout, stderr, status = Open3.capture3(
-      'bundle', 'exec', 'srb', 'tc', '--lsp',
+      'bundle', 'exec', 'srb', 'tc', '--lsp', '--verbose',
       chdir: Rails.root.to_path,
     )
     puts "rails root: #{Rails.root.to_path}"


### PR DESCRIPTION
This prints the output of the `lsp` command and provides a better debugging context.