### PR TITLE
Add require for typed_params

### DIFF
--- a/lib/sorbet-rails.rb
+++ b/lib/sorbet-rails.rb
@@ -6,5 +6,6 @@ module SorbetRails
     require 'sorbet-rails/type_assert/type_assert'
     require 'sorbet-rails/custom_types/integer_string'
     require 'sorbet-rails/custom_types/boolean_string'
+    require 'sorbet-rails/typed_params'
   end
 end


### PR DESCRIPTION
I am playing with this on `master`, and get an uninitialized constant error without this (or an explicit require in my app).

If this is not the right place for this let me know and I'll move it.
