### PR TITLE
Upgrade sorbet-coerce to v0.2.3

### DIFF
--- a/lib/sorbet-rails/typed_params.rb
+++ b/lib/sorbet-rails/typed_params.rb
@@ -7,11 +7,11 @@ module TypedParams
     Class.new do
       define_method(:extract!) do |params, raise_coercion_error: nil|
         begin
-          T::Coerce[type].new.from(
+          TypeCoerce[type].new.from(
             params.permit!.to_h,
             raise_coercion_error: raise_coercion_error
           )
-        rescue T::Coerce::CoercionError, T::Coerce::ShapeError, TypeError, ArgumentError => e
+        rescue TypeCoerce::CoercionError, TypeCoerce::ShapeError, TypeError, ArgumentError => e
           raise ActionController::BadRequest.new(e)
         end
       end

--- a/sorbet-rails.gemspec
+++ b/sorbet-rails.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'parlour', '~> 2.0'
   s.add_dependency 'sorbet', '>= 0.5'
-  s.add_dependency 'sorbet-coerce', '>= 0.2.2'
+  s.add_dependency 'sorbet-coerce', '>= 0.2.3'
 
   # Development
   s.add_development_dependency 'rspec', '~> 3.8', '>= 3.8'


### PR DESCRIPTION
The new version of sorbet-coerce supports
- `T::Set`
- `T.untyped`

Also, it renames `T::Coerce` to `TypeCoerce` since sorbet is planning to lock the `T` namespace.