### PR TITLE
Adds XXX::RelationType alias

### DIFF
--- a/lib/sorbet-rails/model_rbi_formatter.rb
+++ b/lib/sorbet-rails/model_rbi_formatter.rb
@@ -109,6 +109,10 @@ class SorbetRails::ModelRbiFormatter
     )
     model_rbi.create_extend("T::Sig")
     model_rbi.create_extend("T::Generic")
+    model_rbi.create_type_alias(
+      self.model_relation_type_class_name,
+      type: self.model_relation_type_alias
+    )
   end
 
   sig {

--- a/lib/sorbet-rails/model_utils.rb
+++ b/lib/sorbet-rails/model_utils.rb
@@ -28,6 +28,22 @@ module SorbetRails::ModelUtils
     "#{model_class.name}::ActiveRecord_AssociationRelation"
   end
 
+  sig { returns(String) }
+  def model_relation_type_alias
+    types = [
+      self.model_relation_class_name,
+      self.model_assoc_proxy_class_name,
+      self.model_assoc_relation_class_name
+    ].join(', ')
+
+    "T.any(#{types})"
+  end
+
+  sig { returns(String) }
+  def model_relation_type_class_name
+    'RelationType'
+  end
+
   sig { params(module_name: String).returns(String) }
   def model_module_name(module_name)
     "#{model_class.name}::#{module_name}"

--- a/lib/sorbet-rails/railtie.rb
+++ b/lib/sorbet-rails/railtie.rb
@@ -34,6 +34,16 @@ class SorbetRails::Railtie < Rails::Railtie
             child.send(:public_constant, :ActiveRecord_Relation)
             child.send(:public_constant, :ActiveRecord_AssociationRelation)
             child.send(:public_constant, :ActiveRecord_Associations_CollectionProxy)
+
+            relation_type = T.type_alias do
+              T.any(
+                child.const_get(:ActiveRecord_Relation),
+                child.const_get(:ActiveRecord_AssociationRelation),
+                child.const_get(:ActiveRecord_Associations_CollectionProxy)
+              )
+            end
+            child.const_set(:RelationType, relation_type)
+            child.send(:public_constant, :RelationType)
           end
         end
       end

--- a/spec/model_rbi_formatter_spec.rb
+++ b/spec/model_rbi_formatter_spec.rb
@@ -53,4 +53,11 @@ RSpec.describe SorbetRails::ModelRbiFormatter do
       )
     end
   end
+
+  it 'creates Model::RelationType alias at runtime' do
+    ActiveRecord::Base.descendants.each do |model|
+      expect(model.const_defined?("RelationType")).to be(true)
+      expect(model.const_get("RelationType")).to be_a(T::Private::Types::TypeAlias)
+    end
+  end
 end

--- a/spec/test_data/v5.0/expected_internal_metadata.rbi
+++ b/spec/test_data/v5.0/expected_internal_metadata.rbi
@@ -69,6 +69,7 @@ class ActiveRecord::InternalMetadata < ActiveRecord::Base
   extend ActiveRecord::InternalMetadata::CustomFinderMethods
   extend T::Sig
   extend T::Generic
+  RelationType = T.type_alias { T.any(ActiveRecord::InternalMetadata::ActiveRecord_Relation, ActiveRecord::InternalMetadata::ActiveRecord_Associations_CollectionProxy, ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
 
   sig { returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
   def self.all; end

--- a/spec/test_data/v5.0/expected_potion.rbi
+++ b/spec/test_data/v5.0/expected_potion.rbi
@@ -39,6 +39,7 @@ class Potion < ApplicationRecord
   extend Potion::CustomFinderMethods
   extend T::Sig
   extend T::Generic
+  RelationType = T.type_alias { T.any(Potion::ActiveRecord_Relation, Potion::ActiveRecord_Associations_CollectionProxy, Potion::ActiveRecord_AssociationRelation) }
 
   sig { returns(Potion::ActiveRecord_Relation) }
   def self.all; end

--- a/spec/test_data/v5.0/expected_robe.rbi
+++ b/spec/test_data/v5.0/expected_robe.rbi
@@ -62,6 +62,7 @@ class Robe < ApplicationRecord
   extend Robe::CustomFinderMethods
   extend T::Sig
   extend T::Generic
+  RelationType = T.type_alias { T.any(Robe::ActiveRecord_Relation, Robe::ActiveRecord_Associations_CollectionProxy, Robe::ActiveRecord_AssociationRelation) }
 
   sig { returns(Robe::ActiveRecord_Relation) }
   def self.all; end

--- a/spec/test_data/v5.0/expected_schema_migration.rbi
+++ b/spec/test_data/v5.0/expected_schema_migration.rbi
@@ -42,6 +42,7 @@ class ActiveRecord::SchemaMigration < ActiveRecord::Base
   extend ActiveRecord::SchemaMigration::CustomFinderMethods
   extend T::Sig
   extend T::Generic
+  RelationType = T.type_alias { T.any(ActiveRecord::SchemaMigration::ActiveRecord_Relation, ActiveRecord::SchemaMigration::ActiveRecord_Associations_CollectionProxy, ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
 
   sig { returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
   def self.all; end

--- a/spec/test_data/v5.0/expected_school.rbi
+++ b/spec/test_data/v5.0/expected_school.rbi
@@ -51,6 +51,7 @@ class School < ApplicationRecord
   extend School::CustomFinderMethods
   extend T::Sig
   extend T::Generic
+  RelationType = T.type_alias { T.any(School::ActiveRecord_Relation, School::ActiveRecord_Associations_CollectionProxy, School::ActiveRecord_AssociationRelation) }
 
   sig { returns(School::ActiveRecord_Relation) }
   def self.all; end

--- a/spec/test_data/v5.0/expected_spell_book.rbi
+++ b/spec/test_data/v5.0/expected_spell_book.rbi
@@ -112,6 +112,7 @@ class SpellBook < ApplicationRecord
   extend SpellBook::CustomFinderMethods
   extend T::Sig
   extend T::Generic
+  RelationType = T.type_alias { T.any(SpellBook::ActiveRecord_Relation, SpellBook::ActiveRecord_Associations_CollectionProxy, SpellBook::ActiveRecord_AssociationRelation) }
 
   sig { returns(T::Hash[T.any(String, Symbol), Integer]) }
   def self.book_types; end

--- a/spec/test_data/v5.0/expected_squib.rbi
+++ b/spec/test_data/v5.0/expected_squib.rbi
@@ -298,6 +298,7 @@ class Squib < Wizard
   extend Squib::CustomFinderMethods
   extend T::Sig
   extend T::Generic
+  RelationType = T.type_alias { T.any(Squib::ActiveRecord_Relation, Squib::ActiveRecord_Associations_CollectionProxy, Squib::ActiveRecord_AssociationRelation) }
 
   sig { returns(T::Hash[T.any(String, Symbol), String]) }
   def self.brooms; end

--- a/spec/test_data/v5.0/expected_wand.rbi
+++ b/spec/test_data/v5.0/expected_wand.rbi
@@ -200,6 +200,7 @@ class Wand < ApplicationRecord
   extend Wand::CustomFinderMethods
   extend T::Sig
   extend T::Generic
+  RelationType = T.type_alias { T.any(Wand::ActiveRecord_Relation, Wand::ActiveRecord_Associations_CollectionProxy, Wand::ActiveRecord_AssociationRelation) }
 
   sig { returns(T::Hash[T.any(String, Symbol), Integer]) }
   def self.core_types; end

--- a/spec/test_data/v5.0/expected_wizard.rbi
+++ b/spec/test_data/v5.0/expected_wizard.rbi
@@ -337,6 +337,7 @@ class Wizard < ApplicationRecord
   extend Wizard::CustomFinderMethods
   extend T::Sig
   extend T::Generic
+  RelationType = T.type_alias { T.any(Wizard::ActiveRecord_Relation, Wizard::ActiveRecord_Associations_CollectionProxy, Wizard::ActiveRecord_AssociationRelation) }
 
   sig { returns(T::Hash[T.any(String, Symbol), String]) }
   def self.brooms; end

--- a/spec/test_data/v5.0/expected_wizard_wo_spellbook.rbi
+++ b/spec/test_data/v5.0/expected_wizard_wo_spellbook.rbi
@@ -337,6 +337,7 @@ class Wizard < ApplicationRecord
   extend Wizard::CustomFinderMethods
   extend T::Sig
   extend T::Generic
+  RelationType = T.type_alias { T.any(Wizard::ActiveRecord_Relation, Wizard::ActiveRecord_Associations_CollectionProxy, Wizard::ActiveRecord_AssociationRelation) }
 
   sig { returns(T::Hash[T.any(String, Symbol), String]) }
   def self.brooms; end

--- a/spec/test_data/v5.1/expected_internal_metadata.rbi
+++ b/spec/test_data/v5.1/expected_internal_metadata.rbi
@@ -69,6 +69,7 @@ class ActiveRecord::InternalMetadata < ActiveRecord::Base
   extend ActiveRecord::InternalMetadata::CustomFinderMethods
   extend T::Sig
   extend T::Generic
+  RelationType = T.type_alias { T.any(ActiveRecord::InternalMetadata::ActiveRecord_Relation, ActiveRecord::InternalMetadata::ActiveRecord_Associations_CollectionProxy, ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
 
   sig { returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
   def self.all; end

--- a/spec/test_data/v5.1/expected_potion.rbi
+++ b/spec/test_data/v5.1/expected_potion.rbi
@@ -39,6 +39,7 @@ class Potion < ApplicationRecord
   extend Potion::CustomFinderMethods
   extend T::Sig
   extend T::Generic
+  RelationType = T.type_alias { T.any(Potion::ActiveRecord_Relation, Potion::ActiveRecord_Associations_CollectionProxy, Potion::ActiveRecord_AssociationRelation) }
 
   sig { returns(Potion::ActiveRecord_Relation) }
   def self.all; end

--- a/spec/test_data/v5.1/expected_robe.rbi
+++ b/spec/test_data/v5.1/expected_robe.rbi
@@ -62,6 +62,7 @@ class Robe < ApplicationRecord
   extend Robe::CustomFinderMethods
   extend T::Sig
   extend T::Generic
+  RelationType = T.type_alias { T.any(Robe::ActiveRecord_Relation, Robe::ActiveRecord_Associations_CollectionProxy, Robe::ActiveRecord_AssociationRelation) }
 
   sig { returns(Robe::ActiveRecord_Relation) }
   def self.all; end

--- a/spec/test_data/v5.1/expected_schema_migration.rbi
+++ b/spec/test_data/v5.1/expected_schema_migration.rbi
@@ -42,6 +42,7 @@ class ActiveRecord::SchemaMigration < ActiveRecord::Base
   extend ActiveRecord::SchemaMigration::CustomFinderMethods
   extend T::Sig
   extend T::Generic
+  RelationType = T.type_alias { T.any(ActiveRecord::SchemaMigration::ActiveRecord_Relation, ActiveRecord::SchemaMigration::ActiveRecord_Associations_CollectionProxy, ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
 
   sig { returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
   def self.all; end

--- a/spec/test_data/v5.1/expected_school.rbi
+++ b/spec/test_data/v5.1/expected_school.rbi
@@ -51,6 +51,7 @@ class School < ApplicationRecord
   extend School::CustomFinderMethods
   extend T::Sig
   extend T::Generic
+  RelationType = T.type_alias { T.any(School::ActiveRecord_Relation, School::ActiveRecord_Associations_CollectionProxy, School::ActiveRecord_AssociationRelation) }
 
   sig { returns(School::ActiveRecord_Relation) }
   def self.all; end

--- a/spec/test_data/v5.1/expected_spell_book.rbi
+++ b/spec/test_data/v5.1/expected_spell_book.rbi
@@ -112,6 +112,7 @@ class SpellBook < ApplicationRecord
   extend SpellBook::CustomFinderMethods
   extend T::Sig
   extend T::Generic
+  RelationType = T.type_alias { T.any(SpellBook::ActiveRecord_Relation, SpellBook::ActiveRecord_Associations_CollectionProxy, SpellBook::ActiveRecord_AssociationRelation) }
 
   sig { returns(T::Hash[T.any(String, Symbol), Integer]) }
   def self.book_types; end

--- a/spec/test_data/v5.1/expected_squib.rbi
+++ b/spec/test_data/v5.1/expected_squib.rbi
@@ -298,6 +298,7 @@ class Squib < Wizard
   extend Squib::CustomFinderMethods
   extend T::Sig
   extend T::Generic
+  RelationType = T.type_alias { T.any(Squib::ActiveRecord_Relation, Squib::ActiveRecord_Associations_CollectionProxy, Squib::ActiveRecord_AssociationRelation) }
 
   sig { returns(T::Hash[T.any(String, Symbol), String]) }
   def self.brooms; end

--- a/spec/test_data/v5.1/expected_wand.rbi
+++ b/spec/test_data/v5.1/expected_wand.rbi
@@ -200,6 +200,7 @@ class Wand < ApplicationRecord
   extend Wand::CustomFinderMethods
   extend T::Sig
   extend T::Generic
+  RelationType = T.type_alias { T.any(Wand::ActiveRecord_Relation, Wand::ActiveRecord_Associations_CollectionProxy, Wand::ActiveRecord_AssociationRelation) }
 
   sig { returns(T::Hash[T.any(String, Symbol), Integer]) }
   def self.core_types; end

--- a/spec/test_data/v5.1/expected_wizard.rbi
+++ b/spec/test_data/v5.1/expected_wizard.rbi
@@ -337,6 +337,7 @@ class Wizard < ApplicationRecord
   extend Wizard::CustomFinderMethods
   extend T::Sig
   extend T::Generic
+  RelationType = T.type_alias { T.any(Wizard::ActiveRecord_Relation, Wizard::ActiveRecord_Associations_CollectionProxy, Wizard::ActiveRecord_AssociationRelation) }
 
   sig { returns(T::Hash[T.any(String, Symbol), String]) }
   def self.brooms; end

--- a/spec/test_data/v5.1/expected_wizard_wo_spellbook.rbi
+++ b/spec/test_data/v5.1/expected_wizard_wo_spellbook.rbi
@@ -337,6 +337,7 @@ class Wizard < ApplicationRecord
   extend Wizard::CustomFinderMethods
   extend T::Sig
   extend T::Generic
+  RelationType = T.type_alias { T.any(Wizard::ActiveRecord_Relation, Wizard::ActiveRecord_Associations_CollectionProxy, Wizard::ActiveRecord_AssociationRelation) }
 
   sig { returns(T::Hash[T.any(String, Symbol), String]) }
   def self.brooms; end

--- a/spec/test_data/v5.2/expected_attachment.rbi
+++ b/spec/test_data/v5.2/expected_attachment.rbi
@@ -45,6 +45,7 @@ class ActiveStorage::Attachment < ActiveRecord::Base
   extend ActiveStorage::Attachment::CustomFinderMethods
   extend T::Sig
   extend T::Generic
+  RelationType = T.type_alias { T.any(ActiveStorage::Attachment::ActiveRecord_Relation, ActiveStorage::Attachment::ActiveRecord_Associations_CollectionProxy, ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
 
   sig { returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
   def self.all; end

--- a/spec/test_data/v5.2/expected_blob.rbi
+++ b/spec/test_data/v5.2/expected_blob.rbi
@@ -51,6 +51,7 @@ class ActiveStorage::Blob < ActiveRecord::Base
   extend ActiveStorage::Blob::CustomFinderMethods
   extend T::Sig
   extend T::Generic
+  RelationType = T.type_alias { T.any(ActiveStorage::Blob::ActiveRecord_Relation, ActiveStorage::Blob::ActiveRecord_Associations_CollectionProxy, ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
 
   sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
   def self.unattached(*args); end

--- a/spec/test_data/v5.2/expected_internal_metadata.rbi
+++ b/spec/test_data/v5.2/expected_internal_metadata.rbi
@@ -69,6 +69,7 @@ class ActiveRecord::InternalMetadata < ActiveRecord::Base
   extend ActiveRecord::InternalMetadata::CustomFinderMethods
   extend T::Sig
   extend T::Generic
+  RelationType = T.type_alias { T.any(ActiveRecord::InternalMetadata::ActiveRecord_Relation, ActiveRecord::InternalMetadata::ActiveRecord_Associations_CollectionProxy, ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
 
   sig { returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
   def self.all; end

--- a/spec/test_data/v5.2/expected_potion.rbi
+++ b/spec/test_data/v5.2/expected_potion.rbi
@@ -39,6 +39,7 @@ class Potion < ApplicationRecord
   extend Potion::CustomFinderMethods
   extend T::Sig
   extend T::Generic
+  RelationType = T.type_alias { T.any(Potion::ActiveRecord_Relation, Potion::ActiveRecord_Associations_CollectionProxy, Potion::ActiveRecord_AssociationRelation) }
 
   sig { returns(Potion::ActiveRecord_Relation) }
   def self.all; end

--- a/spec/test_data/v5.2/expected_robe.rbi
+++ b/spec/test_data/v5.2/expected_robe.rbi
@@ -62,6 +62,7 @@ class Robe < ApplicationRecord
   extend Robe::CustomFinderMethods
   extend T::Sig
   extend T::Generic
+  RelationType = T.type_alias { T.any(Robe::ActiveRecord_Relation, Robe::ActiveRecord_Associations_CollectionProxy, Robe::ActiveRecord_AssociationRelation) }
 
   sig { returns(Robe::ActiveRecord_Relation) }
   def self.all; end

--- a/spec/test_data/v5.2/expected_schema_migration.rbi
+++ b/spec/test_data/v5.2/expected_schema_migration.rbi
@@ -42,6 +42,7 @@ class ActiveRecord::SchemaMigration < ActiveRecord::Base
   extend ActiveRecord::SchemaMigration::CustomFinderMethods
   extend T::Sig
   extend T::Generic
+  RelationType = T.type_alias { T.any(ActiveRecord::SchemaMigration::ActiveRecord_Relation, ActiveRecord::SchemaMigration::ActiveRecord_Associations_CollectionProxy, ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
 
   sig { returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
   def self.all; end

--- a/spec/test_data/v5.2/expected_school.rbi
+++ b/spec/test_data/v5.2/expected_school.rbi
@@ -51,6 +51,7 @@ class School < ApplicationRecord
   extend School::CustomFinderMethods
   extend T::Sig
   extend T::Generic
+  RelationType = T.type_alias { T.any(School::ActiveRecord_Relation, School::ActiveRecord_Associations_CollectionProxy, School::ActiveRecord_AssociationRelation) }
 
   sig { returns(School::ActiveRecord_Relation) }
   def self.all; end

--- a/spec/test_data/v5.2/expected_spell_book.rbi
+++ b/spec/test_data/v5.2/expected_spell_book.rbi
@@ -112,6 +112,7 @@ class SpellBook < ApplicationRecord
   extend SpellBook::CustomFinderMethods
   extend T::Sig
   extend T::Generic
+  RelationType = T.type_alias { T.any(SpellBook::ActiveRecord_Relation, SpellBook::ActiveRecord_Associations_CollectionProxy, SpellBook::ActiveRecord_AssociationRelation) }
 
   sig { returns(T::Hash[T.any(String, Symbol), Integer]) }
   def self.book_types; end

--- a/spec/test_data/v5.2/expected_squib.rbi
+++ b/spec/test_data/v5.2/expected_squib.rbi
@@ -322,6 +322,7 @@ class Squib < Wizard
   extend Squib::CustomFinderMethods
   extend T::Sig
   extend T::Generic
+  RelationType = T.type_alias { T.any(Squib::ActiveRecord_Relation, Squib::ActiveRecord_Associations_CollectionProxy, Squib::ActiveRecord_AssociationRelation) }
 
   sig { returns(T::Hash[T.any(String, Symbol), String]) }
   def self.brooms; end

--- a/spec/test_data/v5.2/expected_wand.rbi
+++ b/spec/test_data/v5.2/expected_wand.rbi
@@ -218,6 +218,7 @@ class Wand < ApplicationRecord
   extend Wand::CustomFinderMethods
   extend T::Sig
   extend T::Generic
+  RelationType = T.type_alias { T.any(Wand::ActiveRecord_Relation, Wand::ActiveRecord_Associations_CollectionProxy, Wand::ActiveRecord_AssociationRelation) }
 
   sig { returns(T::Hash[T.any(String, Symbol), Integer]) }
   def self.core_types; end

--- a/spec/test_data/v5.2/expected_wizard.rbi
+++ b/spec/test_data/v5.2/expected_wizard.rbi
@@ -361,6 +361,7 @@ class Wizard < ApplicationRecord
   extend Wizard::CustomFinderMethods
   extend T::Sig
   extend T::Generic
+  RelationType = T.type_alias { T.any(Wizard::ActiveRecord_Relation, Wizard::ActiveRecord_Associations_CollectionProxy, Wizard::ActiveRecord_AssociationRelation) }
 
   sig { returns(T::Hash[T.any(String, Symbol), String]) }
   def self.brooms; end

--- a/spec/test_data/v5.2/expected_wizard_wo_spellbook.rbi
+++ b/spec/test_data/v5.2/expected_wizard_wo_spellbook.rbi
@@ -361,6 +361,7 @@ class Wizard < ApplicationRecord
   extend Wizard::CustomFinderMethods
   extend T::Sig
   extend T::Generic
+  RelationType = T.type_alias { T.any(Wizard::ActiveRecord_Relation, Wizard::ActiveRecord_Associations_CollectionProxy, Wizard::ActiveRecord_AssociationRelation) }
 
   sig { returns(T::Hash[T.any(String, Symbol), String]) }
   def self.brooms; end

--- a/spec/test_data/v6.0/expected_attachment.rbi
+++ b/spec/test_data/v6.0/expected_attachment.rbi
@@ -45,6 +45,7 @@ class ActiveStorage::Attachment < ActiveRecord::Base
   extend ActiveStorage::Attachment::CustomFinderMethods
   extend T::Sig
   extend T::Generic
+  RelationType = T.type_alias { T.any(ActiveStorage::Attachment::ActiveRecord_Relation, ActiveStorage::Attachment::ActiveRecord_Associations_CollectionProxy, ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
 
   sig { returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
   def self.all; end

--- a/spec/test_data/v6.0/expected_blob.rbi
+++ b/spec/test_data/v6.0/expected_blob.rbi
@@ -29,6 +29,7 @@ class ActiveStorage::Blob < ActiveRecord::Base
   extend ActiveStorage::Blob::CustomFinderMethods
   extend T::Sig
   extend T::Generic
+  RelationType = T.type_alias { T.any(ActiveStorage::Blob::ActiveRecord_Relation, ActiveStorage::Blob::ActiveRecord_Associations_CollectionProxy, ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
 
   sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
   def self.unattached(*args); end

--- a/spec/test_data/v6.0/expected_internal_metadata.rbi
+++ b/spec/test_data/v6.0/expected_internal_metadata.rbi
@@ -69,6 +69,7 @@ class ActiveRecord::InternalMetadata < ActiveRecord::Base
   extend ActiveRecord::InternalMetadata::CustomFinderMethods
   extend T::Sig
   extend T::Generic
+  RelationType = T.type_alias { T.any(ActiveRecord::InternalMetadata::ActiveRecord_Relation, ActiveRecord::InternalMetadata::ActiveRecord_Associations_CollectionProxy, ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
 
   sig { returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
   def self.all; end

--- a/spec/test_data/v6.0/expected_potion.rbi
+++ b/spec/test_data/v6.0/expected_potion.rbi
@@ -39,6 +39,7 @@ class Potion < ApplicationRecord
   extend Potion::CustomFinderMethods
   extend T::Sig
   extend T::Generic
+  RelationType = T.type_alias { T.any(Potion::ActiveRecord_Relation, Potion::ActiveRecord_Associations_CollectionProxy, Potion::ActiveRecord_AssociationRelation) }
 
   sig { returns(Potion::ActiveRecord_Relation) }
   def self.all; end

--- a/spec/test_data/v6.0/expected_robe.rbi
+++ b/spec/test_data/v6.0/expected_robe.rbi
@@ -62,6 +62,7 @@ class Robe < ApplicationRecord
   extend Robe::CustomFinderMethods
   extend T::Sig
   extend T::Generic
+  RelationType = T.type_alias { T.any(Robe::ActiveRecord_Relation, Robe::ActiveRecord_Associations_CollectionProxy, Robe::ActiveRecord_AssociationRelation) }
 
   sig { returns(Robe::ActiveRecord_Relation) }
   def self.all; end

--- a/spec/test_data/v6.0/expected_schema_migration.rbi
+++ b/spec/test_data/v6.0/expected_schema_migration.rbi
@@ -42,6 +42,7 @@ class ActiveRecord::SchemaMigration < ActiveRecord::Base
   extend ActiveRecord::SchemaMigration::CustomFinderMethods
   extend T::Sig
   extend T::Generic
+  RelationType = T.type_alias { T.any(ActiveRecord::SchemaMigration::ActiveRecord_Relation, ActiveRecord::SchemaMigration::ActiveRecord_Associations_CollectionProxy, ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
 
   sig { returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
   def self.all; end

--- a/spec/test_data/v6.0/expected_school.rbi
+++ b/spec/test_data/v6.0/expected_school.rbi
@@ -51,6 +51,7 @@ class School < ApplicationRecord
   extend School::CustomFinderMethods
   extend T::Sig
   extend T::Generic
+  RelationType = T.type_alias { T.any(School::ActiveRecord_Relation, School::ActiveRecord_Associations_CollectionProxy, School::ActiveRecord_AssociationRelation) }
 
   sig { returns(School::ActiveRecord_Relation) }
   def self.all; end

--- a/spec/test_data/v6.0/expected_spell_book.rbi
+++ b/spec/test_data/v6.0/expected_spell_book.rbi
@@ -112,6 +112,7 @@ class SpellBook < ApplicationRecord
   extend SpellBook::CustomFinderMethods
   extend T::Sig
   extend T::Generic
+  RelationType = T.type_alias { T.any(SpellBook::ActiveRecord_Relation, SpellBook::ActiveRecord_Associations_CollectionProxy, SpellBook::ActiveRecord_AssociationRelation) }
 
   sig { returns(T::Hash[T.any(String, Symbol), Integer]) }
   def self.book_types; end

--- a/spec/test_data/v6.0/expected_squib.rbi
+++ b/spec/test_data/v6.0/expected_squib.rbi
@@ -276,6 +276,7 @@ class Squib < Wizard
   extend Squib::CustomFinderMethods
   extend T::Sig
   extend T::Generic
+  RelationType = T.type_alias { T.any(Squib::ActiveRecord_Relation, Squib::ActiveRecord_Associations_CollectionProxy, Squib::ActiveRecord_AssociationRelation) }
 
   sig { returns(T::Hash[T.any(String, Symbol), String]) }
   def self.brooms; end

--- a/spec/test_data/v6.0/expected_wand.rbi
+++ b/spec/test_data/v6.0/expected_wand.rbi
@@ -218,6 +218,7 @@ class Wand < ApplicationRecord
   extend Wand::CustomFinderMethods
   extend T::Sig
   extend T::Generic
+  RelationType = T.type_alias { T.any(Wand::ActiveRecord_Relation, Wand::ActiveRecord_Associations_CollectionProxy, Wand::ActiveRecord_AssociationRelation) }
 
   sig { returns(T::Hash[T.any(String, Symbol), Integer]) }
   def self.core_types; end

--- a/spec/test_data/v6.0/expected_wizard.rbi
+++ b/spec/test_data/v6.0/expected_wizard.rbi
@@ -315,6 +315,7 @@ class Wizard < ApplicationRecord
   extend Wizard::CustomFinderMethods
   extend T::Sig
   extend T::Generic
+  RelationType = T.type_alias { T.any(Wizard::ActiveRecord_Relation, Wizard::ActiveRecord_Associations_CollectionProxy, Wizard::ActiveRecord_AssociationRelation) }
 
   sig { returns(T::Hash[T.any(String, Symbol), String]) }
   def self.brooms; end

--- a/spec/test_data/v6.0/expected_wizard_wo_spellbook.rbi
+++ b/spec/test_data/v6.0/expected_wizard_wo_spellbook.rbi
@@ -315,6 +315,7 @@ class Wizard < ApplicationRecord
   extend Wizard::CustomFinderMethods
   extend T::Sig
   extend T::Generic
+  RelationType = T.type_alias { T.any(Wizard::ActiveRecord_Relation, Wizard::ActiveRecord_Associations_CollectionProxy, Wizard::ActiveRecord_AssociationRelation) }
 
   sig { returns(T::Hash[T.any(String, Symbol), String]) }
   def self.brooms; end


### PR DESCRIPTION
Many times we just want to check that something receives a collection of
models. Internally Rails uses 3 different classes to represent
an enumerable interface to ActiveRecord.

This commit adds the generation of the following alias:

```rb
class User
  ActiveRecord_Enumerable = T.type_alias do
    T.any(
      User::ActiveRecord_Relation,
      User::ActiveRecord_AssociationRelation,
      User::ActiveRecord_Associations_CollectionProxy
    )
  end
end