### PR TITLE
Make `TypeAssertImpl` visible even if concrete type cannot be loaded

### DIFF
--- a/lib/sorbet-rails/type_assert/type_assert.rb
+++ b/lib/sorbet-rails/type_assert/type_assert.rb
@@ -3,6 +3,11 @@ require 'sorbet-runtime'
 require 'sorbet-rails/type_assert/type_assert_interface'
 require 'sorbet-rails/type_assert/type_assert_impl'
 
+# Make this type visible even when the concrete
+# implementation cannot be loaded.
+module TypeAssertImpl
+end
+
 class TA
   extend T::Sig
   extend T::Generic


### PR DESCRIPTION
Placing the whole declaration of `TypeAssertImpl` in a `typed: ignore` file hides the definition from tools like `tapioca`, since they also use `sorbet` internally to discover symbols.

Since Ruby can reopen classes/modules, there is no harm in adding an empty declaration of the module at the top level even if the concrete type was not loaded.