### PR TITLE
Use percent-string instead of single quotes

### DIFF
--- a/lib/sorbet-rails/model_plugins/active_record_attribute.rb
+++ b/lib/sorbet-rails/model_plugins/active_record_attribute.rb
@@ -96,7 +96,7 @@ class SorbetRails::ModelPlugins::ActiveRecordAttribute < SorbetRails::ModelPlugi
         t_enum_values = @model_class.gen_typed_enum_values(enum_values.keys)
         root.create_enum_class(
           t_enum_type,
-          enums: t_enum_values.map { |k, v| [v, "'#{k}'"] },
+          enums: t_enum_values.map { |k, v| [v, "%q{#{k}}"] },
         )
 
         # define t_enum setter/getter

--- a/spec/generators/rails-template.rb
+++ b/spec/generators/rails-template.rb
@@ -149,6 +149,7 @@ def create_models
         "Pomona Sprout": 2,
         "Filius Flitwick": 3,
         "Hagrid": 4,
+        "Alastor 'Mad-Eye' Moody": 5,
       }
 
       typed_enum broom: {

--- a/spec/support/v5.0/app/models/wizard.rb
+++ b/spec/support/v5.0/app/models/wizard.rb
@@ -18,6 +18,7 @@ class Wizard < ApplicationRecord
     "Pomona Sprout": 2,
     "Filius Flitwick": 3,
     "Hagrid": 4,
+    "Alastor 'Mad-Eye' Moody": 5,
   }
 
   typed_enum broom: {
@@ -53,5 +54,5 @@ class Wizard < ApplicationRecord
   belongs_to :school, optional: true
 
   scope :recent, -> { where('created_at > ?', 1.month.ago) }
-  
+
 end

--- a/spec/support/v5.1/app/models/wizard.rb
+++ b/spec/support/v5.1/app/models/wizard.rb
@@ -18,6 +18,7 @@ class Wizard < ApplicationRecord
     "Pomona Sprout": 2,
     "Filius Flitwick": 3,
     "Hagrid": 4,
+    "Alastor 'Mad-Eye' Moody": 5,
   }
 
   typed_enum broom: {
@@ -53,5 +54,5 @@ class Wizard < ApplicationRecord
   belongs_to :school, optional: true
 
   scope :recent, -> { where('created_at > ?', 1.month.ago) }
-  
+
 end

--- a/spec/support/v5.2/app/models/wizard.rb
+++ b/spec/support/v5.2/app/models/wizard.rb
@@ -18,6 +18,7 @@ class Wizard < ApplicationRecord
     "Pomona Sprout": 2,
     "Filius Flitwick": 3,
     "Hagrid": 4,
+    "Alastor 'Mad-Eye' Moody": 5,
   }
 
   typed_enum broom: {

--- a/spec/support/v6.0/app/models/wizard.rb
+++ b/spec/support/v6.0/app/models/wizard.rb
@@ -18,6 +18,7 @@ class Wizard < ApplicationRecord
     "Pomona Sprout": 2,
     "Filius Flitwick": 3,
     "Hagrid": 4,
+    "Alastor 'Mad-Eye' Moody": 5,
   }
 
   typed_enum broom: {

--- a/spec/test_data/v5.0/expected_spell_book.rbi
+++ b/spec/test_data/v5.0/expected_spell_book.rbi
@@ -71,9 +71,9 @@ end
 
 class SpellBook::BookType < T::Enum
   enums do
-    Unclassified = new('unclassified')
-    Biology = new('biology')
-    DarkArt = new('dark_art')
+    Unclassified = new(%q{unclassified})
+    Biology = new(%q{biology})
+    DarkArt = new(%q{dark_art})
   end
 
 end

--- a/spec/test_data/v5.0/expected_wand.rbi
+++ b/spec/test_data/v5.0/expected_wand.rbi
@@ -158,10 +158,10 @@ end
 
 class Wand::CoreType < T::Enum
   enums do
-    PhoenixFeather = new('phoenix_feather')
-    DragonHeartstring = new('dragon_heartstring')
-    UnicornTailHair = new('unicorn_tail_hair')
-    BasiliskHorn = new('basilisk_horn')
+    PhoenixFeather = new(%q{phoenix_feather})
+    DragonHeartstring = new(%q{dragon_heartstring})
+    UnicornTailHair = new(%q{unicorn_tail_hair})
+    BasiliskHorn = new(%q{basilisk_horn})
   end
 
 end

--- a/spec/test_data/v5.0/expected_wizard.rbi
+++ b/spec/test_data/v5.0/expected_wizard.rbi
@@ -236,57 +236,58 @@ end
 
 class Wizard::Broom < T::Enum
   enums do
-    Nimbus = new('nimbus')
-    Firebolt = new('firebolt')
+    Nimbus = new(%q{nimbus})
+    Firebolt = new(%q{firebolt})
   end
 
 end
 
 class Wizard::EyeColor < T::Enum
   enums do
-    Brown = new('brown')
-    Green = new('green')
-    Blue = new('blue')
+    Brown = new(%q{brown})
+    Green = new(%q{green})
+    Blue = new(%q{blue})
   end
 
 end
 
 class Wizard::HairColor < T::Enum
   enums do
-    Brown = new('brown')
-    Black = new('black')
-    Blonde = new('blonde')
+    Brown = new(%q{brown})
+    Black = new(%q{black})
+    Blonde = new(%q{blonde})
   end
 
 end
 
 class Wizard::House < T::Enum
   enums do
-    Gryffindor = new('Gryffindor')
-    Hufflepuff = new('Hufflepuff')
-    Ravenclaw = new('Ravenclaw')
-    Slytherin = new('Slytherin')
+    Gryffindor = new(%q{Gryffindor})
+    Hufflepuff = new(%q{Hufflepuff})
+    Ravenclaw = new(%q{Ravenclaw})
+    Slytherin = new(%q{Slytherin})
   end
 
 end
 
 class Wizard::ProfessorEnum < T::Enum
   enums do
-    SeverusSnape = new('Severus Snape')
-    MinervaMcGonagall = new('Minerva McGonagall')
-    PomonaSprout = new('Pomona Sprout')
-    FiliusFlitwick = new('Filius Flitwick')
-    Hagrid = new('Hagrid')
+    SeverusSnape = new(%q{Severus Snape})
+    MinervaMcGonagall = new(%q{Minerva McGonagall})
+    PomonaSprout = new(%q{Pomona Sprout})
+    FiliusFlitwick = new(%q{Filius Flitwick})
+    Hagrid = new(%q{Hagrid})
+    AlastorMadEyeMoody = new(%q{Alastor 'Mad-Eye' Moody})
   end
 
 end
 
 class Wizard::QuidditchPosition < T::Enum
   enums do
-    Keeper = new('keeper')
-    Seeker = new('seeker')
-    Beater = new('beater')
-    Chaser = new('chaser')
+    Keeper = new(%q{keeper})
+    Seeker = new(%q{seeker})
+    Beater = new(%q{beater})
+    Chaser = new(%q{chaser})
   end
 
 end

--- a/spec/test_data/v5.0/expected_wizard_wo_spellbook.rbi
+++ b/spec/test_data/v5.0/expected_wizard_wo_spellbook.rbi
@@ -236,57 +236,58 @@ end
 
 class Wizard::Broom < T::Enum
   enums do
-    Nimbus = new('nimbus')
-    Firebolt = new('firebolt')
+    Nimbus = new(%q{nimbus})
+    Firebolt = new(%q{firebolt})
   end
 
 end
 
 class Wizard::EyeColor < T::Enum
   enums do
-    Brown = new('brown')
-    Green = new('green')
-    Blue = new('blue')
+    Brown = new(%q{brown})
+    Green = new(%q{green})
+    Blue = new(%q{blue})
   end
 
 end
 
 class Wizard::HairColor < T::Enum
   enums do
-    Brown = new('brown')
-    Black = new('black')
-    Blonde = new('blonde')
+    Brown = new(%q{brown})
+    Black = new(%q{black})
+    Blonde = new(%q{blonde})
   end
 
 end
 
 class Wizard::House < T::Enum
   enums do
-    Gryffindor = new('Gryffindor')
-    Hufflepuff = new('Hufflepuff')
-    Ravenclaw = new('Ravenclaw')
-    Slytherin = new('Slytherin')
+    Gryffindor = new(%q{Gryffindor})
+    Hufflepuff = new(%q{Hufflepuff})
+    Ravenclaw = new(%q{Ravenclaw})
+    Slytherin = new(%q{Slytherin})
   end
 
 end
 
 class Wizard::ProfessorEnum < T::Enum
   enums do
-    SeverusSnape = new('Severus Snape')
-    MinervaMcGonagall = new('Minerva McGonagall')
-    PomonaSprout = new('Pomona Sprout')
-    FiliusFlitwick = new('Filius Flitwick')
-    Hagrid = new('Hagrid')
+    SeverusSnape = new(%q{Severus Snape})
+    MinervaMcGonagall = new(%q{Minerva McGonagall})
+    PomonaSprout = new(%q{Pomona Sprout})
+    FiliusFlitwick = new(%q{Filius Flitwick})
+    Hagrid = new(%q{Hagrid})
+    AlastorMadEyeMoody = new(%q{Alastor 'Mad-Eye' Moody})
   end
 
 end
 
 class Wizard::QuidditchPosition < T::Enum
   enums do
-    Keeper = new('keeper')
-    Seeker = new('seeker')
-    Beater = new('beater')
-    Chaser = new('chaser')
+    Keeper = new(%q{keeper})
+    Seeker = new(%q{seeker})
+    Beater = new(%q{beater})
+    Chaser = new(%q{chaser})
   end
 
 end

--- a/spec/test_data/v5.1/expected_spell_book.rbi
+++ b/spec/test_data/v5.1/expected_spell_book.rbi
@@ -71,9 +71,9 @@ end
 
 class SpellBook::BookType < T::Enum
   enums do
-    Unclassified = new('unclassified')
-    Biology = new('biology')
-    DarkArt = new('dark_art')
+    Unclassified = new(%q{unclassified})
+    Biology = new(%q{biology})
+    DarkArt = new(%q{dark_art})
   end
 
 end

--- a/spec/test_data/v5.1/expected_wand.rbi
+++ b/spec/test_data/v5.1/expected_wand.rbi
@@ -158,10 +158,10 @@ end
 
 class Wand::CoreType < T::Enum
   enums do
-    PhoenixFeather = new('phoenix_feather')
-    DragonHeartstring = new('dragon_heartstring')
-    UnicornTailHair = new('unicorn_tail_hair')
-    BasiliskHorn = new('basilisk_horn')
+    PhoenixFeather = new(%q{phoenix_feather})
+    DragonHeartstring = new(%q{dragon_heartstring})
+    UnicornTailHair = new(%q{unicorn_tail_hair})
+    BasiliskHorn = new(%q{basilisk_horn})
   end
 
 end

--- a/spec/test_data/v5.1/expected_wizard.rbi
+++ b/spec/test_data/v5.1/expected_wizard.rbi
@@ -236,57 +236,58 @@ end
 
 class Wizard::Broom < T::Enum
   enums do
-    Nimbus = new('nimbus')
-    Firebolt = new('firebolt')
+    Nimbus = new(%q{nimbus})
+    Firebolt = new(%q{firebolt})
   end
 
 end
 
 class Wizard::EyeColor < T::Enum
   enums do
-    Brown = new('brown')
-    Green = new('green')
-    Blue = new('blue')
+    Brown = new(%q{brown})
+    Green = new(%q{green})
+    Blue = new(%q{blue})
   end
 
 end
 
 class Wizard::HairColor < T::Enum
   enums do
-    Brown = new('brown')
-    Black = new('black')
-    Blonde = new('blonde')
+    Brown = new(%q{brown})
+    Black = new(%q{black})
+    Blonde = new(%q{blonde})
   end
 
 end
 
 class Wizard::House < T::Enum
   enums do
-    Gryffindor = new('Gryffindor')
-    Hufflepuff = new('Hufflepuff')
-    Ravenclaw = new('Ravenclaw')
-    Slytherin = new('Slytherin')
+    Gryffindor = new(%q{Gryffindor})
+    Hufflepuff = new(%q{Hufflepuff})
+    Ravenclaw = new(%q{Ravenclaw})
+    Slytherin = new(%q{Slytherin})
   end
 
 end
 
 class Wizard::ProfessorEnum < T::Enum
   enums do
-    SeverusSnape = new('Severus Snape')
-    MinervaMcGonagall = new('Minerva McGonagall')
-    PomonaSprout = new('Pomona Sprout')
-    FiliusFlitwick = new('Filius Flitwick')
-    Hagrid = new('Hagrid')
+    SeverusSnape = new(%q{Severus Snape})
+    MinervaMcGonagall = new(%q{Minerva McGonagall})
+    PomonaSprout = new(%q{Pomona Sprout})
+    FiliusFlitwick = new(%q{Filius Flitwick})
+    Hagrid = new(%q{Hagrid})
+    AlastorMadEyeMoody = new(%q{Alastor 'Mad-Eye' Moody})
   end
 
 end
 
 class Wizard::QuidditchPosition < T::Enum
   enums do
-    Keeper = new('keeper')
-    Seeker = new('seeker')
-    Beater = new('beater')
-    Chaser = new('chaser')
+    Keeper = new(%q{keeper})
+    Seeker = new(%q{seeker})
+    Beater = new(%q{beater})
+    Chaser = new(%q{chaser})
   end
 
 end

--- a/spec/test_data/v5.1/expected_wizard_wo_spellbook.rbi
+++ b/spec/test_data/v5.1/expected_wizard_wo_spellbook.rbi
@@ -236,57 +236,58 @@ end
 
 class Wizard::Broom < T::Enum
   enums do
-    Nimbus = new('nimbus')
-    Firebolt = new('firebolt')
+    Nimbus = new(%q{nimbus})
+    Firebolt = new(%q{firebolt})
   end
 
 end
 
 class Wizard::EyeColor < T::Enum
   enums do
-    Brown = new('brown')
-    Green = new('green')
-    Blue = new('blue')
+    Brown = new(%q{brown})
+    Green = new(%q{green})
+    Blue = new(%q{blue})
   end
 
 end
 
 class Wizard::HairColor < T::Enum
   enums do
-    Brown = new('brown')
-    Black = new('black')
-    Blonde = new('blonde')
+    Brown = new(%q{brown})
+    Black = new(%q{black})
+    Blonde = new(%q{blonde})
   end
 
 end
 
 class Wizard::House < T::Enum
   enums do
-    Gryffindor = new('Gryffindor')
-    Hufflepuff = new('Hufflepuff')
-    Ravenclaw = new('Ravenclaw')
-    Slytherin = new('Slytherin')
+    Gryffindor = new(%q{Gryffindor})
+    Hufflepuff = new(%q{Hufflepuff})
+    Ravenclaw = new(%q{Ravenclaw})
+    Slytherin = new(%q{Slytherin})
   end
 
 end
 
 class Wizard::ProfessorEnum < T::Enum
   enums do
-    SeverusSnape = new('Severus Snape')
-    MinervaMcGonagall = new('Minerva McGonagall')
-    PomonaSprout = new('Pomona Sprout')
-    FiliusFlitwick = new('Filius Flitwick')
-    Hagrid = new('Hagrid')
+    SeverusSnape = new(%q{Severus Snape})
+    MinervaMcGonagall = new(%q{Minerva McGonagall})
+    PomonaSprout = new(%q{Pomona Sprout})
+    FiliusFlitwick = new(%q{Filius Flitwick})
+    Hagrid = new(%q{Hagrid})
+    AlastorMadEyeMoody = new(%q{Alastor 'Mad-Eye' Moody})
   end
 
 end
 
 class Wizard::QuidditchPosition < T::Enum
   enums do
-    Keeper = new('keeper')
-    Seeker = new('seeker')
-    Beater = new('beater')
-    Chaser = new('chaser')
+    Keeper = new(%q{keeper})
+    Seeker = new(%q{seeker})
+    Beater = new(%q{beater})
+    Chaser = new(%q{chaser})
   end
 
 end

--- a/spec/test_data/v5.2/expected_spell_book.rbi
+++ b/spec/test_data/v5.2/expected_spell_book.rbi
@@ -71,9 +71,9 @@ end
 
 class SpellBook::BookType < T::Enum
   enums do
-    Unclassified = new('unclassified')
-    Biology = new('biology')
-    DarkArt = new('dark_art')
+    Unclassified = new(%q{unclassified})
+    Biology = new(%q{biology})
+    DarkArt = new(%q{dark_art})
   end
 
 end

--- a/spec/test_data/v5.2/expected_wand.rbi
+++ b/spec/test_data/v5.2/expected_wand.rbi
@@ -176,10 +176,10 @@ end
 
 class Wand::CoreType < T::Enum
   enums do
-    PhoenixFeather = new('phoenix_feather')
-    DragonHeartstring = new('dragon_heartstring')
-    UnicornTailHair = new('unicorn_tail_hair')
-    BasiliskHorn = new('basilisk_horn')
+    PhoenixFeather = new(%q{phoenix_feather})
+    DragonHeartstring = new(%q{dragon_heartstring})
+    UnicornTailHair = new(%q{unicorn_tail_hair})
+    BasiliskHorn = new(%q{basilisk_horn})
   end
 
 end

--- a/spec/test_data/v5.2/expected_wizard.rbi
+++ b/spec/test_data/v5.2/expected_wizard.rbi
@@ -236,57 +236,58 @@ end
 
 class Wizard::Broom < T::Enum
   enums do
-    Nimbus = new('nimbus')
-    Firebolt = new('firebolt')
+    Nimbus = new(%q{nimbus})
+    Firebolt = new(%q{firebolt})
   end
 
 end
 
 class Wizard::EyeColor < T::Enum
   enums do
-    Brown = new('brown')
-    Green = new('green')
-    Blue = new('blue')
+    Brown = new(%q{brown})
+    Green = new(%q{green})
+    Blue = new(%q{blue})
   end
 
 end
 
 class Wizard::HairColor < T::Enum
   enums do
-    Brown = new('brown')
-    Black = new('black')
-    Blonde = new('blonde')
+    Brown = new(%q{brown})
+    Black = new(%q{black})
+    Blonde = new(%q{blonde})
   end
 
 end
 
 class Wizard::House < T::Enum
   enums do
-    Gryffindor = new('Gryffindor')
-    Hufflepuff = new('Hufflepuff')
-    Ravenclaw = new('Ravenclaw')
-    Slytherin = new('Slytherin')
+    Gryffindor = new(%q{Gryffindor})
+    Hufflepuff = new(%q{Hufflepuff})
+    Ravenclaw = new(%q{Ravenclaw})
+    Slytherin = new(%q{Slytherin})
   end
 
 end
 
 class Wizard::ProfessorEnum < T::Enum
   enums do
-    SeverusSnape = new('Severus Snape')
-    MinervaMcGonagall = new('Minerva McGonagall')
-    PomonaSprout = new('Pomona Sprout')
-    FiliusFlitwick = new('Filius Flitwick')
-    Hagrid = new('Hagrid')
+    SeverusSnape = new(%q{Severus Snape})
+    MinervaMcGonagall = new(%q{Minerva McGonagall})
+    PomonaSprout = new(%q{Pomona Sprout})
+    FiliusFlitwick = new(%q{Filius Flitwick})
+    Hagrid = new(%q{Hagrid})
+    AlastorMadEyeMoody = new(%q{Alastor 'Mad-Eye' Moody})
   end
 
 end
 
 class Wizard::QuidditchPosition < T::Enum
   enums do
-    Keeper = new('keeper')
-    Seeker = new('seeker')
-    Beater = new('beater')
-    Chaser = new('chaser')
+    Keeper = new(%q{keeper})
+    Seeker = new(%q{seeker})
+    Beater = new(%q{beater})
+    Chaser = new(%q{chaser})
   end
 
 end

--- a/spec/test_data/v5.2/expected_wizard_wo_spellbook.rbi
+++ b/spec/test_data/v5.2/expected_wizard_wo_spellbook.rbi
@@ -236,57 +236,58 @@ end
 
 class Wizard::Broom < T::Enum
   enums do
-    Nimbus = new('nimbus')
-    Firebolt = new('firebolt')
+    Nimbus = new(%q{nimbus})
+    Firebolt = new(%q{firebolt})
   end
 
 end
 
 class Wizard::EyeColor < T::Enum
   enums do
-    Brown = new('brown')
-    Green = new('green')
-    Blue = new('blue')
+    Brown = new(%q{brown})
+    Green = new(%q{green})
+    Blue = new(%q{blue})
   end
 
 end
 
 class Wizard::HairColor < T::Enum
   enums do
-    Brown = new('brown')
-    Black = new('black')
-    Blonde = new('blonde')
+    Brown = new(%q{brown})
+    Black = new(%q{black})
+    Blonde = new(%q{blonde})
   end
 
 end
 
 class Wizard::House < T::Enum
   enums do
-    Gryffindor = new('Gryffindor')
-    Hufflepuff = new('Hufflepuff')
-    Ravenclaw = new('Ravenclaw')
-    Slytherin = new('Slytherin')
+    Gryffindor = new(%q{Gryffindor})
+    Hufflepuff = new(%q{Hufflepuff})
+    Ravenclaw = new(%q{Ravenclaw})
+    Slytherin = new(%q{Slytherin})
   end
 
 end
 
 class Wizard::ProfessorEnum < T::Enum
   enums do
-    SeverusSnape = new('Severus Snape')
-    MinervaMcGonagall = new('Minerva McGonagall')
-    PomonaSprout = new('Pomona Sprout')
-    FiliusFlitwick = new('Filius Flitwick')
-    Hagrid = new('Hagrid')
+    SeverusSnape = new(%q{Severus Snape})
+    MinervaMcGonagall = new(%q{Minerva McGonagall})
+    PomonaSprout = new(%q{Pomona Sprout})
+    FiliusFlitwick = new(%q{Filius Flitwick})
+    Hagrid = new(%q{Hagrid})
+    AlastorMadEyeMoody = new(%q{Alastor 'Mad-Eye' Moody})
   end
 
 end
 
 class Wizard::QuidditchPosition < T::Enum
   enums do
-    Keeper = new('keeper')
-    Seeker = new('seeker')
-    Beater = new('beater')
-    Chaser = new('chaser')
+    Keeper = new(%q{keeper})
+    Seeker = new(%q{seeker})
+    Beater = new(%q{beater})
+    Chaser = new(%q{chaser})
   end
 
 end

--- a/spec/test_data/v6.0/expected_spell_book.rbi
+++ b/spec/test_data/v6.0/expected_spell_book.rbi
@@ -71,9 +71,9 @@ end
 
 class SpellBook::BookType < T::Enum
   enums do
-    Unclassified = new('unclassified')
-    Biology = new('biology')
-    DarkArt = new('dark_art')
+    Unclassified = new(%q{unclassified})
+    Biology = new(%q{biology})
+    DarkArt = new(%q{dark_art})
   end
 
 end

--- a/spec/test_data/v6.0/expected_wand.rbi
+++ b/spec/test_data/v6.0/expected_wand.rbi
@@ -176,10 +176,10 @@ end
 
 class Wand::CoreType < T::Enum
   enums do
-    PhoenixFeather = new('phoenix_feather')
-    DragonHeartstring = new('dragon_heartstring')
-    UnicornTailHair = new('unicorn_tail_hair')
-    BasiliskHorn = new('basilisk_horn')
+    PhoenixFeather = new(%q{phoenix_feather})
+    DragonHeartstring = new(%q{dragon_heartstring})
+    UnicornTailHair = new(%q{unicorn_tail_hair})
+    BasiliskHorn = new(%q{basilisk_horn})
   end
 
 end

--- a/spec/test_data/v6.0/expected_wizard.rbi
+++ b/spec/test_data/v6.0/expected_wizard.rbi
@@ -236,57 +236,58 @@ end
 
 class Wizard::Broom < T::Enum
   enums do
-    Nimbus = new('nimbus')
-    Firebolt = new('firebolt')
+    Nimbus = new(%q{nimbus})
+    Firebolt = new(%q{firebolt})
   end
 
 end
 
 class Wizard::EyeColor < T::Enum
   enums do
-    Brown = new('brown')
-    Green = new('green')
-    Blue = new('blue')
+    Brown = new(%q{brown})
+    Green = new(%q{green})
+    Blue = new(%q{blue})
   end
 
 end
 
 class Wizard::HairColor < T::Enum
   enums do
-    Brown = new('brown')
-    Black = new('black')
-    Blonde = new('blonde')
+    Brown = new(%q{brown})
+    Black = new(%q{black})
+    Blonde = new(%q{blonde})
   end
 
 end
 
 class Wizard::House < T::Enum
   enums do
-    Gryffindor = new('Gryffindor')
-    Hufflepuff = new('Hufflepuff')
-    Ravenclaw = new('Ravenclaw')
-    Slytherin = new('Slytherin')
+    Gryffindor = new(%q{Gryffindor})
+    Hufflepuff = new(%q{Hufflepuff})
+    Ravenclaw = new(%q{Ravenclaw})
+    Slytherin = new(%q{Slytherin})
   end
 
 end
 
 class Wizard::ProfessorEnum < T::Enum
   enums do
-    SeverusSnape = new('Severus Snape')
-    MinervaMcGonagall = new('Minerva McGonagall')
-    PomonaSprout = new('Pomona Sprout')
-    FiliusFlitwick = new('Filius Flitwick')
-    Hagrid = new('Hagrid')
+    SeverusSnape = new(%q{Severus Snape})
+    MinervaMcGonagall = new(%q{Minerva McGonagall})
+    PomonaSprout = new(%q{Pomona Sprout})
+    FiliusFlitwick = new(%q{Filius Flitwick})
+    Hagrid = new(%q{Hagrid})
+    AlastorMadEyeMoody = new(%q{Alastor 'Mad-Eye' Moody})
   end
 
 end
 
 class Wizard::QuidditchPosition < T::Enum
   enums do
-    Keeper = new('keeper')
-    Seeker = new('seeker')
-    Beater = new('beater')
-    Chaser = new('chaser')
+    Keeper = new(%q{keeper})
+    Seeker = new(%q{seeker})
+    Beater = new(%q{beater})
+    Chaser = new(%q{chaser})
   end
 
 end

--- a/spec/test_data/v6.0/expected_wizard_wo_spellbook.rbi
+++ b/spec/test_data/v6.0/expected_wizard_wo_spellbook.rbi
@@ -236,57 +236,58 @@ end
 
 class Wizard::Broom < T::Enum
   enums do
-    Nimbus = new('nimbus')
-    Firebolt = new('firebolt')
+    Nimbus = new(%q{nimbus})
+    Firebolt = new(%q{firebolt})
   end
 
 end
 
 class Wizard::EyeColor < T::Enum
   enums do
-    Brown = new('brown')
-    Green = new('green')
-    Blue = new('blue')
+    Brown = new(%q{brown})
+    Green = new(%q{green})
+    Blue = new(%q{blue})
   end
 
 end
 
 class Wizard::HairColor < T::Enum
   enums do
-    Brown = new('brown')
-    Black = new('black')
-    Blonde = new('blonde')
+    Brown = new(%q{brown})
+    Black = new(%q{black})
+    Blonde = new(%q{blonde})
   end
 
 end
 
 class Wizard::House < T::Enum
   enums do
-    Gryffindor = new('Gryffindor')
-    Hufflepuff = new('Hufflepuff')
-    Ravenclaw = new('Ravenclaw')
-    Slytherin = new('Slytherin')
+    Gryffindor = new(%q{Gryffindor})
+    Hufflepuff = new(%q{Hufflepuff})
+    Ravenclaw = new(%q{Ravenclaw})
+    Slytherin = new(%q{Slytherin})
   end
 
 end
 
 class Wizard::ProfessorEnum < T::Enum
   enums do
-    SeverusSnape = new('Severus Snape')
-    MinervaMcGonagall = new('Minerva McGonagall')
-    PomonaSprout = new('Pomona Sprout')
-    FiliusFlitwick = new('Filius Flitwick')
-    Hagrid = new('Hagrid')
+    SeverusSnape = new(%q{Severus Snape})
+    MinervaMcGonagall = new(%q{Minerva McGonagall})
+    PomonaSprout = new(%q{Pomona Sprout})
+    FiliusFlitwick = new(%q{Filius Flitwick})
+    Hagrid = new(%q{Hagrid})
+    AlastorMadEyeMoody = new(%q{Alastor 'Mad-Eye' Moody})
   end
 
 end
 
 class Wizard::QuidditchPosition < T::Enum
   enums do
-    Keeper = new('keeper')
-    Seeker = new('seeker')
-    Beater = new('beater')
-    Chaser = new('chaser')
+    Keeper = new(%q{keeper})
+    Seeker = new(%q{seeker})
+    Beater = new(%q{beater})
+    Chaser = new(%q{chaser})
   end
 
 end


### PR DESCRIPTION
For `T::Enum` enums generated from rails enums, use `%q{}` instead of
`''` so that enums with single-quotes won't break sorbet-rails

Also added a test case which before generated a bunch of errors and now works