### PR TITLE
Add more sorbet test cases

### DIFF
--- a/lib/sorbet-rails/active_record_rbi_formatter.rb
+++ b/lib/sorbet-rails/active_record_rbi_formatter.rb
@@ -129,14 +129,21 @@ class SorbetRails::ActiveRecordRbiFormatter
 
     build_methods = %w(create create! new)
     build_methods.each do |build_method|
+      # This needs to match the generated method signature in activerecord.rbi and
+      # in Rails 5.0 and 5.1 the param is a splat.
+      if Rails.version =~ /^5\.(0|1)/ && %w(new build create create!).include?(build_method)
+        param = Parameter.new("*args", type: "T.untyped")
+      elsif
+        param = Parameter.new("attributes", type: "T.untyped", default: 'nil')
+      end
+
       class_rbi.create_method(
         build_method,
         parameters: [
-          Parameter.new("attributes", type: "T.untyped", default: 'nil'),
+          param,
           Parameter.new(
             "&block",
-            type: "T.untyped",
-            # type: "T.nilable(T.proc.params(object: #{type}).void)",
+            type: "T.nilable(T.proc.params(object: #{type}).void)",
           ),
         ],
         return_type: type,

--- a/lib/sorbet-rails/active_record_rbi_formatter.rb
+++ b/lib/sorbet-rails/active_record_rbi_formatter.rb
@@ -18,7 +18,7 @@ class SorbetRails::ActiveRecordRbiFormatter
     ])
 
     parlour.root.create_class('ActiveRecord::Base') do |class_rbi|
-      create_finder_methods(class_rbi, type: 'T.attached_class', class_method: true)
+      create_elem_specific_query_methods(class_rbi, type: 'T.attached_class', class_method: true)
     end
 
     parlour.rbi
@@ -41,7 +41,7 @@ class SorbetRails::ActiveRecordRbiFormatter
         value: "type_member(fixed: T.untyped)",
       )
 
-      create_finder_methods(class_rbi, type: 'Elem', class_method: false)
+      create_elem_specific_query_methods(class_rbi, type: 'Elem', class_method: false)
 
       class_rbi.create_method(
         "each",
@@ -91,7 +91,7 @@ class SorbetRails::ActiveRecordRbiFormatter
       class_method: T::Boolean,
     ).void
   }
-  def create_finder_methods(class_rbi, type:, class_method:)
+  def create_elem_specific_query_methods(class_rbi, type:, class_method:)
     finder_methods = %w(find find_by find_by!)
     finder_methods.each do |finder_method|
       class_rbi.create_method(
@@ -129,9 +129,6 @@ class SorbetRails::ActiveRecordRbiFormatter
 
     build_methods = %w(create create! new)
     build_methods.each do |build_method|
-      # This should be defined on both but trying to keep the diff small in this commit
-      next unless class_method
-
       class_rbi.create_method(
         build_method,
         parameters: [
@@ -147,8 +144,7 @@ class SorbetRails::ActiveRecordRbiFormatter
       )
     end
 
-    # batch_methods = %w(find_each find_in_batches)
-    batch_methods = %w(find_each)
+    batch_methods = %w(find_each find_in_batches)
     batch_methods.each do |batch_method|
       inner_type = batch_method == 'find_each' ? type : "T::Array[#{type}]"
 
@@ -161,7 +157,7 @@ class SorbetRails::ActiveRecordRbiFormatter
           Parameter.new("error_on_ignore:", type: "T.nilable(T::Boolean)", default: "nil"),
           Parameter.new("&block", type: "T.nilable(T.proc.params(e: #{inner_type}).void)"),
         ],
-        return_type: "T::Array[#{inner_type}]",
+        return_type: "T::Enumerator[#{inner_type}]",
         class_method: class_method,
         override: true,
       )

--- a/spec/generators/sorbet_test_cases.rb
+++ b/spec/generators/sorbet_test_cases.rb
@@ -62,6 +62,26 @@ T.assert_type!(Wizard.find_by(name: 'Harry Potter'), T.nilable(Wizard))
 T.assert_type!(Wizard.find_by!(name: 'Harry Potter'), Wizard)
 T.assert_type!(Wizard.find_by_id(wizard.id), T.nilable(Wizard))
 T.assert_type!(Wizard.find_by_id!(wizard.id), Wizard)
+T.assert_type!(Wizard.find_or_initialize_by(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard)
+T.assert_type!(Wizard.find_or_create_by(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard)
+T.assert_type!(Wizard.find_or_create_by!(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard)
+T.assert_type!(Wizard.new { |w| T.assert_type!(w, Wizard) }, Wizard)
+T.assert_type!(Wizard.create(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard)
+T.assert_type!(Wizard.create!(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard)
+# T.assert_type!(Wizard.first_or_create(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard) # Ignored until we add support
+# T.assert_type!(Wizard.first_or_create!(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard) # Ignored until we add support
+# T.assert_type!(Wizard.first_or_initialize { |w| T.assert_type!(w, Wizard) }, Wizard) # Ignored until we add support
+Wizard.find_each { |w| T.assert_type!(w, Wizard) }
+T.assert_type!(Wizard.find_each, T::Enumerator[Wizard])
+Wizard.find_in_batches { |w| T.assert_type!(w, T::Array[Wizard]) }
+T.assert_type!(Wizard.find_in_batches, T::Enumerator[T::Array[Wizard]])
+# T.assert_type!(Wizard.destroy_all, T::Array[Wizard]) # Ignored until we add support
+T.assert_type!(Wizard.any?, T::Boolean)
+T.assert_type!(Wizard.many?, T::Boolean)
+T.assert_type!(Wizard.none?, T::Boolean)
+T.assert_type!(Wizard.one?, T::Boolean)
+# T.assert_type!(Wizard.update_all(name: 'Harry Potter'), Integer) # Ignored until we add support
+# T.assert_type!(Wizard.delete_all, Integer) # Ignored until we add support
 
 # Finder methods -- ActiveRecord::Relation
 T.assert_type!(Wizard.all.exists?(name: 'Harry Potter'), T::Boolean)
@@ -76,6 +96,32 @@ T.assert_type!(Wizard.all.find_by(name: 'Harry Potter'), T.nilable(Wizard))
 T.assert_type!(Wizard.all.find_by!(name: 'Harry Potter'), Wizard)
 T.assert_type!(Wizard.all.find_by_id(wizard.id), T.nilable(Wizard))
 T.assert_type!(Wizard.all.find_by_id!(wizard.id), Wizard)
+T.assert_type!(Wizard.all.find_or_initialize_by(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard)
+T.assert_type!(Wizard.all.find_or_create_by(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard)
+T.assert_type!(Wizard.all.find_or_create_by!(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard)
+T.assert_type!(Wizard.all.new { |w| T.assert_type!(w, Wizard) }, Wizard)
+# T.assert_type!(Wizard.all.build { |w| T.assert_type!(w, Wizard) }, Wizard) # Ignored until we add support
+T.assert_type!(Wizard.all.create(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard)
+T.assert_type!(Wizard.all.create!(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard)
+# T.assert_type!(Wizard.all.first_or_create(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard) # Ignored until we add support
+# T.assert_type!(Wizard.all.first_or_create!(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard) # Ignored until we add support
+# T.assert_type!(Wizard.all.first_or_initialize { |w| T.assert_type!(w, Wizard) }, Wizard) # Ignored until we add support
+Wizard.all.find_each { |w| T.assert_type!(w, Wizard) }
+T.assert_type!(Wizard.all.find_each, T::Enumerator[Wizard])
+Wizard.all.find_in_batches { |w| T.assert_type!(w, T::Array[Wizard]) }
+T.assert_type!(Wizard.all.find_in_batches, T::Enumerator[T::Array[Wizard]])
+# T.assert_type!(Wizard.all.destroy_all, T::Array[Wizard]) # Ignored until we add support
+T.assert_type!(Wizard.all.any?, T::Boolean)
+T.assert_type!(Wizard.all.many?, T::Boolean)
+T.assert_type!(Wizard.all.none?, T::Boolean)
+T.assert_type!(Wizard.all.one?, T::Boolean)
+# T.assert_type!(Wizard.all.update_all(name: 'Harry Potter'), Integer) # Ignored until we add support
+# T.assert_type!(Wizard.all.delete_all, Integer) # Ignored until we add support
+# Enumerable methods
+Wizard.all.each { |w| T.assert_type!(w, Wizard) }
+Wizard.all.map { |w| T.assert_type!(w, Wizard) }
+T.assert_type!(Wizard.all.to_a, T::Array[Wizard])
+T.assert_type!(Wizard.all.empty?, T::Boolean)
 
 # Finder methods -- CollectionProxy
 spell_book = wizard.spell_books.first!
@@ -92,6 +138,27 @@ T.assert_type!(spell_books.find_by(name: 'Fantastic Beasts'), T.nilable(SpellBoo
 T.assert_type!(spell_books.find_by!(name: 'Fantastic Beasts'), SpellBook)
 T.assert_type!(spell_books.find_by_id(spell_book.id), T.nilable(SpellBook))
 T.assert_type!(spell_books.find_by_id!(spell_book.id), SpellBook)
+T.assert_type!(spell_books.find_or_initialize_by(name: 'Fantastic Beasts') { |s| T.assert_type!(s, SpellBook) }, SpellBook)
+T.assert_type!(spell_books.find_or_create_by(name: 'Fantastic Beasts') { |s| T.assert_type!(s, SpellBook) }, SpellBook)
+T.assert_type!(spell_books.find_or_create_by!(name: 'Fantastic Beasts') { |s| T.assert_type!(s, SpellBook) }, SpellBook)
+# T.assert_type!(spell_books.new { |s| T.assert_type!(s, SpellBook) }, SpellBook) # Ignored until we add support
+# T.assert_type!(spell_books.build { |s| T.assert_type!(s, SpellBook) }, SpellBook) # Ignored until we add support # Ignored until we add support
+# T.assert_type!(spell_books.create(name: 'Fantastic Beasts') { |s| T.assert_type!(s, SpellBook) }, SpellBook) # Ignored until we add support
+# T.assert_type!(spell_books.create!(name: 'Fantastic Beasts') { |s| T.assert_type!(s, SpellBook) }, SpellBook) # Ignored until we add support
+# T.assert_type!(spell_books.first_or_create(name: 'Fantastic Beasts') { |s| T.assert_type!(s, SpellBook) }, SpellBook) # Ignored until we add support
+# T.assert_type!(spell_books.first_or_create!(name: 'Fantastic Beasts') { |s| T.assert_type!(s, SpellBook) }, SpellBook) # Ignored until we add support
+# T.assert_type!(spell_books.first_or_initialize { |s| T.assert_type!(s, SpellBook) }, SpellBook) # Ignored until we add support
+# spell_books.find_each { |s| T.assert_type!(s, SpellBook) } # TODO: Handle for Rails 6
+# T.assert_type!(spell_books.find_each, T::Enumerator[SpellBook]) # TODO: Handle for Rails 6
+# spell_books.find_in_batches { |s| T.assert_type!(s, T::Array[SpellBook]) } # TODO: Handle for Rails 6
+# T.assert_type!(spell_books.find_in_batches, T::Enumerator[T::Array[SpellBook]]) # TODO: Handle for Rails 6
+# T.assert_type!(spell_books.destroy_all, T::Array[SpellBook]) # Ignored until we add support
+T.assert_type!(spell_books.any?, T::Boolean)
+T.assert_type!(spell_books.many?, T::Boolean)
+T.assert_type!(spell_books.none?, T::Boolean)
+T.assert_type!(spell_books.one?, T::Boolean)
+# T.assert_type!(spell_books.update_all(name: 'Fantastic Beasts'), Integer) # Ignored until we add support
+# T.assert_type!(spell_books.delete_all, Integer) # Ignored until we add support
 # CollectionProxy query also typed correctly!
 T.assert_type!(spell_books.where(id: 1), SpellBook::ActiveRecord_AssociationRelation)
 T.assert_type!(spell_books.preload(:wizard), SpellBook::ActiveRecord_AssociationRelation)
@@ -99,6 +166,11 @@ T.assert_type!(spell_books.eager_load(:wizard), SpellBook::ActiveRecord_Associat
 T.assert_type!(spell_books.order(:id), SpellBook::ActiveRecord_AssociationRelation)
 T.assert_type!(spell_books.where.not(id: 1), SpellBook::ActiveRecord_AssociationRelation)
 T.assert_type!(spell_books.biology, SpellBook::ActiveRecord_AssociationRelation)
+# Enumerable methods
+spell_books.each { |s| T.assert_type!(s, SpellBook) }
+spell_books.map { |s| T.assert_type!(s, SpellBook) }
+T.assert_type!(spell_books.to_a, T::Array[SpellBook])
+T.assert_type!(spell_books.empty?, T::Boolean)
 
 # finder methods -- AssociationRelation
 spell_books_query = spell_books.where(id: 1)
@@ -114,48 +186,38 @@ T.assert_type!(spell_books_query.find_by(name: 'Fantastic Beasts'), T.nilable(Sp
 T.assert_type!(spell_books_query.find_by!(name: 'Fantastic Beasts'), SpellBook)
 T.assert_type!(spell_books_query.find_by_id(spell_book.id), T.nilable(SpellBook))
 T.assert_type!(spell_books_query.find_by_id!(spell_book.id), SpellBook)
+T.assert_type!(spell_books_query.find_or_initialize_by(name: 'Fantastic Beasts') { |s| T.assert_type!(s, SpellBook) }, SpellBook)
+T.assert_type!(spell_books_query.find_or_create_by(name: 'Fantastic Beasts') { |s| T.assert_type!(s, SpellBook) }, SpellBook)
+T.assert_type!(spell_books_query.find_or_create_by!(name: 'Fantastic Beasts') { |s| T.assert_type!(s, SpellBook) }, SpellBook)
+# T.assert_type!(spell_books_query.new { |s| T.assert_type!(s, SpellBook) }, SpellBook) # Ignored until we add support
+# T.assert_type!(spell_books_query.build { |s| T.assert_type!(s, SpellBook) }, SpellBook) # Ignored until we add support # Ignored until we add support
+# T.assert_type!(spell_books_query.create(name: 'Fantastic Beasts') { |s| T.assert_type!(s, SpellBook) }, SpellBook) # Ignored until we add support
+# T.assert_type!(spell_books_query.create!(name: 'Fantastic Beasts') { |s| T.assert_type!(s, SpellBook) }, SpellBook) # Ignored until we add support
+# T.assert_type!(spell_books_query.first_or_create(name: 'Fantastic Beasts') { |s| T.assert_type!(s, SpellBook) }, SpellBook) # Ignored until we add support
+# T.assert_type!(spell_books_query.first_or_create!(name: 'Fantastic Beasts') { |s| T.assert_type!(s, SpellBook) }, SpellBook) # Ignored until we add support
+# T.assert_type!(spell_books_query.first_or_initialize { |s| T.assert_type!(s, SpellBook) }, SpellBook) # Ignored until we add support
+# spell_books_query.find_each { |s| T.assert_type!(s, SpellBook) } # TODO: Handle for Rails 6
+# T.assert_type!(spell_books_query.find_each, T::Enumerator[SpellBook]) # TODO: Handle for Rails 6
+# spell_books_query.find_in_batches { |s| T.assert_type!(s, T::Array[SpellBook]) } # TODO: Handle for Rails 6
+# T.assert_type!(spell_books_query.find_in_batches, T::Enumerator[T::Array[SpellBook]]) # TODO: Handle for Rails 6
+# T.assert_type!(spell_books_query.destroy_all, T::Array[SpellBook]) # Ignored until we add support
+T.assert_type!(spell_books_query.any?, T::Boolean)
+T.assert_type!(spell_books_query.many?, T::Boolean)
+T.assert_type!(spell_books_query.none?, T::Boolean)
+T.assert_type!(spell_books_query.one?, T::Boolean)
+# T.assert_type!(spell_books_query.update_all(name: 'Fantastic Beasts'), Integer) # Ignored until we add support
+# T.assert_type!(spell_books_query.delete_all, Integer) # Ignored until we add support
 # Query chaining
 T.assert_type!(spell_books_query.preload(:wizard), SpellBook::ActiveRecord_AssociationRelation)
 T.assert_type!(spell_books_query.eager_load(:wizard), SpellBook::ActiveRecord_AssociationRelation)
 T.assert_type!(spell_books_query.order(:id), SpellBook::ActiveRecord_AssociationRelation)
 T.assert_type!(spell_books_query.where.not(id: 1), SpellBook::ActiveRecord_AssociationRelation)
 T.assert_type!(spell_books_query.biology, SpellBook::ActiveRecord_AssociationRelation)
-
-# Enumerable on activerecord relation
-T.assert_type!(Wizard.all.to_a, T::Array[Wizard])
-Wizard.all.each do |w|
-  T.assert_type!(w, Wizard)
-end
-Wizard.all.map do |w|
-  T.assert_type!(w, Wizard)
-end
-Wizard.all.to_a.map do |w|
-  T.assert_type!(w, Wizard)
-end
-
-# enum on association collection proxy
-T.assert_type!(wizard.spell_books.to_a, T::Array[SpellBook])
-wizard.spell_books.each do |sp|
-  T.assert_type!(sp, SpellBook)
-end
-wizard.spell_books.map do |sp|
-  T.assert_type!(sp, SpellBook)
-end
-wizard.spell_books.to_a.map do |sp|
-  T.assert_type!(sp, SpellBook)
-end
-
-# enum on association relation
-T.assert_type!(wizard.spell_books.where(id: 1).to_a, T::Array[SpellBook])
-wizard.spell_books.where(id: 1).each do |sp|
-  T.assert_type!(sp, SpellBook)
-end
-wizard.spell_books.where(id: 1).map do |sp|
-  T.assert_type!(sp, SpellBook)
-end
-wizard.spell_books.where(id: 1).to_a.map do |sp|
-  T.assert_type!(sp, SpellBook)
-end
+# Enumerable methods
+spell_books_query.each { |s| T.assert_type!(s, SpellBook) }
+spell_books_query.map { |s| T.assert_type!(s, SpellBook) }
+T.assert_type!(spell_books_query.to_a, T::Array[SpellBook])
+T.assert_type!(spell_books_query.empty?, T::Boolean)
 
 # Model columns
 T.assert_type!(wizard.id, Integer)

--- a/spec/support/v5.0/sorbet_test_cases.rb
+++ b/spec/support/v5.0/sorbet_test_cases.rb
@@ -62,6 +62,26 @@ T.assert_type!(Wizard.find_by(name: 'Harry Potter'), T.nilable(Wizard))
 T.assert_type!(Wizard.find_by!(name: 'Harry Potter'), Wizard)
 T.assert_type!(Wizard.find_by_id(wizard.id), T.nilable(Wizard))
 T.assert_type!(Wizard.find_by_id!(wizard.id), Wizard)
+T.assert_type!(Wizard.find_or_initialize_by(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard)
+T.assert_type!(Wizard.find_or_create_by(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard)
+T.assert_type!(Wizard.find_or_create_by!(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard)
+T.assert_type!(Wizard.new { |w| T.assert_type!(w, Wizard) }, Wizard)
+T.assert_type!(Wizard.create(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard)
+T.assert_type!(Wizard.create!(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard)
+# T.assert_type!(Wizard.first_or_create(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard) # Ignored until we add support
+# T.assert_type!(Wizard.first_or_create!(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard) # Ignored until we add support
+# T.assert_type!(Wizard.first_or_initialize { |w| T.assert_type!(w, Wizard) }, Wizard) # Ignored until we add support
+Wizard.find_each { |w| T.assert_type!(w, Wizard) }
+T.assert_type!(Wizard.find_each, T::Enumerator[Wizard])
+Wizard.find_in_batches { |w| T.assert_type!(w, T::Array[Wizard]) }
+T.assert_type!(Wizard.find_in_batches, T::Enumerator[T::Array[Wizard]])
+# T.assert_type!(Wizard.destroy_all, T::Array[Wizard]) # Ignored until we add support
+T.assert_type!(Wizard.any?, T::Boolean)
+T.assert_type!(Wizard.many?, T::Boolean)
+T.assert_type!(Wizard.none?, T::Boolean)
+T.assert_type!(Wizard.one?, T::Boolean)
+# T.assert_type!(Wizard.update_all(name: 'Harry Potter'), Integer) # Ignored until we add support
+# T.assert_type!(Wizard.delete_all, Integer) # Ignored until we add support
 
 # Finder methods -- ActiveRecord::Relation
 T.assert_type!(Wizard.all.exists?(name: 'Harry Potter'), T::Boolean)
@@ -76,6 +96,32 @@ T.assert_type!(Wizard.all.find_by(name: 'Harry Potter'), T.nilable(Wizard))
 T.assert_type!(Wizard.all.find_by!(name: 'Harry Potter'), Wizard)
 T.assert_type!(Wizard.all.find_by_id(wizard.id), T.nilable(Wizard))
 T.assert_type!(Wizard.all.find_by_id!(wizard.id), Wizard)
+T.assert_type!(Wizard.all.find_or_initialize_by(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard)
+T.assert_type!(Wizard.all.find_or_create_by(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard)
+T.assert_type!(Wizard.all.find_or_create_by!(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard)
+T.assert_type!(Wizard.all.new { |w| T.assert_type!(w, Wizard) }, Wizard)
+# T.assert_type!(Wizard.all.build { |w| T.assert_type!(w, Wizard) }, Wizard) # Ignored until we add support
+T.assert_type!(Wizard.all.create(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard)
+T.assert_type!(Wizard.all.create!(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard)
+# T.assert_type!(Wizard.all.first_or_create(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard) # Ignored until we add support
+# T.assert_type!(Wizard.all.first_or_create!(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard) # Ignored until we add support
+# T.assert_type!(Wizard.all.first_or_initialize { |w| T.assert_type!(w, Wizard) }, Wizard) # Ignored until we add support
+Wizard.all.find_each { |w| T.assert_type!(w, Wizard) }
+T.assert_type!(Wizard.all.find_each, T::Enumerator[Wizard])
+Wizard.all.find_in_batches { |w| T.assert_type!(w, T::Array[Wizard]) }
+T.assert_type!(Wizard.all.find_in_batches, T::Enumerator[T::Array[Wizard]])
+# T.assert_type!(Wizard.all.destroy_all, T::Array[Wizard]) # Ignored until we add support
+T.assert_type!(Wizard.all.any?, T::Boolean)
+T.assert_type!(Wizard.all.many?, T::Boolean)
+T.assert_type!(Wizard.all.none?, T::Boolean)
+T.assert_type!(Wizard.all.one?, T::Boolean)
+# T.assert_type!(Wizard.all.update_all(name: 'Harry Potter'), Integer) # Ignored until we add support
+# T.assert_type!(Wizard.all.delete_all, Integer) # Ignored until we add support
+# Enumerable methods
+Wizard.all.each { |w| T.assert_type!(w, Wizard) }
+Wizard.all.map { |w| T.assert_type!(w, Wizard) }
+T.assert_type!(Wizard.all.to_a, T::Array[Wizard])
+T.assert_type!(Wizard.all.empty?, T::Boolean)
 
 # Finder methods -- CollectionProxy
 spell_book = wizard.spell_books.first!
@@ -92,6 +138,27 @@ T.assert_type!(spell_books.find_by(name: 'Fantastic Beasts'), T.nilable(SpellBoo
 T.assert_type!(spell_books.find_by!(name: 'Fantastic Beasts'), SpellBook)
 T.assert_type!(spell_books.find_by_id(spell_book.id), T.nilable(SpellBook))
 T.assert_type!(spell_books.find_by_id!(spell_book.id), SpellBook)
+T.assert_type!(spell_books.find_or_initialize_by(name: 'Fantastic Beasts') { |s| T.assert_type!(s, SpellBook) }, SpellBook)
+T.assert_type!(spell_books.find_or_create_by(name: 'Fantastic Beasts') { |s| T.assert_type!(s, SpellBook) }, SpellBook)
+T.assert_type!(spell_books.find_or_create_by!(name: 'Fantastic Beasts') { |s| T.assert_type!(s, SpellBook) }, SpellBook)
+# T.assert_type!(spell_books.new { |s| T.assert_type!(s, SpellBook) }, SpellBook) # Ignored until we add support
+# T.assert_type!(spell_books.build { |s| T.assert_type!(s, SpellBook) }, SpellBook) # Ignored until we add support # Ignored until we add support
+# T.assert_type!(spell_books.create(name: 'Fantastic Beasts') { |s| T.assert_type!(s, SpellBook) }, SpellBook) # Ignored until we add support
+# T.assert_type!(spell_books.create!(name: 'Fantastic Beasts') { |s| T.assert_type!(s, SpellBook) }, SpellBook) # Ignored until we add support
+# T.assert_type!(spell_books.first_or_create(name: 'Fantastic Beasts') { |s| T.assert_type!(s, SpellBook) }, SpellBook) # Ignored until we add support
+# T.assert_type!(spell_books.first_or_create!(name: 'Fantastic Beasts') { |s| T.assert_type!(s, SpellBook) }, SpellBook) # Ignored until we add support
+# T.assert_type!(spell_books.first_or_initialize { |s| T.assert_type!(s, SpellBook) }, SpellBook) # Ignored until we add support
+# spell_books.find_each { |s| T.assert_type!(s, SpellBook) } # TODO: Handle for Rails 6
+# T.assert_type!(spell_books.find_each, T::Enumerator[SpellBook]) # TODO: Handle for Rails 6
+# spell_books.find_in_batches { |s| T.assert_type!(s, T::Array[SpellBook]) } # TODO: Handle for Rails 6
+# T.assert_type!(spell_books.find_in_batches, T::Enumerator[T::Array[SpellBook]]) # TODO: Handle for Rails 6
+# T.assert_type!(spell_books.destroy_all, T::Array[SpellBook]) # Ignored until we add support
+T.assert_type!(spell_books.any?, T::Boolean)
+T.assert_type!(spell_books.many?, T::Boolean)
+T.assert_type!(spell_books.none?, T::Boolean)
+T.assert_type!(spell_books.one?, T::Boolean)
+# T.assert_type!(spell_books.update_all(name: 'Fantastic Beasts'), Integer) # Ignored until we add support
+# T.assert_type!(spell_books.delete_all, Integer) # Ignored until we add support
 # CollectionProxy query also typed correctly!
 T.assert_type!(spell_books.where(id: 1), SpellBook::ActiveRecord_AssociationRelation)
 T.assert_type!(spell_books.preload(:wizard), SpellBook::ActiveRecord_AssociationRelation)
@@ -99,6 +166,11 @@ T.assert_type!(spell_books.eager_load(:wizard), SpellBook::ActiveRecord_Associat
 T.assert_type!(spell_books.order(:id), SpellBook::ActiveRecord_AssociationRelation)
 T.assert_type!(spell_books.where.not(id: 1), SpellBook::ActiveRecord_AssociationRelation)
 T.assert_type!(spell_books.biology, SpellBook::ActiveRecord_AssociationRelation)
+# Enumerable methods
+spell_books.each { |s| T.assert_type!(s, SpellBook) }
+spell_books.map { |s| T.assert_type!(s, SpellBook) }
+T.assert_type!(spell_books.to_a, T::Array[SpellBook])
+T.assert_type!(spell_books.empty?, T::Boolean)
 
 # finder methods -- AssociationRelation
 spell_books_query = spell_books.where(id: 1)
@@ -114,48 +186,38 @@ T.assert_type!(spell_books_query.find_by(name: 'Fantastic Beasts'), T.nilable(Sp
 T.assert_type!(spell_books_query.find_by!(name: 'Fantastic Beasts'), SpellBook)
 T.assert_type!(spell_books_query.find_by_id(spell_book.id), T.nilable(SpellBook))
 T.assert_type!(spell_books_query.find_by_id!(spell_book.id), SpellBook)
+T.assert_type!(spell_books_query.find_or_initialize_by(name: 'Fantastic Beasts') { |s| T.assert_type!(s, SpellBook) }, SpellBook)
+T.assert_type!(spell_books_query.find_or_create_by(name: 'Fantastic Beasts') { |s| T.assert_type!(s, SpellBook) }, SpellBook)
+T.assert_type!(spell_books_query.find_or_create_by!(name: 'Fantastic Beasts') { |s| T.assert_type!(s, SpellBook) }, SpellBook)
+# T.assert_type!(spell_books_query.new { |s| T.assert_type!(s, SpellBook) }, SpellBook) # Ignored until we add support
+# T.assert_type!(spell_books_query.build { |s| T.assert_type!(s, SpellBook) }, SpellBook) # Ignored until we add support # Ignored until we add support
+# T.assert_type!(spell_books_query.create(name: 'Fantastic Beasts') { |s| T.assert_type!(s, SpellBook) }, SpellBook) # Ignored until we add support
+# T.assert_type!(spell_books_query.create!(name: 'Fantastic Beasts') { |s| T.assert_type!(s, SpellBook) }, SpellBook) # Ignored until we add support
+# T.assert_type!(spell_books_query.first_or_create(name: 'Fantastic Beasts') { |s| T.assert_type!(s, SpellBook) }, SpellBook) # Ignored until we add support
+# T.assert_type!(spell_books_query.first_or_create!(name: 'Fantastic Beasts') { |s| T.assert_type!(s, SpellBook) }, SpellBook) # Ignored until we add support
+# T.assert_type!(spell_books_query.first_or_initialize { |s| T.assert_type!(s, SpellBook) }, SpellBook) # Ignored until we add support
+# spell_books_query.find_each { |s| T.assert_type!(s, SpellBook) } # TODO: Handle for Rails 6
+# T.assert_type!(spell_books_query.find_each, T::Enumerator[SpellBook]) # TODO: Handle for Rails 6
+# spell_books_query.find_in_batches { |s| T.assert_type!(s, T::Array[SpellBook]) } # TODO: Handle for Rails 6
+# T.assert_type!(spell_books_query.find_in_batches, T::Enumerator[T::Array[SpellBook]]) # TODO: Handle for Rails 6
+# T.assert_type!(spell_books_query.destroy_all, T::Array[SpellBook]) # Ignored until we add support
+T.assert_type!(spell_books_query.any?, T::Boolean)
+T.assert_type!(spell_books_query.many?, T::Boolean)
+T.assert_type!(spell_books_query.none?, T::Boolean)
+T.assert_type!(spell_books_query.one?, T::Boolean)
+# T.assert_type!(spell_books_query.update_all(name: 'Fantastic Beasts'), Integer) # Ignored until we add support
+# T.assert_type!(spell_books_query.delete_all, Integer) # Ignored until we add support
 # Query chaining
 T.assert_type!(spell_books_query.preload(:wizard), SpellBook::ActiveRecord_AssociationRelation)
 T.assert_type!(spell_books_query.eager_load(:wizard), SpellBook::ActiveRecord_AssociationRelation)
 T.assert_type!(spell_books_query.order(:id), SpellBook::ActiveRecord_AssociationRelation)
 T.assert_type!(spell_books_query.where.not(id: 1), SpellBook::ActiveRecord_AssociationRelation)
 T.assert_type!(spell_books_query.biology, SpellBook::ActiveRecord_AssociationRelation)
-
-# Enumerable on activerecord relation
-T.assert_type!(Wizard.all.to_a, T::Array[Wizard])
-Wizard.all.each do |w|
-  T.assert_type!(w, Wizard)
-end
-Wizard.all.map do |w|
-  T.assert_type!(w, Wizard)
-end
-Wizard.all.to_a.map do |w|
-  T.assert_type!(w, Wizard)
-end
-
-# enum on association collection proxy
-T.assert_type!(wizard.spell_books.to_a, T::Array[SpellBook])
-wizard.spell_books.each do |sp|
-  T.assert_type!(sp, SpellBook)
-end
-wizard.spell_books.map do |sp|
-  T.assert_type!(sp, SpellBook)
-end
-wizard.spell_books.to_a.map do |sp|
-  T.assert_type!(sp, SpellBook)
-end
-
-# enum on association relation
-T.assert_type!(wizard.spell_books.where(id: 1).to_a, T::Array[SpellBook])
-wizard.spell_books.where(id: 1).each do |sp|
-  T.assert_type!(sp, SpellBook)
-end
-wizard.spell_books.where(id: 1).map do |sp|
-  T.assert_type!(sp, SpellBook)
-end
-wizard.spell_books.where(id: 1).to_a.map do |sp|
-  T.assert_type!(sp, SpellBook)
-end
+# Enumerable methods
+spell_books_query.each { |s| T.assert_type!(s, SpellBook) }
+spell_books_query.map { |s| T.assert_type!(s, SpellBook) }
+T.assert_type!(spell_books_query.to_a, T::Array[SpellBook])
+T.assert_type!(spell_books_query.empty?, T::Boolean)
 
 # Model columns
 T.assert_type!(wizard.id, Integer)

--- a/spec/support/v5.1/sorbet_test_cases.rb
+++ b/spec/support/v5.1/sorbet_test_cases.rb
@@ -62,6 +62,26 @@ T.assert_type!(Wizard.find_by(name: 'Harry Potter'), T.nilable(Wizard))
 T.assert_type!(Wizard.find_by!(name: 'Harry Potter'), Wizard)
 T.assert_type!(Wizard.find_by_id(wizard.id), T.nilable(Wizard))
 T.assert_type!(Wizard.find_by_id!(wizard.id), Wizard)
+T.assert_type!(Wizard.find_or_initialize_by(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard)
+T.assert_type!(Wizard.find_or_create_by(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard)
+T.assert_type!(Wizard.find_or_create_by!(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard)
+T.assert_type!(Wizard.new { |w| T.assert_type!(w, Wizard) }, Wizard)
+T.assert_type!(Wizard.create(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard)
+T.assert_type!(Wizard.create!(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard)
+# T.assert_type!(Wizard.first_or_create(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard) # Ignored until we add support
+# T.assert_type!(Wizard.first_or_create!(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard) # Ignored until we add support
+# T.assert_type!(Wizard.first_or_initialize { |w| T.assert_type!(w, Wizard) }, Wizard) # Ignored until we add support
+Wizard.find_each { |w| T.assert_type!(w, Wizard) }
+T.assert_type!(Wizard.find_each, T::Enumerator[Wizard])
+Wizard.find_in_batches { |w| T.assert_type!(w, T::Array[Wizard]) }
+T.assert_type!(Wizard.find_in_batches, T::Enumerator[T::Array[Wizard]])
+# T.assert_type!(Wizard.destroy_all, T::Array[Wizard]) # Ignored until we add support
+T.assert_type!(Wizard.any?, T::Boolean)
+T.assert_type!(Wizard.many?, T::Boolean)
+T.assert_type!(Wizard.none?, T::Boolean)
+T.assert_type!(Wizard.one?, T::Boolean)
+# T.assert_type!(Wizard.update_all(name: 'Harry Potter'), Integer) # Ignored until we add support
+# T.assert_type!(Wizard.delete_all, Integer) # Ignored until we add support
 
 # Finder methods -- ActiveRecord::Relation
 T.assert_type!(Wizard.all.exists?(name: 'Harry Potter'), T::Boolean)
@@ -76,6 +96,32 @@ T.assert_type!(Wizard.all.find_by(name: 'Harry Potter'), T.nilable(Wizard))
 T.assert_type!(Wizard.all.find_by!(name: 'Harry Potter'), Wizard)
 T.assert_type!(Wizard.all.find_by_id(wizard.id), T.nilable(Wizard))
 T.assert_type!(Wizard.all.find_by_id!(wizard.id), Wizard)
+T.assert_type!(Wizard.all.find_or_initialize_by(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard)
+T.assert_type!(Wizard.all.find_or_create_by(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard)
+T.assert_type!(Wizard.all.find_or_create_by!(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard)
+T.assert_type!(Wizard.all.new { |w| T.assert_type!(w, Wizard) }, Wizard)
+# T.assert_type!(Wizard.all.build { |w| T.assert_type!(w, Wizard) }, Wizard) # Ignored until we add support
+T.assert_type!(Wizard.all.create(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard)
+T.assert_type!(Wizard.all.create!(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard)
+# T.assert_type!(Wizard.all.first_or_create(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard) # Ignored until we add support
+# T.assert_type!(Wizard.all.first_or_create!(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard) # Ignored until we add support
+# T.assert_type!(Wizard.all.first_or_initialize { |w| T.assert_type!(w, Wizard) }, Wizard) # Ignored until we add support
+Wizard.all.find_each { |w| T.assert_type!(w, Wizard) }
+T.assert_type!(Wizard.all.find_each, T::Enumerator[Wizard])
+Wizard.all.find_in_batches { |w| T.assert_type!(w, T::Array[Wizard]) }
+T.assert_type!(Wizard.all.find_in_batches, T::Enumerator[T::Array[Wizard]])
+# T.assert_type!(Wizard.all.destroy_all, T::Array[Wizard]) # Ignored until we add support
+T.assert_type!(Wizard.all.any?, T::Boolean)
+T.assert_type!(Wizard.all.many?, T::Boolean)
+T.assert_type!(Wizard.all.none?, T::Boolean)
+T.assert_type!(Wizard.all.one?, T::Boolean)
+# T.assert_type!(Wizard.all.update_all(name: 'Harry Potter'), Integer) # Ignored until we add support
+# T.assert_type!(Wizard.all.delete_all, Integer) # Ignored until we add support
+# Enumerable methods
+Wizard.all.each { |w| T.assert_type!(w, Wizard) }
+Wizard.all.map { |w| T.assert_type!(w, Wizard) }
+T.assert_type!(Wizard.all.to_a, T::Array[Wizard])
+T.assert_type!(Wizard.all.empty?, T::Boolean)
 
 # Finder methods -- CollectionProxy
 spell_book = wizard.spell_books.first!
@@ -92,6 +138,27 @@ T.assert_type!(spell_books.find_by(name: 'Fantastic Beasts'), T.nilable(SpellBoo
 T.assert_type!(spell_books.find_by!(name: 'Fantastic Beasts'), SpellBook)
 T.assert_type!(spell_books.find_by_id(spell_book.id), T.nilable(SpellBook))
 T.assert_type!(spell_books.find_by_id!(spell_book.id), SpellBook)
+T.assert_type!(spell_books.find_or_initialize_by(name: 'Fantastic Beasts') { |s| T.assert_type!(s, SpellBook) }, SpellBook)
+T.assert_type!(spell_books.find_or_create_by(name: 'Fantastic Beasts') { |s| T.assert_type!(s, SpellBook) }, SpellBook)
+T.assert_type!(spell_books.find_or_create_by!(name: 'Fantastic Beasts') { |s| T.assert_type!(s, SpellBook) }, SpellBook)
+# T.assert_type!(spell_books.new { |s| T.assert_type!(s, SpellBook) }, SpellBook) # Ignored until we add support
+# T.assert_type!(spell_books.build { |s| T.assert_type!(s, SpellBook) }, SpellBook) # Ignored until we add support # Ignored until we add support
+# T.assert_type!(spell_books.create(name: 'Fantastic Beasts') { |s| T.assert_type!(s, SpellBook) }, SpellBook) # Ignored until we add support
+# T.assert_type!(spell_books.create!(name: 'Fantastic Beasts') { |s| T.assert_type!(s, SpellBook) }, SpellBook) # Ignored until we add support
+# T.assert_type!(spell_books.first_or_create(name: 'Fantastic Beasts') { |s| T.assert_type!(s, SpellBook) }, SpellBook) # Ignored until we add support
+# T.assert_type!(spell_books.first_or_create!(name: 'Fantastic Beasts') { |s| T.assert_type!(s, SpellBook) }, SpellBook) # Ignored until we add support
+# T.assert_type!(spell_books.first_or_initialize { |s| T.assert_type!(s, SpellBook) }, SpellBook) # Ignored until we add support
+# spell_books.find_each { |s| T.assert_type!(s, SpellBook) } # TODO: Handle for Rails 6
+# T.assert_type!(spell_books.find_each, T::Enumerator[SpellBook]) # TODO: Handle for Rails 6
+# spell_books.find_in_batches { |s| T.assert_type!(s, T::Array[SpellBook]) } # TODO: Handle for Rails 6
+# T.assert_type!(spell_books.find_in_batches, T::Enumerator[T::Array[SpellBook]]) # TODO: Handle for Rails 6
+# T.assert_type!(spell_books.destroy_all, T::Array[SpellBook]) # Ignored until we add support
+T.assert_type!(spell_books.any?, T::Boolean)
+T.assert_type!(spell_books.many?, T::Boolean)
+T.assert_type!(spell_books.none?, T::Boolean)
+T.assert_type!(spell_books.one?, T::Boolean)
+# T.assert_type!(spell_books.update_all(name: 'Fantastic Beasts'), Integer) # Ignored until we add support
+# T.assert_type!(spell_books.delete_all, Integer) # Ignored until we add support
 # CollectionProxy query also typed correctly!
 T.assert_type!(spell_books.where(id: 1), SpellBook::ActiveRecord_AssociationRelation)
 T.assert_type!(spell_books.preload(:wizard), SpellBook::ActiveRecord_AssociationRelation)
@@ -99,6 +166,11 @@ T.assert_type!(spell_books.eager_load(:wizard), SpellBook::ActiveRecord_Associat
 T.assert_type!(spell_books.order(:id), SpellBook::ActiveRecord_AssociationRelation)
 T.assert_type!(spell_books.where.not(id: 1), SpellBook::ActiveRecord_AssociationRelation)
 T.assert_type!(spell_books.biology, SpellBook::ActiveRecord_AssociationRelation)
+# Enumerable methods
+spell_books.each { |s| T.assert_type!(s, SpellBook) }
+spell_books.map { |s| T.assert_type!(s, SpellBook) }
+T.assert_type!(spell_books.to_a, T::Array[SpellBook])
+T.assert_type!(spell_books.empty?, T::Boolean)
 
 # finder methods -- AssociationRelation
 spell_books_query = spell_books.where(id: 1)
@@ -114,48 +186,38 @@ T.assert_type!(spell_books_query.find_by(name: 'Fantastic Beasts'), T.nilable(Sp
 T.assert_type!(spell_books_query.find_by!(name: 'Fantastic Beasts'), SpellBook)
 T.assert_type!(spell_books_query.find_by_id(spell_book.id), T.nilable(SpellBook))
 T.assert_type!(spell_books_query.find_by_id!(spell_book.id), SpellBook)
+T.assert_type!(spell_books_query.find_or_initialize_by(name: 'Fantastic Beasts') { |s| T.assert_type!(s, SpellBook) }, SpellBook)
+T.assert_type!(spell_books_query.find_or_create_by(name: 'Fantastic Beasts') { |s| T.assert_type!(s, SpellBook) }, SpellBook)
+T.assert_type!(spell_books_query.find_or_create_by!(name: 'Fantastic Beasts') { |s| T.assert_type!(s, SpellBook) }, SpellBook)
+# T.assert_type!(spell_books_query.new { |s| T.assert_type!(s, SpellBook) }, SpellBook) # Ignored until we add support
+# T.assert_type!(spell_books_query.build { |s| T.assert_type!(s, SpellBook) }, SpellBook) # Ignored until we add support # Ignored until we add support
+# T.assert_type!(spell_books_query.create(name: 'Fantastic Beasts') { |s| T.assert_type!(s, SpellBook) }, SpellBook) # Ignored until we add support
+# T.assert_type!(spell_books_query.create!(name: 'Fantastic Beasts') { |s| T.assert_type!(s, SpellBook) }, SpellBook) # Ignored until we add support
+# T.assert_type!(spell_books_query.first_or_create(name: 'Fantastic Beasts') { |s| T.assert_type!(s, SpellBook) }, SpellBook) # Ignored until we add support
+# T.assert_type!(spell_books_query.first_or_create!(name: 'Fantastic Beasts') { |s| T.assert_type!(s, SpellBook) }, SpellBook) # Ignored until we add support
+# T.assert_type!(spell_books_query.first_or_initialize { |s| T.assert_type!(s, SpellBook) }, SpellBook) # Ignored until we add support
+# spell_books_query.find_each { |s| T.assert_type!(s, SpellBook) } # TODO: Handle for Rails 6
+# T.assert_type!(spell_books_query.find_each, T::Enumerator[SpellBook]) # TODO: Handle for Rails 6
+# spell_books_query.find_in_batches { |s| T.assert_type!(s, T::Array[SpellBook]) } # TODO: Handle for Rails 6
+# T.assert_type!(spell_books_query.find_in_batches, T::Enumerator[T::Array[SpellBook]]) # TODO: Handle for Rails 6
+# T.assert_type!(spell_books_query.destroy_all, T::Array[SpellBook]) # Ignored until we add support
+T.assert_type!(spell_books_query.any?, T::Boolean)
+T.assert_type!(spell_books_query.many?, T::Boolean)
+T.assert_type!(spell_books_query.none?, T::Boolean)
+T.assert_type!(spell_books_query.one?, T::Boolean)
+# T.assert_type!(spell_books_query.update_all(name: 'Fantastic Beasts'), Integer) # Ignored until we add support
+# T.assert_type!(spell_books_query.delete_all, Integer) # Ignored until we add support
 # Query chaining
 T.assert_type!(spell_books_query.preload(:wizard), SpellBook::ActiveRecord_AssociationRelation)
 T.assert_type!(spell_books_query.eager_load(:wizard), SpellBook::ActiveRecord_AssociationRelation)
 T.assert_type!(spell_books_query.order(:id), SpellBook::ActiveRecord_AssociationRelation)
 T.assert_type!(spell_books_query.where.not(id: 1), SpellBook::ActiveRecord_AssociationRelation)
 T.assert_type!(spell_books_query.biology, SpellBook::ActiveRecord_AssociationRelation)
-
-# Enumerable on activerecord relation
-T.assert_type!(Wizard.all.to_a, T::Array[Wizard])
-Wizard.all.each do |w|
-  T.assert_type!(w, Wizard)
-end
-Wizard.all.map do |w|
-  T.assert_type!(w, Wizard)
-end
-Wizard.all.to_a.map do |w|
-  T.assert_type!(w, Wizard)
-end
-
-# enum on association collection proxy
-T.assert_type!(wizard.spell_books.to_a, T::Array[SpellBook])
-wizard.spell_books.each do |sp|
-  T.assert_type!(sp, SpellBook)
-end
-wizard.spell_books.map do |sp|
-  T.assert_type!(sp, SpellBook)
-end
-wizard.spell_books.to_a.map do |sp|
-  T.assert_type!(sp, SpellBook)
-end
-
-# enum on association relation
-T.assert_type!(wizard.spell_books.where(id: 1).to_a, T::Array[SpellBook])
-wizard.spell_books.where(id: 1).each do |sp|
-  T.assert_type!(sp, SpellBook)
-end
-wizard.spell_books.where(id: 1).map do |sp|
-  T.assert_type!(sp, SpellBook)
-end
-wizard.spell_books.where(id: 1).to_a.map do |sp|
-  T.assert_type!(sp, SpellBook)
-end
+# Enumerable methods
+spell_books_query.each { |s| T.assert_type!(s, SpellBook) }
+spell_books_query.map { |s| T.assert_type!(s, SpellBook) }
+T.assert_type!(spell_books_query.to_a, T::Array[SpellBook])
+T.assert_type!(spell_books_query.empty?, T::Boolean)
 
 # Model columns
 T.assert_type!(wizard.id, Integer)

--- a/spec/support/v5.2/sorbet_test_cases.rb
+++ b/spec/support/v5.2/sorbet_test_cases.rb
@@ -62,6 +62,26 @@ T.assert_type!(Wizard.find_by(name: 'Harry Potter'), T.nilable(Wizard))
 T.assert_type!(Wizard.find_by!(name: 'Harry Potter'), Wizard)
 T.assert_type!(Wizard.find_by_id(wizard.id), T.nilable(Wizard))
 T.assert_type!(Wizard.find_by_id!(wizard.id), Wizard)
+T.assert_type!(Wizard.find_or_initialize_by(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard)
+T.assert_type!(Wizard.find_or_create_by(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard)
+T.assert_type!(Wizard.find_or_create_by!(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard)
+T.assert_type!(Wizard.new { |w| T.assert_type!(w, Wizard) }, Wizard)
+T.assert_type!(Wizard.create(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard)
+T.assert_type!(Wizard.create!(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard)
+# T.assert_type!(Wizard.first_or_create(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard) # Ignored until we add support
+# T.assert_type!(Wizard.first_or_create!(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard) # Ignored until we add support
+# T.assert_type!(Wizard.first_or_initialize { |w| T.assert_type!(w, Wizard) }, Wizard) # Ignored until we add support
+Wizard.find_each { |w| T.assert_type!(w, Wizard) }
+T.assert_type!(Wizard.find_each, T::Enumerator[Wizard])
+Wizard.find_in_batches { |w| T.assert_type!(w, T::Array[Wizard]) }
+T.assert_type!(Wizard.find_in_batches, T::Enumerator[T::Array[Wizard]])
+# T.assert_type!(Wizard.destroy_all, T::Array[Wizard]) # Ignored until we add support
+T.assert_type!(Wizard.any?, T::Boolean)
+T.assert_type!(Wizard.many?, T::Boolean)
+T.assert_type!(Wizard.none?, T::Boolean)
+T.assert_type!(Wizard.one?, T::Boolean)
+# T.assert_type!(Wizard.update_all(name: 'Harry Potter'), Integer) # Ignored until we add support
+# T.assert_type!(Wizard.delete_all, Integer) # Ignored until we add support
 
 # Finder methods -- ActiveRecord::Relation
 T.assert_type!(Wizard.all.exists?(name: 'Harry Potter'), T::Boolean)
@@ -76,6 +96,32 @@ T.assert_type!(Wizard.all.find_by(name: 'Harry Potter'), T.nilable(Wizard))
 T.assert_type!(Wizard.all.find_by!(name: 'Harry Potter'), Wizard)
 T.assert_type!(Wizard.all.find_by_id(wizard.id), T.nilable(Wizard))
 T.assert_type!(Wizard.all.find_by_id!(wizard.id), Wizard)
+T.assert_type!(Wizard.all.find_or_initialize_by(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard)
+T.assert_type!(Wizard.all.find_or_create_by(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard)
+T.assert_type!(Wizard.all.find_or_create_by!(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard)
+T.assert_type!(Wizard.all.new { |w| T.assert_type!(w, Wizard) }, Wizard)
+# T.assert_type!(Wizard.all.build { |w| T.assert_type!(w, Wizard) }, Wizard) # Ignored until we add support
+T.assert_type!(Wizard.all.create(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard)
+T.assert_type!(Wizard.all.create!(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard)
+# T.assert_type!(Wizard.all.first_or_create(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard) # Ignored until we add support
+# T.assert_type!(Wizard.all.first_or_create!(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard) # Ignored until we add support
+# T.assert_type!(Wizard.all.first_or_initialize { |w| T.assert_type!(w, Wizard) }, Wizard) # Ignored until we add support
+Wizard.all.find_each { |w| T.assert_type!(w, Wizard) }
+T.assert_type!(Wizard.all.find_each, T::Enumerator[Wizard])
+Wizard.all.find_in_batches { |w| T.assert_type!(w, T::Array[Wizard]) }
+T.assert_type!(Wizard.all.find_in_batches, T::Enumerator[T::Array[Wizard]])
+# T.assert_type!(Wizard.all.destroy_all, T::Array[Wizard]) # Ignored until we add support
+T.assert_type!(Wizard.all.any?, T::Boolean)
+T.assert_type!(Wizard.all.many?, T::Boolean)
+T.assert_type!(Wizard.all.none?, T::Boolean)
+T.assert_type!(Wizard.all.one?, T::Boolean)
+# T.assert_type!(Wizard.all.update_all(name: 'Harry Potter'), Integer) # Ignored until we add support
+# T.assert_type!(Wizard.all.delete_all, Integer) # Ignored until we add support
+# Enumerable methods
+Wizard.all.each { |w| T.assert_type!(w, Wizard) }
+Wizard.all.map { |w| T.assert_type!(w, Wizard) }
+T.assert_type!(Wizard.all.to_a, T::Array[Wizard])
+T.assert_type!(Wizard.all.empty?, T::Boolean)
 
 # Finder methods -- CollectionProxy
 spell_book = wizard.spell_books.first!
@@ -92,6 +138,27 @@ T.assert_type!(spell_books.find_by(name: 'Fantastic Beasts'), T.nilable(SpellBoo
 T.assert_type!(spell_books.find_by!(name: 'Fantastic Beasts'), SpellBook)
 T.assert_type!(spell_books.find_by_id(spell_book.id), T.nilable(SpellBook))
 T.assert_type!(spell_books.find_by_id!(spell_book.id), SpellBook)
+T.assert_type!(spell_books.find_or_initialize_by(name: 'Fantastic Beasts') { |s| T.assert_type!(s, SpellBook) }, SpellBook)
+T.assert_type!(spell_books.find_or_create_by(name: 'Fantastic Beasts') { |s| T.assert_type!(s, SpellBook) }, SpellBook)
+T.assert_type!(spell_books.find_or_create_by!(name: 'Fantastic Beasts') { |s| T.assert_type!(s, SpellBook) }, SpellBook)
+# T.assert_type!(spell_books.new { |s| T.assert_type!(s, SpellBook) }, SpellBook) # Ignored until we add support
+# T.assert_type!(spell_books.build { |s| T.assert_type!(s, SpellBook) }, SpellBook) # Ignored until we add support # Ignored until we add support
+# T.assert_type!(spell_books.create(name: 'Fantastic Beasts') { |s| T.assert_type!(s, SpellBook) }, SpellBook) # Ignored until we add support
+# T.assert_type!(spell_books.create!(name: 'Fantastic Beasts') { |s| T.assert_type!(s, SpellBook) }, SpellBook) # Ignored until we add support
+# T.assert_type!(spell_books.first_or_create(name: 'Fantastic Beasts') { |s| T.assert_type!(s, SpellBook) }, SpellBook) # Ignored until we add support
+# T.assert_type!(spell_books.first_or_create!(name: 'Fantastic Beasts') { |s| T.assert_type!(s, SpellBook) }, SpellBook) # Ignored until we add support
+# T.assert_type!(spell_books.first_or_initialize { |s| T.assert_type!(s, SpellBook) }, SpellBook) # Ignored until we add support
+# spell_books.find_each { |s| T.assert_type!(s, SpellBook) } # TODO: Handle for Rails 6
+# T.assert_type!(spell_books.find_each, T::Enumerator[SpellBook]) # TODO: Handle for Rails 6
+# spell_books.find_in_batches { |s| T.assert_type!(s, T::Array[SpellBook]) } # TODO: Handle for Rails 6
+# T.assert_type!(spell_books.find_in_batches, T::Enumerator[T::Array[SpellBook]]) # TODO: Handle for Rails 6
+# T.assert_type!(spell_books.destroy_all, T::Array[SpellBook]) # Ignored until we add support
+T.assert_type!(spell_books.any?, T::Boolean)
+T.assert_type!(spell_books.many?, T::Boolean)
+T.assert_type!(spell_books.none?, T::Boolean)
+T.assert_type!(spell_books.one?, T::Boolean)
+# T.assert_type!(spell_books.update_all(name: 'Fantastic Beasts'), Integer) # Ignored until we add support
+# T.assert_type!(spell_books.delete_all, Integer) # Ignored until we add support
 # CollectionProxy query also typed correctly!
 T.assert_type!(spell_books.where(id: 1), SpellBook::ActiveRecord_AssociationRelation)
 T.assert_type!(spell_books.preload(:wizard), SpellBook::ActiveRecord_AssociationRelation)
@@ -99,6 +166,11 @@ T.assert_type!(spell_books.eager_load(:wizard), SpellBook::ActiveRecord_Associat
 T.assert_type!(spell_books.order(:id), SpellBook::ActiveRecord_AssociationRelation)
 T.assert_type!(spell_books.where.not(id: 1), SpellBook::ActiveRecord_AssociationRelation)
 T.assert_type!(spell_books.biology, SpellBook::ActiveRecord_AssociationRelation)
+# Enumerable methods
+spell_books.each { |s| T.assert_type!(s, SpellBook) }
+spell_books.map { |s| T.assert_type!(s, SpellBook) }
+T.assert_type!(spell_books.to_a, T::Array[SpellBook])
+T.assert_type!(spell_books.empty?, T::Boolean)
 
 # finder methods -- AssociationRelation
 spell_books_query = spell_books.where(id: 1)
@@ -114,48 +186,38 @@ T.assert_type!(spell_books_query.find_by(name: 'Fantastic Beasts'), T.nilable(Sp
 T.assert_type!(spell_books_query.find_by!(name: 'Fantastic Beasts'), SpellBook)
 T.assert_type!(spell_books_query.find_by_id(spell_book.id), T.nilable(SpellBook))
 T.assert_type!(spell_books_query.find_by_id!(spell_book.id), SpellBook)
+T.assert_type!(spell_books_query.find_or_initialize_by(name: 'Fantastic Beasts') { |s| T.assert_type!(s, SpellBook) }, SpellBook)
+T.assert_type!(spell_books_query.find_or_create_by(name: 'Fantastic Beasts') { |s| T.assert_type!(s, SpellBook) }, SpellBook)
+T.assert_type!(spell_books_query.find_or_create_by!(name: 'Fantastic Beasts') { |s| T.assert_type!(s, SpellBook) }, SpellBook)
+# T.assert_type!(spell_books_query.new { |s| T.assert_type!(s, SpellBook) }, SpellBook) # Ignored until we add support
+# T.assert_type!(spell_books_query.build { |s| T.assert_type!(s, SpellBook) }, SpellBook) # Ignored until we add support # Ignored until we add support
+# T.assert_type!(spell_books_query.create(name: 'Fantastic Beasts') { |s| T.assert_type!(s, SpellBook) }, SpellBook) # Ignored until we add support
+# T.assert_type!(spell_books_query.create!(name: 'Fantastic Beasts') { |s| T.assert_type!(s, SpellBook) }, SpellBook) # Ignored until we add support
+# T.assert_type!(spell_books_query.first_or_create(name: 'Fantastic Beasts') { |s| T.assert_type!(s, SpellBook) }, SpellBook) # Ignored until we add support
+# T.assert_type!(spell_books_query.first_or_create!(name: 'Fantastic Beasts') { |s| T.assert_type!(s, SpellBook) }, SpellBook) # Ignored until we add support
+# T.assert_type!(spell_books_query.first_or_initialize { |s| T.assert_type!(s, SpellBook) }, SpellBook) # Ignored until we add support
+# spell_books_query.find_each { |s| T.assert_type!(s, SpellBook) } # TODO: Handle for Rails 6
+# T.assert_type!(spell_books_query.find_each, T::Enumerator[SpellBook]) # TODO: Handle for Rails 6
+# spell_books_query.find_in_batches { |s| T.assert_type!(s, T::Array[SpellBook]) } # TODO: Handle for Rails 6
+# T.assert_type!(spell_books_query.find_in_batches, T::Enumerator[T::Array[SpellBook]]) # TODO: Handle for Rails 6
+# T.assert_type!(spell_books_query.destroy_all, T::Array[SpellBook]) # Ignored until we add support
+T.assert_type!(spell_books_query.any?, T::Boolean)
+T.assert_type!(spell_books_query.many?, T::Boolean)
+T.assert_type!(spell_books_query.none?, T::Boolean)
+T.assert_type!(spell_books_query.one?, T::Boolean)
+# T.assert_type!(spell_books_query.update_all(name: 'Fantastic Beasts'), Integer) # Ignored until we add support
+# T.assert_type!(spell_books_query.delete_all, Integer) # Ignored until we add support
 # Query chaining
 T.assert_type!(spell_books_query.preload(:wizard), SpellBook::ActiveRecord_AssociationRelation)
 T.assert_type!(spell_books_query.eager_load(:wizard), SpellBook::ActiveRecord_AssociationRelation)
 T.assert_type!(spell_books_query.order(:id), SpellBook::ActiveRecord_AssociationRelation)
 T.assert_type!(spell_books_query.where.not(id: 1), SpellBook::ActiveRecord_AssociationRelation)
 T.assert_type!(spell_books_query.biology, SpellBook::ActiveRecord_AssociationRelation)
-
-# Enumerable on activerecord relation
-T.assert_type!(Wizard.all.to_a, T::Array[Wizard])
-Wizard.all.each do |w|
-  T.assert_type!(w, Wizard)
-end
-Wizard.all.map do |w|
-  T.assert_type!(w, Wizard)
-end
-Wizard.all.to_a.map do |w|
-  T.assert_type!(w, Wizard)
-end
-
-# enum on association collection proxy
-T.assert_type!(wizard.spell_books.to_a, T::Array[SpellBook])
-wizard.spell_books.each do |sp|
-  T.assert_type!(sp, SpellBook)
-end
-wizard.spell_books.map do |sp|
-  T.assert_type!(sp, SpellBook)
-end
-wizard.spell_books.to_a.map do |sp|
-  T.assert_type!(sp, SpellBook)
-end
-
-# enum on association relation
-T.assert_type!(wizard.spell_books.where(id: 1).to_a, T::Array[SpellBook])
-wizard.spell_books.where(id: 1).each do |sp|
-  T.assert_type!(sp, SpellBook)
-end
-wizard.spell_books.where(id: 1).map do |sp|
-  T.assert_type!(sp, SpellBook)
-end
-wizard.spell_books.where(id: 1).to_a.map do |sp|
-  T.assert_type!(sp, SpellBook)
-end
+# Enumerable methods
+spell_books_query.each { |s| T.assert_type!(s, SpellBook) }
+spell_books_query.map { |s| T.assert_type!(s, SpellBook) }
+T.assert_type!(spell_books_query.to_a, T::Array[SpellBook])
+T.assert_type!(spell_books_query.empty?, T::Boolean)
 
 # Model columns
 T.assert_type!(wizard.id, Integer)

--- a/spec/support/v6.0/sorbet_test_cases.rb
+++ b/spec/support/v6.0/sorbet_test_cases.rb
@@ -62,6 +62,26 @@ T.assert_type!(Wizard.find_by(name: 'Harry Potter'), T.nilable(Wizard))
 T.assert_type!(Wizard.find_by!(name: 'Harry Potter'), Wizard)
 T.assert_type!(Wizard.find_by_id(wizard.id), T.nilable(Wizard))
 T.assert_type!(Wizard.find_by_id!(wizard.id), Wizard)
+T.assert_type!(Wizard.find_or_initialize_by(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard)
+T.assert_type!(Wizard.find_or_create_by(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard)
+T.assert_type!(Wizard.find_or_create_by!(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard)
+T.assert_type!(Wizard.new { |w| T.assert_type!(w, Wizard) }, Wizard)
+T.assert_type!(Wizard.create(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard)
+T.assert_type!(Wizard.create!(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard)
+# T.assert_type!(Wizard.first_or_create(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard) # Ignored until we add support
+# T.assert_type!(Wizard.first_or_create!(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard) # Ignored until we add support
+# T.assert_type!(Wizard.first_or_initialize { |w| T.assert_type!(w, Wizard) }, Wizard) # Ignored until we add support
+Wizard.find_each { |w| T.assert_type!(w, Wizard) }
+T.assert_type!(Wizard.find_each, T::Enumerator[Wizard])
+Wizard.find_in_batches { |w| T.assert_type!(w, T::Array[Wizard]) }
+T.assert_type!(Wizard.find_in_batches, T::Enumerator[T::Array[Wizard]])
+# T.assert_type!(Wizard.destroy_all, T::Array[Wizard]) # Ignored until we add support
+T.assert_type!(Wizard.any?, T::Boolean)
+T.assert_type!(Wizard.many?, T::Boolean)
+T.assert_type!(Wizard.none?, T::Boolean)
+T.assert_type!(Wizard.one?, T::Boolean)
+# T.assert_type!(Wizard.update_all(name: 'Harry Potter'), Integer) # Ignored until we add support
+# T.assert_type!(Wizard.delete_all, Integer) # Ignored until we add support
 
 # Finder methods -- ActiveRecord::Relation
 T.assert_type!(Wizard.all.exists?(name: 'Harry Potter'), T::Boolean)
@@ -76,6 +96,32 @@ T.assert_type!(Wizard.all.find_by(name: 'Harry Potter'), T.nilable(Wizard))
 T.assert_type!(Wizard.all.find_by!(name: 'Harry Potter'), Wizard)
 T.assert_type!(Wizard.all.find_by_id(wizard.id), T.nilable(Wizard))
 T.assert_type!(Wizard.all.find_by_id!(wizard.id), Wizard)
+T.assert_type!(Wizard.all.find_or_initialize_by(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard)
+T.assert_type!(Wizard.all.find_or_create_by(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard)
+T.assert_type!(Wizard.all.find_or_create_by!(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard)
+T.assert_type!(Wizard.all.new { |w| T.assert_type!(w, Wizard) }, Wizard)
+# T.assert_type!(Wizard.all.build { |w| T.assert_type!(w, Wizard) }, Wizard) # Ignored until we add support
+T.assert_type!(Wizard.all.create(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard)
+T.assert_type!(Wizard.all.create!(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard)
+# T.assert_type!(Wizard.all.first_or_create(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard) # Ignored until we add support
+# T.assert_type!(Wizard.all.first_or_create!(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard) # Ignored until we add support
+# T.assert_type!(Wizard.all.first_or_initialize { |w| T.assert_type!(w, Wizard) }, Wizard) # Ignored until we add support
+Wizard.all.find_each { |w| T.assert_type!(w, Wizard) }
+T.assert_type!(Wizard.all.find_each, T::Enumerator[Wizard])
+Wizard.all.find_in_batches { |w| T.assert_type!(w, T::Array[Wizard]) }
+T.assert_type!(Wizard.all.find_in_batches, T::Enumerator[T::Array[Wizard]])
+# T.assert_type!(Wizard.all.destroy_all, T::Array[Wizard]) # Ignored until we add support
+T.assert_type!(Wizard.all.any?, T::Boolean)
+T.assert_type!(Wizard.all.many?, T::Boolean)
+T.assert_type!(Wizard.all.none?, T::Boolean)
+T.assert_type!(Wizard.all.one?, T::Boolean)
+# T.assert_type!(Wizard.all.update_all(name: 'Harry Potter'), Integer) # Ignored until we add support
+# T.assert_type!(Wizard.all.delete_all, Integer) # Ignored until we add support
+# Enumerable methods
+Wizard.all.each { |w| T.assert_type!(w, Wizard) }
+Wizard.all.map { |w| T.assert_type!(w, Wizard) }
+T.assert_type!(Wizard.all.to_a, T::Array[Wizard])
+T.assert_type!(Wizard.all.empty?, T::Boolean)
 
 # Finder methods -- CollectionProxy
 spell_book = wizard.spell_books.first!
@@ -92,6 +138,27 @@ T.assert_type!(spell_books.find_by(name: 'Fantastic Beasts'), T.nilable(SpellBoo
 T.assert_type!(spell_books.find_by!(name: 'Fantastic Beasts'), SpellBook)
 T.assert_type!(spell_books.find_by_id(spell_book.id), T.nilable(SpellBook))
 T.assert_type!(spell_books.find_by_id!(spell_book.id), SpellBook)
+T.assert_type!(spell_books.find_or_initialize_by(name: 'Fantastic Beasts') { |s| T.assert_type!(s, SpellBook) }, SpellBook)
+T.assert_type!(spell_books.find_or_create_by(name: 'Fantastic Beasts') { |s| T.assert_type!(s, SpellBook) }, SpellBook)
+T.assert_type!(spell_books.find_or_create_by!(name: 'Fantastic Beasts') { |s| T.assert_type!(s, SpellBook) }, SpellBook)
+# T.assert_type!(spell_books.new { |s| T.assert_type!(s, SpellBook) }, SpellBook) # Ignored until we add support
+# T.assert_type!(spell_books.build { |s| T.assert_type!(s, SpellBook) }, SpellBook) # Ignored until we add support # Ignored until we add support
+# T.assert_type!(spell_books.create(name: 'Fantastic Beasts') { |s| T.assert_type!(s, SpellBook) }, SpellBook) # Ignored until we add support
+# T.assert_type!(spell_books.create!(name: 'Fantastic Beasts') { |s| T.assert_type!(s, SpellBook) }, SpellBook) # Ignored until we add support
+# T.assert_type!(spell_books.first_or_create(name: 'Fantastic Beasts') { |s| T.assert_type!(s, SpellBook) }, SpellBook) # Ignored until we add support
+# T.assert_type!(spell_books.first_or_create!(name: 'Fantastic Beasts') { |s| T.assert_type!(s, SpellBook) }, SpellBook) # Ignored until we add support
+# T.assert_type!(spell_books.first_or_initialize { |s| T.assert_type!(s, SpellBook) }, SpellBook) # Ignored until we add support
+# spell_books.find_each { |s| T.assert_type!(s, SpellBook) } # TODO: Handle for Rails 6
+# T.assert_type!(spell_books.find_each, T::Enumerator[SpellBook]) # TODO: Handle for Rails 6
+# spell_books.find_in_batches { |s| T.assert_type!(s, T::Array[SpellBook]) } # TODO: Handle for Rails 6
+# T.assert_type!(spell_books.find_in_batches, T::Enumerator[T::Array[SpellBook]]) # TODO: Handle for Rails 6
+# T.assert_type!(spell_books.destroy_all, T::Array[SpellBook]) # Ignored until we add support
+T.assert_type!(spell_books.any?, T::Boolean)
+T.assert_type!(spell_books.many?, T::Boolean)
+T.assert_type!(spell_books.none?, T::Boolean)
+T.assert_type!(spell_books.one?, T::Boolean)
+# T.assert_type!(spell_books.update_all(name: 'Fantastic Beasts'), Integer) # Ignored until we add support
+# T.assert_type!(spell_books.delete_all, Integer) # Ignored until we add support
 # CollectionProxy query also typed correctly!
 T.assert_type!(spell_books.where(id: 1), SpellBook::ActiveRecord_AssociationRelation)
 T.assert_type!(spell_books.preload(:wizard), SpellBook::ActiveRecord_AssociationRelation)
@@ -99,6 +166,11 @@ T.assert_type!(spell_books.eager_load(:wizard), SpellBook::ActiveRecord_Associat
 T.assert_type!(spell_books.order(:id), SpellBook::ActiveRecord_AssociationRelation)
 T.assert_type!(spell_books.where.not(id: 1), SpellBook::ActiveRecord_AssociationRelation)
 T.assert_type!(spell_books.biology, SpellBook::ActiveRecord_AssociationRelation)
+# Enumerable methods
+spell_books.each { |s| T.assert_type!(s, SpellBook) }
+spell_books.map { |s| T.assert_type!(s, SpellBook) }
+T.assert_type!(spell_books.to_a, T::Array[SpellBook])
+T.assert_type!(spell_books.empty?, T::Boolean)
 
 # finder methods -- AssociationRelation
 spell_books_query = spell_books.where(id: 1)
@@ -114,48 +186,38 @@ T.assert_type!(spell_books_query.find_by(name: 'Fantastic Beasts'), T.nilable(Sp
 T.assert_type!(spell_books_query.find_by!(name: 'Fantastic Beasts'), SpellBook)
 T.assert_type!(spell_books_query.find_by_id(spell_book.id), T.nilable(SpellBook))
 T.assert_type!(spell_books_query.find_by_id!(spell_book.id), SpellBook)
+T.assert_type!(spell_books_query.find_or_initialize_by(name: 'Fantastic Beasts') { |s| T.assert_type!(s, SpellBook) }, SpellBook)
+T.assert_type!(spell_books_query.find_or_create_by(name: 'Fantastic Beasts') { |s| T.assert_type!(s, SpellBook) }, SpellBook)
+T.assert_type!(spell_books_query.find_or_create_by!(name: 'Fantastic Beasts') { |s| T.assert_type!(s, SpellBook) }, SpellBook)
+# T.assert_type!(spell_books_query.new { |s| T.assert_type!(s, SpellBook) }, SpellBook) # Ignored until we add support
+# T.assert_type!(spell_books_query.build { |s| T.assert_type!(s, SpellBook) }, SpellBook) # Ignored until we add support # Ignored until we add support
+# T.assert_type!(spell_books_query.create(name: 'Fantastic Beasts') { |s| T.assert_type!(s, SpellBook) }, SpellBook) # Ignored until we add support
+# T.assert_type!(spell_books_query.create!(name: 'Fantastic Beasts') { |s| T.assert_type!(s, SpellBook) }, SpellBook) # Ignored until we add support
+# T.assert_type!(spell_books_query.first_or_create(name: 'Fantastic Beasts') { |s| T.assert_type!(s, SpellBook) }, SpellBook) # Ignored until we add support
+# T.assert_type!(spell_books_query.first_or_create!(name: 'Fantastic Beasts') { |s| T.assert_type!(s, SpellBook) }, SpellBook) # Ignored until we add support
+# T.assert_type!(spell_books_query.first_or_initialize { |s| T.assert_type!(s, SpellBook) }, SpellBook) # Ignored until we add support
+# spell_books_query.find_each { |s| T.assert_type!(s, SpellBook) } # TODO: Handle for Rails 6
+# T.assert_type!(spell_books_query.find_each, T::Enumerator[SpellBook]) # TODO: Handle for Rails 6
+# spell_books_query.find_in_batches { |s| T.assert_type!(s, T::Array[SpellBook]) } # TODO: Handle for Rails 6
+# T.assert_type!(spell_books_query.find_in_batches, T::Enumerator[T::Array[SpellBook]]) # TODO: Handle for Rails 6
+# T.assert_type!(spell_books_query.destroy_all, T::Array[SpellBook]) # Ignored until we add support
+T.assert_type!(spell_books_query.any?, T::Boolean)
+T.assert_type!(spell_books_query.many?, T::Boolean)
+T.assert_type!(spell_books_query.none?, T::Boolean)
+T.assert_type!(spell_books_query.one?, T::Boolean)
+# T.assert_type!(spell_books_query.update_all(name: 'Fantastic Beasts'), Integer) # Ignored until we add support
+# T.assert_type!(spell_books_query.delete_all, Integer) # Ignored until we add support
 # Query chaining
 T.assert_type!(spell_books_query.preload(:wizard), SpellBook::ActiveRecord_AssociationRelation)
 T.assert_type!(spell_books_query.eager_load(:wizard), SpellBook::ActiveRecord_AssociationRelation)
 T.assert_type!(spell_books_query.order(:id), SpellBook::ActiveRecord_AssociationRelation)
 T.assert_type!(spell_books_query.where.not(id: 1), SpellBook::ActiveRecord_AssociationRelation)
 T.assert_type!(spell_books_query.biology, SpellBook::ActiveRecord_AssociationRelation)
-
-# Enumerable on activerecord relation
-T.assert_type!(Wizard.all.to_a, T::Array[Wizard])
-Wizard.all.each do |w|
-  T.assert_type!(w, Wizard)
-end
-Wizard.all.map do |w|
-  T.assert_type!(w, Wizard)
-end
-Wizard.all.to_a.map do |w|
-  T.assert_type!(w, Wizard)
-end
-
-# enum on association collection proxy
-T.assert_type!(wizard.spell_books.to_a, T::Array[SpellBook])
-wizard.spell_books.each do |sp|
-  T.assert_type!(sp, SpellBook)
-end
-wizard.spell_books.map do |sp|
-  T.assert_type!(sp, SpellBook)
-end
-wizard.spell_books.to_a.map do |sp|
-  T.assert_type!(sp, SpellBook)
-end
-
-# enum on association relation
-T.assert_type!(wizard.spell_books.where(id: 1).to_a, T::Array[SpellBook])
-wizard.spell_books.where(id: 1).each do |sp|
-  T.assert_type!(sp, SpellBook)
-end
-wizard.spell_books.where(id: 1).map do |sp|
-  T.assert_type!(sp, SpellBook)
-end
-wizard.spell_books.where(id: 1).to_a.map do |sp|
-  T.assert_type!(sp, SpellBook)
-end
+# Enumerable methods
+spell_books_query.each { |s| T.assert_type!(s, SpellBook) }
+spell_books_query.map { |s| T.assert_type!(s, SpellBook) }
+T.assert_type!(spell_books_query.to_a, T::Array[SpellBook])
+T.assert_type!(spell_books_query.empty?, T::Boolean)
 
 # Model columns
 T.assert_type!(wizard.id, Integer)

--- a/spec/test_data/v5.0/expected_active_record_base.rbi
+++ b/spec/test_data/v5.0/expected_active_record_base.rbi
@@ -72,7 +72,18 @@ class ActiveRecord::Base
       batch_size: T.nilable(Integer),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: T.attached_class).void)
-    ).returns(T::Array[T.attached_class])
+    ).returns(T::Enumerator[T.attached_class])
   end
   def self.find_each(start: nil, finish: nil, batch_size: 1000, error_on_ignore: nil, &block); end
+
+  sig do
+    override.params(
+      start: T.nilable(Integer),
+      finish: T.nilable(Integer),
+      batch_size: T.nilable(Integer),
+      error_on_ignore: T.nilable(T::Boolean),
+      block: T.nilable(T.proc.params(e: T::Array[T.attached_class]).void)
+    ).returns(T::Enumerator[T::Array[T.attached_class]])
+  end
+  def self.find_in_batches(start: nil, finish: nil, batch_size: 1000, error_on_ignore: nil, &block); end
 end

--- a/spec/test_data/v5.0/expected_active_record_base.rbi
+++ b/spec/test_data/v5.0/expected_active_record_base.rbi
@@ -56,14 +56,14 @@ class ActiveRecord::Base
   sig { returns(T.attached_class) }
   def self.last!; end
 
-  sig { params(attributes: T.untyped, block: T.untyped).returns(T.attached_class) }
-  def self.create(attributes = nil, &block); end
+  sig { params(args: T.untyped, block: T.nilable(T.proc.params(object: T.attached_class).void)).returns(T.attached_class) }
+  def self.create(*args, &block); end
 
-  sig { params(attributes: T.untyped, block: T.untyped).returns(T.attached_class) }
-  def self.create!(attributes = nil, &block); end
+  sig { params(args: T.untyped, block: T.nilable(T.proc.params(object: T.attached_class).void)).returns(T.attached_class) }
+  def self.create!(*args, &block); end
 
-  sig { params(attributes: T.untyped, block: T.untyped).returns(T.attached_class) }
-  def self.new(attributes = nil, &block); end
+  sig { params(args: T.untyped, block: T.nilable(T.proc.params(object: T.attached_class).void)).returns(T.attached_class) }
+  def self.new(*args, &block); end
 
   sig do
     override.params(

--- a/spec/test_data/v5.0/expected_active_record_relation.rbi
+++ b/spec/test_data/v5.0/expected_active_record_relation.rbi
@@ -58,6 +58,15 @@ class ActiveRecord::Relation
   sig { returns(Elem) }
   def last!; end
 
+  sig { params(attributes: T.untyped, block: T.untyped).returns(Elem) }
+  def create(attributes = nil, &block); end
+
+  sig { params(attributes: T.untyped, block: T.untyped).returns(Elem) }
+  def create!(attributes = nil, &block); end
+
+  sig { params(attributes: T.untyped, block: T.untyped).returns(Elem) }
+  def new(attributes = nil, &block); end
+
   sig do
     override.params(
       start: T.nilable(Integer),
@@ -65,9 +74,20 @@ class ActiveRecord::Relation
       batch_size: T.nilable(Integer),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: Elem).void)
-    ).returns(T::Array[Elem])
+    ).returns(T::Enumerator[Elem])
   end
   def find_each(start: nil, finish: nil, batch_size: 1000, error_on_ignore: nil, &block); end
+
+  sig do
+    override.params(
+      start: T.nilable(Integer),
+      finish: T.nilable(Integer),
+      batch_size: T.nilable(Integer),
+      error_on_ignore: T.nilable(T::Boolean),
+      block: T.nilable(T.proc.params(e: T::Array[Elem]).void)
+    ).returns(T::Enumerator[T::Array[Elem]])
+  end
+  def find_in_batches(start: nil, finish: nil, batch_size: 1000, error_on_ignore: nil, &block); end
 
   sig { override.params(block: T.proc.params(e: Elem).void).returns(T::Array[Elem]) }
   def each(&block); end

--- a/spec/test_data/v5.0/expected_active_record_relation.rbi
+++ b/spec/test_data/v5.0/expected_active_record_relation.rbi
@@ -58,14 +58,14 @@ class ActiveRecord::Relation
   sig { returns(Elem) }
   def last!; end
 
-  sig { params(attributes: T.untyped, block: T.untyped).returns(Elem) }
-  def create(attributes = nil, &block); end
+  sig { params(args: T.untyped, block: T.nilable(T.proc.params(object: Elem).void)).returns(Elem) }
+  def create(*args, &block); end
 
-  sig { params(attributes: T.untyped, block: T.untyped).returns(Elem) }
-  def create!(attributes = nil, &block); end
+  sig { params(args: T.untyped, block: T.nilable(T.proc.params(object: Elem).void)).returns(Elem) }
+  def create!(*args, &block); end
 
-  sig { params(attributes: T.untyped, block: T.untyped).returns(Elem) }
-  def new(attributes = nil, &block); end
+  sig { params(args: T.untyped, block: T.nilable(T.proc.params(object: Elem).void)).returns(Elem) }
+  def new(*args, &block); end
 
   sig do
     override.params(

--- a/spec/test_data/v5.1/expected_active_record_base.rbi
+++ b/spec/test_data/v5.1/expected_active_record_base.rbi
@@ -72,7 +72,18 @@ class ActiveRecord::Base
       batch_size: T.nilable(Integer),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: T.attached_class).void)
-    ).returns(T::Array[T.attached_class])
+    ).returns(T::Enumerator[T.attached_class])
   end
   def self.find_each(start: nil, finish: nil, batch_size: 1000, error_on_ignore: nil, &block); end
+
+  sig do
+    override.params(
+      start: T.nilable(Integer),
+      finish: T.nilable(Integer),
+      batch_size: T.nilable(Integer),
+      error_on_ignore: T.nilable(T::Boolean),
+      block: T.nilable(T.proc.params(e: T::Array[T.attached_class]).void)
+    ).returns(T::Enumerator[T::Array[T.attached_class]])
+  end
+  def self.find_in_batches(start: nil, finish: nil, batch_size: 1000, error_on_ignore: nil, &block); end
 end

--- a/spec/test_data/v5.1/expected_active_record_base.rbi
+++ b/spec/test_data/v5.1/expected_active_record_base.rbi
@@ -56,14 +56,14 @@ class ActiveRecord::Base
   sig { returns(T.attached_class) }
   def self.last!; end
 
-  sig { params(attributes: T.untyped, block: T.untyped).returns(T.attached_class) }
-  def self.create(attributes = nil, &block); end
+  sig { params(args: T.untyped, block: T.nilable(T.proc.params(object: T.attached_class).void)).returns(T.attached_class) }
+  def self.create(*args, &block); end
 
-  sig { params(attributes: T.untyped, block: T.untyped).returns(T.attached_class) }
-  def self.create!(attributes = nil, &block); end
+  sig { params(args: T.untyped, block: T.nilable(T.proc.params(object: T.attached_class).void)).returns(T.attached_class) }
+  def self.create!(*args, &block); end
 
-  sig { params(attributes: T.untyped, block: T.untyped).returns(T.attached_class) }
-  def self.new(attributes = nil, &block); end
+  sig { params(args: T.untyped, block: T.nilable(T.proc.params(object: T.attached_class).void)).returns(T.attached_class) }
+  def self.new(*args, &block); end
 
   sig do
     override.params(

--- a/spec/test_data/v5.1/expected_active_record_relation.rbi
+++ b/spec/test_data/v5.1/expected_active_record_relation.rbi
@@ -58,6 +58,15 @@ class ActiveRecord::Relation
   sig { returns(Elem) }
   def last!; end
 
+  sig { params(attributes: T.untyped, block: T.untyped).returns(Elem) }
+  def create(attributes = nil, &block); end
+
+  sig { params(attributes: T.untyped, block: T.untyped).returns(Elem) }
+  def create!(attributes = nil, &block); end
+
+  sig { params(attributes: T.untyped, block: T.untyped).returns(Elem) }
+  def new(attributes = nil, &block); end
+
   sig do
     override.params(
       start: T.nilable(Integer),
@@ -65,9 +74,20 @@ class ActiveRecord::Relation
       batch_size: T.nilable(Integer),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: Elem).void)
-    ).returns(T::Array[Elem])
+    ).returns(T::Enumerator[Elem])
   end
   def find_each(start: nil, finish: nil, batch_size: 1000, error_on_ignore: nil, &block); end
+
+  sig do
+    override.params(
+      start: T.nilable(Integer),
+      finish: T.nilable(Integer),
+      batch_size: T.nilable(Integer),
+      error_on_ignore: T.nilable(T::Boolean),
+      block: T.nilable(T.proc.params(e: T::Array[Elem]).void)
+    ).returns(T::Enumerator[T::Array[Elem]])
+  end
+  def find_in_batches(start: nil, finish: nil, batch_size: 1000, error_on_ignore: nil, &block); end
 
   sig { override.params(block: T.proc.params(e: Elem).void).returns(T::Array[Elem]) }
   def each(&block); end

--- a/spec/test_data/v5.1/expected_active_record_relation.rbi
+++ b/spec/test_data/v5.1/expected_active_record_relation.rbi
@@ -58,14 +58,14 @@ class ActiveRecord::Relation
   sig { returns(Elem) }
   def last!; end
 
-  sig { params(attributes: T.untyped, block: T.untyped).returns(Elem) }
-  def create(attributes = nil, &block); end
+  sig { params(args: T.untyped, block: T.nilable(T.proc.params(object: Elem).void)).returns(Elem) }
+  def create(*args, &block); end
 
-  sig { params(attributes: T.untyped, block: T.untyped).returns(Elem) }
-  def create!(attributes = nil, &block); end
+  sig { params(args: T.untyped, block: T.nilable(T.proc.params(object: Elem).void)).returns(Elem) }
+  def create!(*args, &block); end
 
-  sig { params(attributes: T.untyped, block: T.untyped).returns(Elem) }
-  def new(attributes = nil, &block); end
+  sig { params(args: T.untyped, block: T.nilable(T.proc.params(object: Elem).void)).returns(Elem) }
+  def new(*args, &block); end
 
   sig do
     override.params(

--- a/spec/test_data/v5.2/expected_active_record_base.rbi
+++ b/spec/test_data/v5.2/expected_active_record_base.rbi
@@ -72,7 +72,18 @@ class ActiveRecord::Base
       batch_size: T.nilable(Integer),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: T.attached_class).void)
-    ).returns(T::Array[T.attached_class])
+    ).returns(T::Enumerator[T.attached_class])
   end
   def self.find_each(start: nil, finish: nil, batch_size: 1000, error_on_ignore: nil, &block); end
+
+  sig do
+    override.params(
+      start: T.nilable(Integer),
+      finish: T.nilable(Integer),
+      batch_size: T.nilable(Integer),
+      error_on_ignore: T.nilable(T::Boolean),
+      block: T.nilable(T.proc.params(e: T::Array[T.attached_class]).void)
+    ).returns(T::Enumerator[T::Array[T.attached_class]])
+  end
+  def self.find_in_batches(start: nil, finish: nil, batch_size: 1000, error_on_ignore: nil, &block); end
 end

--- a/spec/test_data/v5.2/expected_active_record_base.rbi
+++ b/spec/test_data/v5.2/expected_active_record_base.rbi
@@ -56,13 +56,13 @@ class ActiveRecord::Base
   sig { returns(T.attached_class) }
   def self.last!; end
 
-  sig { params(attributes: T.untyped, block: T.untyped).returns(T.attached_class) }
+  sig { params(attributes: T.untyped, block: T.nilable(T.proc.params(object: T.attached_class).void)).returns(T.attached_class) }
   def self.create(attributes = nil, &block); end
 
-  sig { params(attributes: T.untyped, block: T.untyped).returns(T.attached_class) }
+  sig { params(attributes: T.untyped, block: T.nilable(T.proc.params(object: T.attached_class).void)).returns(T.attached_class) }
   def self.create!(attributes = nil, &block); end
 
-  sig { params(attributes: T.untyped, block: T.untyped).returns(T.attached_class) }
+  sig { params(attributes: T.untyped, block: T.nilable(T.proc.params(object: T.attached_class).void)).returns(T.attached_class) }
   def self.new(attributes = nil, &block); end
 
   sig do

--- a/spec/test_data/v5.2/expected_active_record_relation.rbi
+++ b/spec/test_data/v5.2/expected_active_record_relation.rbi
@@ -58,13 +58,13 @@ class ActiveRecord::Relation
   sig { returns(Elem) }
   def last!; end
 
-  sig { params(attributes: T.untyped, block: T.untyped).returns(Elem) }
+  sig { params(attributes: T.untyped, block: T.nilable(T.proc.params(object: Elem).void)).returns(Elem) }
   def create(attributes = nil, &block); end
 
-  sig { params(attributes: T.untyped, block: T.untyped).returns(Elem) }
+  sig { params(attributes: T.untyped, block: T.nilable(T.proc.params(object: Elem).void)).returns(Elem) }
   def create!(attributes = nil, &block); end
 
-  sig { params(attributes: T.untyped, block: T.untyped).returns(Elem) }
+  sig { params(attributes: T.untyped, block: T.nilable(T.proc.params(object: Elem).void)).returns(Elem) }
   def new(attributes = nil, &block); end
 
   sig do

--- a/spec/test_data/v5.2/expected_active_record_relation.rbi
+++ b/spec/test_data/v5.2/expected_active_record_relation.rbi
@@ -58,6 +58,15 @@ class ActiveRecord::Relation
   sig { returns(Elem) }
   def last!; end
 
+  sig { params(attributes: T.untyped, block: T.untyped).returns(Elem) }
+  def create(attributes = nil, &block); end
+
+  sig { params(attributes: T.untyped, block: T.untyped).returns(Elem) }
+  def create!(attributes = nil, &block); end
+
+  sig { params(attributes: T.untyped, block: T.untyped).returns(Elem) }
+  def new(attributes = nil, &block); end
+
   sig do
     override.params(
       start: T.nilable(Integer),
@@ -65,9 +74,20 @@ class ActiveRecord::Relation
       batch_size: T.nilable(Integer),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: Elem).void)
-    ).returns(T::Array[Elem])
+    ).returns(T::Enumerator[Elem])
   end
   def find_each(start: nil, finish: nil, batch_size: 1000, error_on_ignore: nil, &block); end
+
+  sig do
+    override.params(
+      start: T.nilable(Integer),
+      finish: T.nilable(Integer),
+      batch_size: T.nilable(Integer),
+      error_on_ignore: T.nilable(T::Boolean),
+      block: T.nilable(T.proc.params(e: T::Array[Elem]).void)
+    ).returns(T::Enumerator[T::Array[Elem]])
+  end
+  def find_in_batches(start: nil, finish: nil, batch_size: 1000, error_on_ignore: nil, &block); end
 
   sig { override.params(block: T.proc.params(e: Elem).void).returns(T::Array[Elem]) }
   def each(&block); end

--- a/spec/test_data/v6.0/expected_active_record_base.rbi
+++ b/spec/test_data/v6.0/expected_active_record_base.rbi
@@ -72,7 +72,18 @@ class ActiveRecord::Base
       batch_size: T.nilable(Integer),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: T.attached_class).void)
-    ).returns(T::Array[T.attached_class])
+    ).returns(T::Enumerator[T.attached_class])
   end
   def self.find_each(start: nil, finish: nil, batch_size: 1000, error_on_ignore: nil, &block); end
+
+  sig do
+    override.params(
+      start: T.nilable(Integer),
+      finish: T.nilable(Integer),
+      batch_size: T.nilable(Integer),
+      error_on_ignore: T.nilable(T::Boolean),
+      block: T.nilable(T.proc.params(e: T::Array[T.attached_class]).void)
+    ).returns(T::Enumerator[T::Array[T.attached_class]])
+  end
+  def self.find_in_batches(start: nil, finish: nil, batch_size: 1000, error_on_ignore: nil, &block); end
 end

--- a/spec/test_data/v6.0/expected_active_record_base.rbi
+++ b/spec/test_data/v6.0/expected_active_record_base.rbi
@@ -56,13 +56,13 @@ class ActiveRecord::Base
   sig { returns(T.attached_class) }
   def self.last!; end
 
-  sig { params(attributes: T.untyped, block: T.untyped).returns(T.attached_class) }
+  sig { params(attributes: T.untyped, block: T.nilable(T.proc.params(object: T.attached_class).void)).returns(T.attached_class) }
   def self.create(attributes = nil, &block); end
 
-  sig { params(attributes: T.untyped, block: T.untyped).returns(T.attached_class) }
+  sig { params(attributes: T.untyped, block: T.nilable(T.proc.params(object: T.attached_class).void)).returns(T.attached_class) }
   def self.create!(attributes = nil, &block); end
 
-  sig { params(attributes: T.untyped, block: T.untyped).returns(T.attached_class) }
+  sig { params(attributes: T.untyped, block: T.nilable(T.proc.params(object: T.attached_class).void)).returns(T.attached_class) }
   def self.new(attributes = nil, &block); end
 
   sig do

--- a/spec/test_data/v6.0/expected_active_record_relation.rbi
+++ b/spec/test_data/v6.0/expected_active_record_relation.rbi
@@ -58,13 +58,13 @@ class ActiveRecord::Relation
   sig { returns(Elem) }
   def last!; end
 
-  sig { params(attributes: T.untyped, block: T.untyped).returns(Elem) }
+  sig { params(attributes: T.untyped, block: T.nilable(T.proc.params(object: Elem).void)).returns(Elem) }
   def create(attributes = nil, &block); end
 
-  sig { params(attributes: T.untyped, block: T.untyped).returns(Elem) }
+  sig { params(attributes: T.untyped, block: T.nilable(T.proc.params(object: Elem).void)).returns(Elem) }
   def create!(attributes = nil, &block); end
 
-  sig { params(attributes: T.untyped, block: T.untyped).returns(Elem) }
+  sig { params(attributes: T.untyped, block: T.nilable(T.proc.params(object: Elem).void)).returns(Elem) }
   def new(attributes = nil, &block); end
 
   sig do

--- a/spec/test_data/v6.0/expected_active_record_relation.rbi
+++ b/spec/test_data/v6.0/expected_active_record_relation.rbi
@@ -58,6 +58,15 @@ class ActiveRecord::Relation
   sig { returns(Elem) }
   def last!; end
 
+  sig { params(attributes: T.untyped, block: T.untyped).returns(Elem) }
+  def create(attributes = nil, &block); end
+
+  sig { params(attributes: T.untyped, block: T.untyped).returns(Elem) }
+  def create!(attributes = nil, &block); end
+
+  sig { params(attributes: T.untyped, block: T.untyped).returns(Elem) }
+  def new(attributes = nil, &block); end
+
   sig do
     override.params(
       start: T.nilable(Integer),
@@ -65,9 +74,20 @@ class ActiveRecord::Relation
       batch_size: T.nilable(Integer),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: Elem).void)
-    ).returns(T::Array[Elem])
+    ).returns(T::Enumerator[Elem])
   end
   def find_each(start: nil, finish: nil, batch_size: 1000, error_on_ignore: nil, &block); end
+
+  sig do
+    override.params(
+      start: T.nilable(Integer),
+      finish: T.nilable(Integer),
+      batch_size: T.nilable(Integer),
+      error_on_ignore: T.nilable(T::Boolean),
+      block: T.nilable(T.proc.params(e: T::Array[Elem]).void)
+    ).returns(T::Enumerator[T::Array[Elem]])
+  end
+  def find_in_batches(start: nil, finish: nil, batch_size: 1000, error_on_ignore: nil, &block); end
 
   sig { override.params(block: T.proc.params(e: Elem).void).returns(T::Array[Elem]) }
   def each(&block); end


### PR DESCRIPTION
- Add more assertions to the `sorbet_test_cases.rb`. Most have been commented out since sorbet-rails doesn't currently support them.
- Minor updates to `ActiveRecordRbiFormatter` to support some of the new assertions.

This is the first of a few PRs that I'll be spinning out of #308 to make it easier/possible to review.