### PR TITLE
Generate sigs for more build/create ActiveRecord methods

### DIFF
--- a/lib/sorbet-rails/active_record_rbi_formatter.rb
+++ b/lib/sorbet-rails/active_record_rbi_formatter.rb
@@ -127,13 +127,16 @@ class SorbetRails::ActiveRecordRbiFormatter
       )
     end
 
-    build_methods = %w(create create! new)
+    build_methods = %w(create create! new build first_or_create first_or_create! first_or_initialize)
     build_methods.each do |build_method|
+      # `build` method doesn't exist on the model, only on the relations
+      next if build_method == 'build' && class_method
+
       # This needs to match the generated method signature in activerecord.rbi and
       # in Rails 5.0 and 5.1 the param is a splat.
       if Rails.version =~ /^5\.(0|1)/ && %w(new build create create!).include?(build_method)
         param = Parameter.new("*args", type: "T.untyped")
-      elsif
+      else
         param = Parameter.new("attributes", type: "T.untyped", default: 'nil')
       end
 

--- a/spec/generators/sorbet_test_cases.rb
+++ b/spec/generators/sorbet_test_cases.rb
@@ -68,9 +68,9 @@ T.assert_type!(Wizard.find_or_create_by!(name: 'Harry Potter') { |w| T.assert_ty
 T.assert_type!(Wizard.new { |w| T.assert_type!(w, Wizard) }, Wizard)
 T.assert_type!(Wizard.create(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard)
 T.assert_type!(Wizard.create!(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard)
-# T.assert_type!(Wizard.first_or_create(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard) # Ignored until we add support
-# T.assert_type!(Wizard.first_or_create!(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard) # Ignored until we add support
-# T.assert_type!(Wizard.first_or_initialize { |w| T.assert_type!(w, Wizard) }, Wizard) # Ignored until we add support
+T.assert_type!(Wizard.first_or_create(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard)
+T.assert_type!(Wizard.first_or_create!(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard)
+T.assert_type!(Wizard.first_or_initialize { |w| T.assert_type!(w, Wizard) }, Wizard)
 Wizard.find_each { |w| T.assert_type!(w, Wizard) }
 T.assert_type!(Wizard.find_each, T::Enumerator[Wizard])
 Wizard.find_in_batches { |w| T.assert_type!(w, T::Array[Wizard]) }
@@ -100,12 +100,12 @@ T.assert_type!(Wizard.all.find_or_initialize_by(name: 'Harry Potter') { |w| T.as
 T.assert_type!(Wizard.all.find_or_create_by(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard)
 T.assert_type!(Wizard.all.find_or_create_by!(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard)
 T.assert_type!(Wizard.all.new { |w| T.assert_type!(w, Wizard) }, Wizard)
-# T.assert_type!(Wizard.all.build { |w| T.assert_type!(w, Wizard) }, Wizard) # Ignored until we add support
+T.assert_type!(Wizard.all.build { |w| T.assert_type!(w, Wizard) }, Wizard)
 T.assert_type!(Wizard.all.create(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard)
 T.assert_type!(Wizard.all.create!(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard)
-# T.assert_type!(Wizard.all.first_or_create(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard) # Ignored until we add support
-# T.assert_type!(Wizard.all.first_or_create!(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard) # Ignored until we add support
-# T.assert_type!(Wizard.all.first_or_initialize { |w| T.assert_type!(w, Wizard) }, Wizard) # Ignored until we add support
+T.assert_type!(Wizard.all.first_or_create(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard)
+T.assert_type!(Wizard.all.first_or_create!(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard)
+T.assert_type!(Wizard.all.first_or_initialize { |w| T.assert_type!(w, Wizard) }, Wizard)
 Wizard.all.find_each { |w| T.assert_type!(w, Wizard) }
 T.assert_type!(Wizard.all.find_each, T::Enumerator[Wizard])
 Wizard.all.find_in_batches { |w| T.assert_type!(w, T::Array[Wizard]) }

--- a/spec/support/v5.0/sorbet_test_cases.rb
+++ b/spec/support/v5.0/sorbet_test_cases.rb
@@ -68,9 +68,9 @@ T.assert_type!(Wizard.find_or_create_by!(name: 'Harry Potter') { |w| T.assert_ty
 T.assert_type!(Wizard.new { |w| T.assert_type!(w, Wizard) }, Wizard)
 T.assert_type!(Wizard.create(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard)
 T.assert_type!(Wizard.create!(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard)
-# T.assert_type!(Wizard.first_or_create(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard) # Ignored until we add support
-# T.assert_type!(Wizard.first_or_create!(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard) # Ignored until we add support
-# T.assert_type!(Wizard.first_or_initialize { |w| T.assert_type!(w, Wizard) }, Wizard) # Ignored until we add support
+T.assert_type!(Wizard.first_or_create(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard)
+T.assert_type!(Wizard.first_or_create!(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard)
+T.assert_type!(Wizard.first_or_initialize { |w| T.assert_type!(w, Wizard) }, Wizard)
 Wizard.find_each { |w| T.assert_type!(w, Wizard) }
 T.assert_type!(Wizard.find_each, T::Enumerator[Wizard])
 Wizard.find_in_batches { |w| T.assert_type!(w, T::Array[Wizard]) }
@@ -100,12 +100,12 @@ T.assert_type!(Wizard.all.find_or_initialize_by(name: 'Harry Potter') { |w| T.as
 T.assert_type!(Wizard.all.find_or_create_by(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard)
 T.assert_type!(Wizard.all.find_or_create_by!(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard)
 T.assert_type!(Wizard.all.new { |w| T.assert_type!(w, Wizard) }, Wizard)
-# T.assert_type!(Wizard.all.build { |w| T.assert_type!(w, Wizard) }, Wizard) # Ignored until we add support
+T.assert_type!(Wizard.all.build { |w| T.assert_type!(w, Wizard) }, Wizard)
 T.assert_type!(Wizard.all.create(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard)
 T.assert_type!(Wizard.all.create!(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard)
-# T.assert_type!(Wizard.all.first_or_create(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard) # Ignored until we add support
-# T.assert_type!(Wizard.all.first_or_create!(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard) # Ignored until we add support
-# T.assert_type!(Wizard.all.first_or_initialize { |w| T.assert_type!(w, Wizard) }, Wizard) # Ignored until we add support
+T.assert_type!(Wizard.all.first_or_create(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard)
+T.assert_type!(Wizard.all.first_or_create!(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard)
+T.assert_type!(Wizard.all.first_or_initialize { |w| T.assert_type!(w, Wizard) }, Wizard)
 Wizard.all.find_each { |w| T.assert_type!(w, Wizard) }
 T.assert_type!(Wizard.all.find_each, T::Enumerator[Wizard])
 Wizard.all.find_in_batches { |w| T.assert_type!(w, T::Array[Wizard]) }

--- a/spec/support/v5.1/sorbet_test_cases.rb
+++ b/spec/support/v5.1/sorbet_test_cases.rb
@@ -68,9 +68,9 @@ T.assert_type!(Wizard.find_or_create_by!(name: 'Harry Potter') { |w| T.assert_ty
 T.assert_type!(Wizard.new { |w| T.assert_type!(w, Wizard) }, Wizard)
 T.assert_type!(Wizard.create(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard)
 T.assert_type!(Wizard.create!(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard)
-# T.assert_type!(Wizard.first_or_create(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard) # Ignored until we add support
-# T.assert_type!(Wizard.first_or_create!(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard) # Ignored until we add support
-# T.assert_type!(Wizard.first_or_initialize { |w| T.assert_type!(w, Wizard) }, Wizard) # Ignored until we add support
+T.assert_type!(Wizard.first_or_create(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard)
+T.assert_type!(Wizard.first_or_create!(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard)
+T.assert_type!(Wizard.first_or_initialize { |w| T.assert_type!(w, Wizard) }, Wizard)
 Wizard.find_each { |w| T.assert_type!(w, Wizard) }
 T.assert_type!(Wizard.find_each, T::Enumerator[Wizard])
 Wizard.find_in_batches { |w| T.assert_type!(w, T::Array[Wizard]) }
@@ -100,12 +100,12 @@ T.assert_type!(Wizard.all.find_or_initialize_by(name: 'Harry Potter') { |w| T.as
 T.assert_type!(Wizard.all.find_or_create_by(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard)
 T.assert_type!(Wizard.all.find_or_create_by!(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard)
 T.assert_type!(Wizard.all.new { |w| T.assert_type!(w, Wizard) }, Wizard)
-# T.assert_type!(Wizard.all.build { |w| T.assert_type!(w, Wizard) }, Wizard) # Ignored until we add support
+T.assert_type!(Wizard.all.build { |w| T.assert_type!(w, Wizard) }, Wizard)
 T.assert_type!(Wizard.all.create(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard)
 T.assert_type!(Wizard.all.create!(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard)
-# T.assert_type!(Wizard.all.first_or_create(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard) # Ignored until we add support
-# T.assert_type!(Wizard.all.first_or_create!(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard) # Ignored until we add support
-# T.assert_type!(Wizard.all.first_or_initialize { |w| T.assert_type!(w, Wizard) }, Wizard) # Ignored until we add support
+T.assert_type!(Wizard.all.first_or_create(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard)
+T.assert_type!(Wizard.all.first_or_create!(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard)
+T.assert_type!(Wizard.all.first_or_initialize { |w| T.assert_type!(w, Wizard) }, Wizard)
 Wizard.all.find_each { |w| T.assert_type!(w, Wizard) }
 T.assert_type!(Wizard.all.find_each, T::Enumerator[Wizard])
 Wizard.all.find_in_batches { |w| T.assert_type!(w, T::Array[Wizard]) }

--- a/spec/support/v5.2/sorbet_test_cases.rb
+++ b/spec/support/v5.2/sorbet_test_cases.rb
@@ -68,9 +68,9 @@ T.assert_type!(Wizard.find_or_create_by!(name: 'Harry Potter') { |w| T.assert_ty
 T.assert_type!(Wizard.new { |w| T.assert_type!(w, Wizard) }, Wizard)
 T.assert_type!(Wizard.create(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard)
 T.assert_type!(Wizard.create!(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard)
-# T.assert_type!(Wizard.first_or_create(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard) # Ignored until we add support
-# T.assert_type!(Wizard.first_or_create!(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard) # Ignored until we add support
-# T.assert_type!(Wizard.first_or_initialize { |w| T.assert_type!(w, Wizard) }, Wizard) # Ignored until we add support
+T.assert_type!(Wizard.first_or_create(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard)
+T.assert_type!(Wizard.first_or_create!(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard)
+T.assert_type!(Wizard.first_or_initialize { |w| T.assert_type!(w, Wizard) }, Wizard)
 Wizard.find_each { |w| T.assert_type!(w, Wizard) }
 T.assert_type!(Wizard.find_each, T::Enumerator[Wizard])
 Wizard.find_in_batches { |w| T.assert_type!(w, T::Array[Wizard]) }
@@ -100,12 +100,12 @@ T.assert_type!(Wizard.all.find_or_initialize_by(name: 'Harry Potter') { |w| T.as
 T.assert_type!(Wizard.all.find_or_create_by(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard)
 T.assert_type!(Wizard.all.find_or_create_by!(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard)
 T.assert_type!(Wizard.all.new { |w| T.assert_type!(w, Wizard) }, Wizard)
-# T.assert_type!(Wizard.all.build { |w| T.assert_type!(w, Wizard) }, Wizard) # Ignored until we add support
+T.assert_type!(Wizard.all.build { |w| T.assert_type!(w, Wizard) }, Wizard)
 T.assert_type!(Wizard.all.create(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard)
 T.assert_type!(Wizard.all.create!(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard)
-# T.assert_type!(Wizard.all.first_or_create(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard) # Ignored until we add support
-# T.assert_type!(Wizard.all.first_or_create!(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard) # Ignored until we add support
-# T.assert_type!(Wizard.all.first_or_initialize { |w| T.assert_type!(w, Wizard) }, Wizard) # Ignored until we add support
+T.assert_type!(Wizard.all.first_or_create(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard)
+T.assert_type!(Wizard.all.first_or_create!(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard)
+T.assert_type!(Wizard.all.first_or_initialize { |w| T.assert_type!(w, Wizard) }, Wizard)
 Wizard.all.find_each { |w| T.assert_type!(w, Wizard) }
 T.assert_type!(Wizard.all.find_each, T::Enumerator[Wizard])
 Wizard.all.find_in_batches { |w| T.assert_type!(w, T::Array[Wizard]) }

--- a/spec/support/v6.0/sorbet_test_cases.rb
+++ b/spec/support/v6.0/sorbet_test_cases.rb
@@ -68,9 +68,9 @@ T.assert_type!(Wizard.find_or_create_by!(name: 'Harry Potter') { |w| T.assert_ty
 T.assert_type!(Wizard.new { |w| T.assert_type!(w, Wizard) }, Wizard)
 T.assert_type!(Wizard.create(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard)
 T.assert_type!(Wizard.create!(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard)
-# T.assert_type!(Wizard.first_or_create(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard) # Ignored until we add support
-# T.assert_type!(Wizard.first_or_create!(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard) # Ignored until we add support
-# T.assert_type!(Wizard.first_or_initialize { |w| T.assert_type!(w, Wizard) }, Wizard) # Ignored until we add support
+T.assert_type!(Wizard.first_or_create(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard)
+T.assert_type!(Wizard.first_or_create!(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard)
+T.assert_type!(Wizard.first_or_initialize { |w| T.assert_type!(w, Wizard) }, Wizard)
 Wizard.find_each { |w| T.assert_type!(w, Wizard) }
 T.assert_type!(Wizard.find_each, T::Enumerator[Wizard])
 Wizard.find_in_batches { |w| T.assert_type!(w, T::Array[Wizard]) }
@@ -100,12 +100,12 @@ T.assert_type!(Wizard.all.find_or_initialize_by(name: 'Harry Potter') { |w| T.as
 T.assert_type!(Wizard.all.find_or_create_by(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard)
 T.assert_type!(Wizard.all.find_or_create_by!(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard)
 T.assert_type!(Wizard.all.new { |w| T.assert_type!(w, Wizard) }, Wizard)
-# T.assert_type!(Wizard.all.build { |w| T.assert_type!(w, Wizard) }, Wizard) # Ignored until we add support
+T.assert_type!(Wizard.all.build { |w| T.assert_type!(w, Wizard) }, Wizard)
 T.assert_type!(Wizard.all.create(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard)
 T.assert_type!(Wizard.all.create!(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard)
-# T.assert_type!(Wizard.all.first_or_create(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard) # Ignored until we add support
-# T.assert_type!(Wizard.all.first_or_create!(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard) # Ignored until we add support
-# T.assert_type!(Wizard.all.first_or_initialize { |w| T.assert_type!(w, Wizard) }, Wizard) # Ignored until we add support
+T.assert_type!(Wizard.all.first_or_create(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard)
+T.assert_type!(Wizard.all.first_or_create!(name: 'Harry Potter') { |w| T.assert_type!(w, Wizard) }, Wizard)
+T.assert_type!(Wizard.all.first_or_initialize { |w| T.assert_type!(w, Wizard) }, Wizard)
 Wizard.all.find_each { |w| T.assert_type!(w, Wizard) }
 T.assert_type!(Wizard.all.find_each, T::Enumerator[Wizard])
 Wizard.all.find_in_batches { |w| T.assert_type!(w, T::Array[Wizard]) }

--- a/spec/test_data/v5.0/expected_active_record_base.rbi
+++ b/spec/test_data/v5.0/expected_active_record_base.rbi
@@ -65,6 +65,15 @@ class ActiveRecord::Base
   sig { params(args: T.untyped, block: T.nilable(T.proc.params(object: T.attached_class).void)).returns(T.attached_class) }
   def self.new(*args, &block); end
 
+  sig { params(attributes: T.untyped, block: T.nilable(T.proc.params(object: T.attached_class).void)).returns(T.attached_class) }
+  def self.first_or_create(attributes = nil, &block); end
+
+  sig { params(attributes: T.untyped, block: T.nilable(T.proc.params(object: T.attached_class).void)).returns(T.attached_class) }
+  def self.first_or_create!(attributes = nil, &block); end
+
+  sig { params(attributes: T.untyped, block: T.nilable(T.proc.params(object: T.attached_class).void)).returns(T.attached_class) }
+  def self.first_or_initialize(attributes = nil, &block); end
+
   sig do
     override.params(
       start: T.nilable(Integer),

--- a/spec/test_data/v5.0/expected_active_record_relation.rbi
+++ b/spec/test_data/v5.0/expected_active_record_relation.rbi
@@ -67,6 +67,18 @@ class ActiveRecord::Relation
   sig { params(args: T.untyped, block: T.nilable(T.proc.params(object: Elem).void)).returns(Elem) }
   def new(*args, &block); end
 
+  sig { params(args: T.untyped, block: T.nilable(T.proc.params(object: Elem).void)).returns(Elem) }
+  def build(*args, &block); end
+
+  sig { params(attributes: T.untyped, block: T.nilable(T.proc.params(object: Elem).void)).returns(Elem) }
+  def first_or_create(attributes = nil, &block); end
+
+  sig { params(attributes: T.untyped, block: T.nilable(T.proc.params(object: Elem).void)).returns(Elem) }
+  def first_or_create!(attributes = nil, &block); end
+
+  sig { params(attributes: T.untyped, block: T.nilable(T.proc.params(object: Elem).void)).returns(Elem) }
+  def first_or_initialize(attributes = nil, &block); end
+
   sig do
     override.params(
       start: T.nilable(Integer),

--- a/spec/test_data/v5.1/expected_active_record_base.rbi
+++ b/spec/test_data/v5.1/expected_active_record_base.rbi
@@ -65,6 +65,15 @@ class ActiveRecord::Base
   sig { params(args: T.untyped, block: T.nilable(T.proc.params(object: T.attached_class).void)).returns(T.attached_class) }
   def self.new(*args, &block); end
 
+  sig { params(attributes: T.untyped, block: T.nilable(T.proc.params(object: T.attached_class).void)).returns(T.attached_class) }
+  def self.first_or_create(attributes = nil, &block); end
+
+  sig { params(attributes: T.untyped, block: T.nilable(T.proc.params(object: T.attached_class).void)).returns(T.attached_class) }
+  def self.first_or_create!(attributes = nil, &block); end
+
+  sig { params(attributes: T.untyped, block: T.nilable(T.proc.params(object: T.attached_class).void)).returns(T.attached_class) }
+  def self.first_or_initialize(attributes = nil, &block); end
+
   sig do
     override.params(
       start: T.nilable(Integer),

--- a/spec/test_data/v5.1/expected_active_record_relation.rbi
+++ b/spec/test_data/v5.1/expected_active_record_relation.rbi
@@ -67,6 +67,18 @@ class ActiveRecord::Relation
   sig { params(args: T.untyped, block: T.nilable(T.proc.params(object: Elem).void)).returns(Elem) }
   def new(*args, &block); end
 
+  sig { params(args: T.untyped, block: T.nilable(T.proc.params(object: Elem).void)).returns(Elem) }
+  def build(*args, &block); end
+
+  sig { params(attributes: T.untyped, block: T.nilable(T.proc.params(object: Elem).void)).returns(Elem) }
+  def first_or_create(attributes = nil, &block); end
+
+  sig { params(attributes: T.untyped, block: T.nilable(T.proc.params(object: Elem).void)).returns(Elem) }
+  def first_or_create!(attributes = nil, &block); end
+
+  sig { params(attributes: T.untyped, block: T.nilable(T.proc.params(object: Elem).void)).returns(Elem) }
+  def first_or_initialize(attributes = nil, &block); end
+
   sig do
     override.params(
       start: T.nilable(Integer),

--- a/spec/test_data/v5.2/expected_active_record_base.rbi
+++ b/spec/test_data/v5.2/expected_active_record_base.rbi
@@ -65,6 +65,15 @@ class ActiveRecord::Base
   sig { params(attributes: T.untyped, block: T.nilable(T.proc.params(object: T.attached_class).void)).returns(T.attached_class) }
   def self.new(attributes = nil, &block); end
 
+  sig { params(attributes: T.untyped, block: T.nilable(T.proc.params(object: T.attached_class).void)).returns(T.attached_class) }
+  def self.first_or_create(attributes = nil, &block); end
+
+  sig { params(attributes: T.untyped, block: T.nilable(T.proc.params(object: T.attached_class).void)).returns(T.attached_class) }
+  def self.first_or_create!(attributes = nil, &block); end
+
+  sig { params(attributes: T.untyped, block: T.nilable(T.proc.params(object: T.attached_class).void)).returns(T.attached_class) }
+  def self.first_or_initialize(attributes = nil, &block); end
+
   sig do
     override.params(
       start: T.nilable(Integer),

--- a/spec/test_data/v5.2/expected_active_record_relation.rbi
+++ b/spec/test_data/v5.2/expected_active_record_relation.rbi
@@ -67,6 +67,18 @@ class ActiveRecord::Relation
   sig { params(attributes: T.untyped, block: T.nilable(T.proc.params(object: Elem).void)).returns(Elem) }
   def new(attributes = nil, &block); end
 
+  sig { params(attributes: T.untyped, block: T.nilable(T.proc.params(object: Elem).void)).returns(Elem) }
+  def build(attributes = nil, &block); end
+
+  sig { params(attributes: T.untyped, block: T.nilable(T.proc.params(object: Elem).void)).returns(Elem) }
+  def first_or_create(attributes = nil, &block); end
+
+  sig { params(attributes: T.untyped, block: T.nilable(T.proc.params(object: Elem).void)).returns(Elem) }
+  def first_or_create!(attributes = nil, &block); end
+
+  sig { params(attributes: T.untyped, block: T.nilable(T.proc.params(object: Elem).void)).returns(Elem) }
+  def first_or_initialize(attributes = nil, &block); end
+
   sig do
     override.params(
       start: T.nilable(Integer),

--- a/spec/test_data/v6.0/expected_active_record_base.rbi
+++ b/spec/test_data/v6.0/expected_active_record_base.rbi
@@ -65,6 +65,15 @@ class ActiveRecord::Base
   sig { params(attributes: T.untyped, block: T.nilable(T.proc.params(object: T.attached_class).void)).returns(T.attached_class) }
   def self.new(attributes = nil, &block); end
 
+  sig { params(attributes: T.untyped, block: T.nilable(T.proc.params(object: T.attached_class).void)).returns(T.attached_class) }
+  def self.first_or_create(attributes = nil, &block); end
+
+  sig { params(attributes: T.untyped, block: T.nilable(T.proc.params(object: T.attached_class).void)).returns(T.attached_class) }
+  def self.first_or_create!(attributes = nil, &block); end
+
+  sig { params(attributes: T.untyped, block: T.nilable(T.proc.params(object: T.attached_class).void)).returns(T.attached_class) }
+  def self.first_or_initialize(attributes = nil, &block); end
+
   sig do
     override.params(
       start: T.nilable(Integer),

--- a/spec/test_data/v6.0/expected_active_record_relation.rbi
+++ b/spec/test_data/v6.0/expected_active_record_relation.rbi
@@ -67,6 +67,18 @@ class ActiveRecord::Relation
   sig { params(attributes: T.untyped, block: T.nilable(T.proc.params(object: Elem).void)).returns(Elem) }
   def new(attributes = nil, &block); end
 
+  sig { params(attributes: T.untyped, block: T.nilable(T.proc.params(object: Elem).void)).returns(Elem) }
+  def build(attributes = nil, &block); end
+
+  sig { params(attributes: T.untyped, block: T.nilable(T.proc.params(object: Elem).void)).returns(Elem) }
+  def first_or_create(attributes = nil, &block); end
+
+  sig { params(attributes: T.untyped, block: T.nilable(T.proc.params(object: Elem).void)).returns(Elem) }
+  def first_or_create!(attributes = nil, &block); end
+
+  sig { params(attributes: T.untyped, block: T.nilable(T.proc.params(object: Elem).void)).returns(Elem) }
+  def first_or_initialize(attributes = nil, &block); end
+
   sig do
     override.params(
       start: T.nilable(Integer),


### PR DESCRIPTION
Follow-up to #311. Generates RBI for `build`, `first_or_create`, `first_or_create!`, `first_or_initialize`.

NOTE: The first 3 commits here are from that branch, they'll go away once that is merged and I rebase.