### PR TITLE
Remove usage of typed override in tests

### DIFF
--- a/spec/generators/sorbet_test_cases.rb
+++ b/spec/generators/sorbet_test_cases.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 require 'sorbet-runtime'
 
 wand = Wand.first!

--- a/spec/sorbet_spec.rb
+++ b/spec/sorbet_spec.rb
@@ -49,6 +49,11 @@ RSpec.describe 'sorbet' do
       puts "================================="
     end
 
+    # Ensure sorbet_test_cases.rb is set to `typed: true` since srb init may
+    # set it to false.
+    sorbet_test_cases_path = Rails.root.join('sorbet_test_cases.rb')
+    File.write(sorbet_test_cases_path, File.read(sorbet_test_cases_path).gsub(/^# typed: \w+$/, "# typed: true"))
+
     # run sorbet-rails rake tasks
     Rake::Task['rails_rbi:all'].invoke
 
@@ -68,7 +73,7 @@ RSpec.describe 'sorbet' do
 
   it 'returns expected sorbet tc result' do
     stdout, stderr, status = Open3.capture3(
-      'bundle', 'exec', 'srb', 'tc', '--typed-override=typed-override.yaml',
+      'bundle', 'exec', 'srb', 'tc',
       chdir: Rails.root.to_path,
     )
     expected_file_path = 'expected_srb_tc_output.txt'

--- a/spec/support/v5.0/sorbet_test_cases.rb
+++ b/spec/support/v5.0/sorbet_test_cases.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 require 'sorbet-runtime'
 
 wand = Wand.first!

--- a/spec/support/v5.0/typed-override.yaml
+++ b/spec/support/v5.0/typed-override.yaml
@@ -1,2 +1,0 @@
-true:
-- ./sorbet_test_cases.rb

--- a/spec/support/v5.1/sorbet_test_cases.rb
+++ b/spec/support/v5.1/sorbet_test_cases.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 require 'sorbet-runtime'
 
 wand = Wand.first!

--- a/spec/support/v5.1/typed-override.yaml
+++ b/spec/support/v5.1/typed-override.yaml
@@ -1,2 +1,0 @@
-true:
-- ./sorbet_test_cases.rb

--- a/spec/support/v5.2/sorbet_test_cases.rb
+++ b/spec/support/v5.2/sorbet_test_cases.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 require 'sorbet-runtime'
 
 wand = Wand.first!

--- a/spec/support/v5.2/typed-override.yaml
+++ b/spec/support/v5.2/typed-override.yaml
@@ -1,2 +1,0 @@
-true:
-- ./sorbet_test_cases.rb

--- a/spec/support/v6.0/sorbet_test_cases.rb
+++ b/spec/support/v6.0/sorbet_test_cases.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 require 'sorbet-runtime'
 
 wand = Wand.first!

--- a/spec/support/v6.0/typed-override.yaml
+++ b/spec/support/v6.0/typed-override.yaml
@@ -1,2 +1,0 @@
-true:
-- ./sorbet_test_cases.rb


### PR DESCRIPTION
From this commit (https://github.com/chanzuckerberg/sorbet-rails/commit/14047ab3bade0ae5d74f93f5bcfde7064741192c) it appears the typed-override was used to prevent issues where `srb init` was setting `sorbet_test_cases.rb` to `typed: false`. I was running into the opposite issue where it was turning it from false to true. When that happens, `srb tc` would fail because it was raise an error saying we were using an unnecessary override.

This PR ensures `sorbet_test_cases.rb` is set to `typed: true` but does so via `gsub`.