### PR TITLE
[deprecation] add deprecation warning for fetch_typed, etc.

### DIFF
--- a/lib/sorbet-rails/custom_types/boolean_string.rb
+++ b/lib/sorbet-rails/custom_types/boolean_string.rb
@@ -1,4 +1,6 @@
 # typed: false
+require('sorbet-rails/deprecation.rb')
+
 module BooleanStringImpl
   def is_a?(type)
     return super unless type == BooleanString
@@ -17,6 +19,10 @@ module BooleanStringImpl
 
   def _is_a_boolean_string?
     return @cached_is_a unless @cached_is_a.nil?
+    SorbetRails::TypeAssertDeprecation.deprecation_warning(
+      :BooleanString,
+      'Use TypedParam with T::Boolean type instead.'
+    )
     @cached_is_a = (self =~ /^(true|false)$/i) == 0
   end
 end
@@ -27,6 +33,10 @@ end
 
 class BooleanString < String
   def self.===(other)
+    SorbetRails::TypeAssertDeprecation.deprecation_warning(
+      :BooleanString,
+      'Use TypedParam with T::Boolean type instead.'
+    )
     other.is_a?(BooleanString)
   end
 end

--- a/lib/sorbet-rails/custom_types/integer_string.rb
+++ b/lib/sorbet-rails/custom_types/integer_string.rb
@@ -1,4 +1,6 @@
 # typed: false
+require('sorbet-rails/deprecation.rb')
+
 module IntegerStringImpl
   def is_a?(type)
     return super unless type == IntegerString
@@ -17,6 +19,10 @@ module IntegerStringImpl
 
   def _is_a_integer_string?
     return @cached_is_a unless @cached_is_a.nil?
+    SorbetRails::TypeAssertDeprecation.deprecation_warning(
+      :IntegerString,
+      'Use TypedParams with Integer type instead.'
+    )
     Integer(self, 10)
     @cached_is_a = true
   rescue ArgumentError => err
@@ -30,6 +36,10 @@ end
 
 class IntegerString < String
   def self.===(other)
+    SorbetRails::TypeAssertDeprecation.deprecation_warning(
+      :IntegerString,
+      'Use TypedParams with Integer type instead.'
+    )
     other.is_a?(IntegerString)
   end
 end

--- a/lib/sorbet-rails/deprecation.rb
+++ b/lib/sorbet-rails/deprecation.rb
@@ -1,0 +1,5 @@
+require 'active_support/deprecation'
+
+module SorbetRails
+  TypeAssertDeprecation = ActiveSupport::Deprecation.new('0.7', 'SorbetRails')
+end

--- a/lib/sorbet-rails/rails_mixins/custom_params_methods.rb
+++ b/lib/sorbet-rails/rails_mixins/custom_params_methods.rb
@@ -1,5 +1,6 @@
 # typed: false
 require 'sorbet-runtime'
+require('sorbet-rails/deprecation.rb')
 
 module SorbetRails::CustomParamsMethods
   include Kernel
@@ -16,6 +17,11 @@ module SorbetRails::CustomParamsMethods
     returns(T.type_parameter(:U))
   }
   def require_typed(key, ta)
+    SorbetRails::TypeAssertDeprecation.deprecation_warning(
+      :require_typed,
+      'Use TypedParams with a T::Struct represents the type of each parameters.'
+    )
+
     val = require(key)
     ta.assert(val)
   rescue TypeError
@@ -35,6 +41,11 @@ module SorbetRails::CustomParamsMethods
     returns(T.type_parameter(:U))
   }
   def fetch_typed(key, ta, *args)
+    SorbetRails::TypeAssertDeprecation.deprecation_warning(
+      :fetch_typed,
+      'Use TypedParams with a T::Struct represents the type of each parameters.'
+    )
+
     val = fetch(key, *args)
     ta.assert(val)
   rescue TypeError


### PR DESCRIPTION
I think `TypedParams` provide a much neater API to do all conversion at once. It also helps converting boolean string or integer string to native ruby type.
Plus, we found through profiling that BooleanString and IntegerString incurs some cost in type-checking String, even when they are not used directly. This deprecation will help us getting rid of them as well.

Slated to remove them by v0.7, but issue a warning for now.

Test plan: spec shows the warning now!