### PR TITLE
Improve performance of model RBI generation

### DIFF
--- a/lib/sorbet-rails/model_plugins/active_record_named_scope.rb
+++ b/lib/sorbet-rails/model_plugins/active_record_named_scope.rb
@@ -7,15 +7,23 @@ class SorbetRails::ModelPlugins::ActiveRecordNamedScope < SorbetRails::ModelPlug
   def generate(root)
     model_class_rbi = root.create_class(self.model_class_name)
 
-    @model_class.methods.sort.each do |method_name|
+    # Named scope methods are dynamically defined by the `scope` method so their
+    # source_location is `lib/active_record/scoping/named.rb`. So we find scopes
+    # by two criteria:
+    # - they are defined in 'activerecord/lib/active_record/scoping/named.rb'
+    # - they are not one of the methods actually defined in that file's source.
+    #
+    # These methods are defined within `lib/active_record/scoping/named.rb` and should
+    # be ignored for the purposes of this plugin.
+    # See: https://github.com/rails/rails/blob/master/activerecord/lib/active_record/scoping/named.rb
+    non_dynamic_methods = %i(all scope_for_association default_scoped default_extensions scope valid_scope_name?)
+
+    (@model_class.methods - non_dynamic_methods).sort.each do |method_name|
       next unless SorbetRails::Utils.valid_method_name?(method_name.to_s)
+
       method_obj = @model_class.method(method_name)
       next unless method_obj.present? && method_obj.source_location.present?
-      # we detect sscopes defined in a model by 2 criteria:
-      # - they don't have an owner name
-      # - they are defined in 'activerecord/lib/active_record/scoping/named.rb'
-      # https://github.com/rails/rails/blob/master/activerecord/lib/active_record/scoping/named.rb
-      next unless method_obj.owner.name == nil
+
       source_file = method_obj.source_location[0]
       next unless source_file.include?("lib/active_record/scoping/named.rb")
 

--- a/lib/sorbet-rails/model_plugins/active_record_named_scope.rb
+++ b/lib/sorbet-rails/model_plugins/active_record_named_scope.rb
@@ -12,11 +12,12 @@ class SorbetRails::ModelPlugins::ActiveRecordNamedScope < SorbetRails::ModelPlug
     # by two criteria:
     # - they are defined in 'activerecord/lib/active_record/scoping/named.rb'
     # - they are not one of the methods actually defined in that file's source.
-    #
-    # These methods are defined within `lib/active_record/scoping/named.rb` and should
-    # be ignored for the purposes of this plugin.
     # See: https://github.com/rails/rails/blob/master/activerecord/lib/active_record/scoping/named.rb
-    non_dynamic_methods = %i(all scope_for_association default_scoped default_extensions scope valid_scope_name?)
+    non_dynamic_methods = (
+      ActiveRecord::Scoping::Named::ClassMethods.instance_methods +
+      ActiveRecord::Scoping::Named::ClassMethods.protected_instance_methods +
+      ActiveRecord::Scoping::Named::ClassMethods.private_instance_methods
+    )
 
     (@model_class.methods - non_dynamic_methods).sort.each do |method_name|
       next unless SorbetRails::Utils.valid_method_name?(method_name.to_s)

--- a/lib/sorbet-rails/tasks/rails_rbi.rake
+++ b/lib/sorbet-rails/tasks/rails_rbi.rake
@@ -77,11 +77,19 @@ namespace :rails_rbi do
       models_to_generate = models_to_generate - blacklisted_models
     end
 
-    generated_rbis = generate_rbis_for_models(models_to_generate, all_models)
-    generated_rbis.each do |model_name, contents|
-      file_path = Rails.root.join("sorbet", "rails-rbi", "models", "#{model_name.underscore}.rbi")
-      FileUtils.mkdir_p(File.dirname(file_path))
-      File.write(file_path, contents)
+    available_class_names = Set.new(all_models.map { |c| c.name })
+    models_to_generate.each do |model_class|
+      model_class_name = model_class.to_s
+      begin
+        formatter = SorbetRails::ModelRbiFormatter.new(model_class, available_class_names)
+        file_path = Rails.root.join("sorbet", "rails-rbi", "models", "#{model_class_name.underscore}.rbi")
+        FileUtils.mkdir_p(File.dirname(file_path))
+        File.write(file_path, formatter.generate_rbi)
+      rescue StandardError, NotImplementedError => ex
+        puts "---"
+        puts "Error when handling model #{model_class_name}: #{ex}"
+        nil
+      end
     end
   end
 
@@ -143,22 +151,6 @@ namespace :rails_rbi do
       FileUtils.mkdir_p(File.dirname(file_path))
       File.write(file_path, formatter.generate_rbi)
     end
-  end
-
-  def generate_rbis_for_models(model_classes, available_classes)
-    available_class_names = Set.new(available_classes.map { |c| c.name })
-    formatted = model_classes.map do |model_class|
-      model_class_name = model_class.to_s
-      begin
-        formatter = SorbetRails::ModelRbiFormatter.new(model_class, available_class_names)
-        [model_class_name, formatter.generate_rbi]
-      rescue StandardError, NotImplementedError => ex
-        puts "---"
-        puts "Error when handling model #{model_class_name}: #{ex}"
-        nil
-      end
-    end
-    Hash[formatted.compact] # remove models with errors
   end
 
   def blacklisted_models


### PR DESCRIPTION
This PR does two things that improve performance and memory usage:
- Write the model RBI after each loop. Previously we were generating all the model RBIs and storing the strings inside of an array and then once we generated it all we were writing it out to files. This is pretty inefficient from a memory perspective which likely leads to a performance hit as well.
- Speed up the `ActiveRecordNamedScope` plugin. I instrumented the plugins (just took `Time.now` before and after and printed it out) and was getting an average of ~4.5s for the ActiveRecordNamedScope. I found the culprit (`method_obj.owner.name` was very expensive for some reason 🤷) and took the time down to an average of 0.03s 🔥.

I ran this against my company's codebase with ~750 models.

**Before**
Using `0.6.3` I actually never got a full time because it was taking too long so I killed it. It was definitely longer than 10 minutes

**After**
Using this branch:
```
$ time bin/rails rails_rbi:all
... output ...

real	3m23.620s
user	2m37.853s
sys	0m21.239s
```