### PR TITLE
Loosen assoc_should_be_untyped check

### DIFF
--- a/lib/sorbet-rails/model_plugins/active_record_assoc.rb
+++ b/lib/sorbet-rails/model_plugins/active_record_assoc.rb
@@ -130,7 +130,15 @@ class SorbetRails::ModelPlugins::ActiveRecordAssoc < SorbetRails::ModelPlugins::
 
   sig { params(reflection: T.untyped).returns(T.nilable(T::Boolean)) }
   def assoc_should_be_untyped?(reflection)
-    polymorphic_assoc?(reflection) || !@available_classes.include?(reflection.klass.name)
+    # For some polymorphic associations (e.g. a has-many-through where the `source`
+    # is polymorphic) we can figure out the type from the class_name or source_type.
+    polymorpic_with_unknowable_klass = (
+      polymorphic_assoc?(reflection) &&
+      !reflection.options.key?(:class_name) &&
+      !reflection.options.key?(:source_type)
+    )
+
+    polymorpic_with_unknowable_klass || !@available_classes.include?(reflection.klass.name)
   end
 
   sig { params(reflection: T.untyped).returns(T.nilable(T::Boolean)) }


### PR DESCRIPTION
I had a model with associations like:
```
has_many :liabilities
has_many :payroll_taxes, through: :liabilities, source: :liability, source_type: 'PayrollTax'
```

This means that payroll_taxes is a "has many through" association where the join table is polymorphic so sorbet-rails was generating:
```ruby
sig { returns(ActiveRecord::Associations::CollectionProxy) }
def payroll_taxes; end
```

I would expect:
```ruby
sig { returns(::PayrollTax::ActiveRecord_Associations_CollectionProxy) }
def payroll_taxes; end
```

This was because it was using logic when checking if the reflection was polymorphic that said "is this a has-many-through? then check if the join table is polymorphic". I don't quite get that logic. In this case it shouldn't matter that the join table is polymorphic (in fact, I actually hadn't realized it was until this came up 😬).

Maybe there's a case you've run into that I'm not considering? If so we should figure out how to handle both ideally 🙂 If not then this PR simplifies the logic a bit.
