### PR TITLE
Move query methods to module

### DIFF
--- a/lib/sorbet-rails/gem_plugins/active_flag_plugin.rb
+++ b/lib/sorbet-rails/gem_plugins/active_flag_plugin.rb
@@ -7,7 +7,6 @@ class ActiveFlagPlugin < SorbetRails::ModelPlugins::Base
 
     module_name = self.model_module_name("GeneratedActiveFlagMethods")
     module_rbi = root.create_module(module_name)
-    module_rbi.create_extend("T::Sig")
 
     model_class_rbi = root.create_class(self.model_class_name)
     model_class_rbi.create_include(module_name)

--- a/lib/sorbet-rails/gem_plugins/paperclip_plugin.rb
+++ b/lib/sorbet-rails/gem_plugins/paperclip_plugin.rb
@@ -8,7 +8,6 @@ class PaperclipPlugin < SorbetRails::ModelPlugins::Base
 
     module_name = self.model_module_name("GeneratedPaperclipMethods")
     module_rbi = root.create_module(module_name)
-    module_rbi.create_extend("T::Sig")
 
     model_class_rbi = root.create_class(self.model_class_name)
     model_class_rbi.create_include(module_name)

--- a/lib/sorbet-rails/model_plugins/active_record_assoc.rb
+++ b/lib/sorbet-rails/model_plugins/active_record_assoc.rb
@@ -13,7 +13,6 @@ class SorbetRails::ModelPlugins::ActiveRecordAssoc < SorbetRails::ModelPlugins::
 
     assoc_module_name = self.model_module_name("GeneratedAssociationMethods")
     assoc_module_rbi = root.create_module(assoc_module_name)
-    assoc_module_rbi.create_extend("T::Sig")
 
     model_class_rbi = root.create_class(self.model_class_name)
     model_class_rbi.create_include(assoc_module_name)

--- a/lib/sorbet-rails/model_plugins/active_record_attribute.rb
+++ b/lib/sorbet-rails/model_plugins/active_record_attribute.rb
@@ -26,7 +26,6 @@ class SorbetRails::ModelPlugins::ActiveRecordAttribute < SorbetRails::ModelPlugi
 
     attribute_module_name = self.model_module_name("GeneratedAttributeMethods")
     attribute_module_rbi = root.create_module(attribute_module_name)
-    attribute_module_rbi.create_extend("T::Sig")
 
     model_class_rbi = root.create_class(self.model_class_name)
     model_class_rbi.create_include(attribute_module_name)

--- a/lib/sorbet-rails/model_plugins/active_record_enum.rb
+++ b/lib/sorbet-rails/model_plugins/active_record_enum.rb
@@ -9,7 +9,6 @@ class SorbetRails::ModelPlugins::ActiveRecordEnum < SorbetRails::ModelPlugins::B
 
     enum_module_name = model_module_name("EnumInstanceMethods")
     enum_module_rbi = root.create_module(enum_module_name)
-    enum_module_rbi.create_extend("T::Sig")
 
     model_class_rbi = root.create_class(self.model_class_name)
     model_class_rbi.create_include(enum_module_name)

--- a/lib/sorbet-rails/model_plugins/active_record_querying.rb
+++ b/lib/sorbet-rails/model_plugins/active_record_querying.rb
@@ -9,7 +9,7 @@ class SorbetRails::ModelPlugins::ActiveRecordQuerying < SorbetRails::ModelPlugin
     add_relation_query_method(
       root,
       "all",
-      standard_query_method: true,
+      builtin_query_method: true,
     )
     add_relation_query_method(
       root,
@@ -17,7 +17,7 @@ class SorbetRails::ModelPlugins::ActiveRecordQuerying < SorbetRails::ModelPlugin
       parameters: [
         Parameter.new("&block", type: "T.nilable(T.proc.void)"),
       ],
-      standard_query_method: true,
+      builtin_query_method: true,
     )
 
     # It's not possible to typedef all methods in ActiveRecord::Querying module to have the
@@ -36,7 +36,7 @@ class SorbetRails::ModelPlugins::ActiveRecordQuerying < SorbetRails::ModelPlugin
         parameters: [
           Parameter.new("*args", type: "T.untyped"),
         ],
-        standard_query_method: true,
+        builtin_query_method: true,
       ) if exists_class_method?(method_name)
     end
 
@@ -47,7 +47,7 @@ class SorbetRails::ModelPlugins::ActiveRecordQuerying < SorbetRails::ModelPlugin
         Parameter.new("*args", type: "T.untyped"),
         Parameter.new("&block", type: "T.nilable(T.proc.void)"),
       ],
-      standard_query_method: true,
+      builtin_query_method: true,
     )
   end
 end

--- a/lib/sorbet-rails/model_plugins/active_record_querying.rb
+++ b/lib/sorbet-rails/model_plugins/active_record_querying.rb
@@ -9,6 +9,7 @@ class SorbetRails::ModelPlugins::ActiveRecordQuerying < SorbetRails::ModelPlugin
     add_relation_query_method(
       root,
       "all",
+      standard_query_method: true,
     )
     add_relation_query_method(
       root,
@@ -16,6 +17,7 @@ class SorbetRails::ModelPlugins::ActiveRecordQuerying < SorbetRails::ModelPlugin
       parameters: [
         Parameter.new("&block", type: "T.nilable(T.proc.void)"),
       ],
+      standard_query_method: true,
     )
 
     # It's not possible to typedef all methods in ActiveRecord::Querying module to have the
@@ -34,6 +36,7 @@ class SorbetRails::ModelPlugins::ActiveRecordQuerying < SorbetRails::ModelPlugin
         parameters: [
           Parameter.new("*args", type: "T.untyped"),
         ],
+        standard_query_method: true,
       ) if exists_class_method?(method_name)
     end
 
@@ -43,7 +46,8 @@ class SorbetRails::ModelPlugins::ActiveRecordQuerying < SorbetRails::ModelPlugin
       parameters: [
         Parameter.new("*args", type: "T.untyped"),
         Parameter.new("&block", type: "T.nilable(T.proc.void)"),
-      ]
+      ],
+      standard_query_method: true,
     )
   end
 end

--- a/lib/sorbet-rails/model_rbi_formatter.rb
+++ b/lib/sorbet-rails/model_rbi_formatter.rb
@@ -75,8 +75,6 @@ class SorbetRails::ModelRbiFormatter
       superclass: "ActiveRecord::Relation",
     )
     model_relation_rbi.create_include(self.model_query_methods_returning_relation_module_name)
-    model_relation_rbi.create_extend("T::Sig")
-    model_relation_rbi.create_extend("T::Generic")
     model_relation_rbi.create_constant(
       "Elem",
       value: "type_member(fixed: #{model_class_name})",
@@ -87,8 +85,6 @@ class SorbetRails::ModelRbiFormatter
       superclass: "ActiveRecord::AssociationRelation",
     )
     model_assoc_relation_rbi.create_include(self.model_query_methods_returning_assoc_relation_module_name)
-    model_assoc_relation_rbi.create_extend("T::Sig")
-    model_assoc_relation_rbi.create_extend("T::Generic")
     model_assoc_relation_rbi.create_constant(
       "Elem",
       value: "type_member(fixed: #{model_class_name})",
@@ -99,8 +95,6 @@ class SorbetRails::ModelRbiFormatter
       superclass: "ActiveRecord::Associations::CollectionProxy",
     )
     collection_proxy_rbi.create_include(self.model_query_methods_returning_assoc_relation_module_name)
-    collection_proxy_rbi.create_extend("T::Sig")
-    collection_proxy_rbi.create_extend("T::Generic")
     collection_proxy_rbi.create_constant(
       "Elem",
       value: "type_member(fixed: #{self.model_class_name})",
@@ -111,8 +105,6 @@ class SorbetRails::ModelRbiFormatter
       superclass: T.must(@model_class.superclass).name,
     )
     model_rbi.create_extend(self.model_query_methods_returning_relation_module_name)
-    model_rbi.create_extend("T::Sig")
-    model_rbi.create_extend("T::Generic")
     model_rbi.create_type_alias(
       self.model_relation_type_class_name,
       type: self.model_relation_type_alias

--- a/lib/sorbet-rails/model_rbi_formatter.rb
+++ b/lib/sorbet-rails/model_rbi_formatter.rb
@@ -74,6 +74,7 @@ class SorbetRails::ModelRbiFormatter
       self.model_relation_class_name,
       superclass: "ActiveRecord::Relation",
     )
+    model_relation_rbi.create_include(self.model_query_methods_returning_relation_module_name)
     model_relation_rbi.create_extend("T::Sig")
     model_relation_rbi.create_extend("T::Generic")
     model_relation_rbi.create_constant(
@@ -85,6 +86,7 @@ class SorbetRails::ModelRbiFormatter
       self.model_assoc_relation_class_name,
       superclass: "ActiveRecord::AssociationRelation",
     )
+    model_assoc_relation_rbi.create_include(self.model_query_methods_returning_assoc_relation_module_name)
     model_assoc_relation_rbi.create_extend("T::Sig")
     model_assoc_relation_rbi.create_extend("T::Generic")
     model_assoc_relation_rbi.create_constant(
@@ -96,6 +98,7 @@ class SorbetRails::ModelRbiFormatter
       self.model_assoc_proxy_class_name,
       superclass: "ActiveRecord::Associations::CollectionProxy",
     )
+    collection_proxy_rbi.create_include(self.model_query_methods_returning_assoc_relation_module_name)
     collection_proxy_rbi.create_extend("T::Sig")
     collection_proxy_rbi.create_extend("T::Generic")
     collection_proxy_rbi.create_constant(
@@ -107,6 +110,7 @@ class SorbetRails::ModelRbiFormatter
       self.model_class_name,
       superclass: T.must(@model_class.superclass).name,
     )
+    model_rbi.create_extend(self.model_query_methods_returning_relation_module_name)
     model_rbi.create_extend("T::Sig")
     model_rbi.create_extend("T::Generic")
     model_rbi.create_type_alias(

--- a/lib/sorbet-rails/model_utils.rb
+++ b/lib/sorbet-rails/model_utils.rb
@@ -83,10 +83,13 @@ module SorbetRails::ModelUtils
       root: Parlour::RbiGenerator::Namespace,
       method_name: String,
       parameters: T.nilable(T::Array[::Parlour::RbiGenerator::Parameter]),
-      standard_query_method: T::Boolean,
+      # This is meant to indicate the method is a rails-provided query method like
+      # where, limit, etc and not something like a named scope. It should likely
+      # only be set to `true` when called from the ActiveRecordQuerying plugin.
+      builtin_query_method: T::Boolean,
     ).void
   }
-  def add_relation_query_method(root, method_name, parameters: nil, standard_query_method: false)
+  def add_relation_query_method(root, method_name, parameters: nil, builtin_query_method: false)
     # a relation querying method will be available on
     # - model (as a class method)
     # - activerecord relation
@@ -103,7 +106,7 @@ module SorbetRails::ModelUtils
     # model. However, in Rails 5 query methods that come from scopes or enums
     # get overridden in hidden-definitions so we need to explicitly define them
     # on the model and relation classes.
-    if standard_query_method || Rails.version =~ /^6\./
+    if builtin_query_method || Rails.version =~ /^6\./
       relation_module_rbi = root.create_module(self.model_query_methods_returning_relation_module_name)
       relation_module_rbi.create_method(
         method_name,

--- a/spec/generators/rails-template.rb
+++ b/spec/generators/rails-template.rb
@@ -91,6 +91,8 @@ def create_models
         biology: 1,
         dark_art: 999,
       }
+
+      scope :recent, -> { where('created_at > ?', 1.month.ago) }
     end
   RUBY
 
@@ -133,7 +135,7 @@ def create_models
     class Wizard < ApplicationRecord
       validates :name, length: { minimum: 5 }, presence: true
       # simulate conditional validation
-      validates :parent_email, presence: true, if: -> { false }
+      validates :parent_email, presence: true, if: :Slytherin?
 
       typed_enum house: {
         Gryffindor: 0,
@@ -478,11 +480,6 @@ def create_jobs
 end
 
 def add_sorbet_test_files
-  file "typed-override.yaml", <<~YAML
-    true:
-    - ./sorbet_test_cases.rb
-  YAML
-
   copy_file "./sorbet_test_cases.rb", "sorbet_test_cases.rb"
 end
 

--- a/spec/generators/sorbet_test_cases.rb
+++ b/spec/generators/sorbet_test_cases.rb
@@ -29,26 +29,6 @@ T.assert_type!(T.must(wizard.wand).wizard, Wizard)
 T.assert_type!(wizard.spell_books, SpellBook::ActiveRecord_Associations_CollectionProxy)
 T.assert_type!(wizard.spell_book_ids, T::Array[Integer])
 
-# -- model relation
-# default
-T.assert_type!(Wizard.all, Wizard::ActiveRecord_Relation)
-
-# custom scope
-T.assert_type!(Wizard.recent, Wizard::ActiveRecord_Relation)
-
-# enum scope
-T.assert_type!(Wizard.Gryffindor, Wizard::ActiveRecord_Relation)
-
-# ActiveRecord Querying
-T.assert_type!(Wizard.Gryffindor.recent, Wizard::ActiveRecord_Relation)
-T.assert_type!(Wizard.Gryffindor.recent.unscoped, Wizard::ActiveRecord_Relation)
-T.assert_type!(Wizard.where(id: 1), Wizard::ActiveRecord_Relation)
-T.assert_type!(Wizard.where(id: 1).recent, Wizard::ActiveRecord_Relation)
-T.assert_type!(Wizard.where.not(id: 1), Wizard::ActiveRecord_Relation)
-T.assert_type!(Wizard.preload(:spell_books), Wizard::ActiveRecord_Relation)
-T.assert_type!(Wizard.eager_load(:spell_books), Wizard::ActiveRecord_Relation)
-T.assert_type!(Wizard.order(:id), Wizard::ActiveRecord_Relation)
-
 # Finder methods -- Model
 T.assert_type!(Wizard.exists?(name: 'Test'), T::Boolean)
 T.assert_type!(Wizard.find(wizard.id), Wizard)
@@ -90,6 +70,18 @@ T.assert_type!(Wizard.none?, T::Boolean)
 T.assert_type!(Wizard.one?, T::Boolean)
 # T.assert_type!(Wizard.update_all(name: 'Harry Potter'), Integer) # Ignored until we add support
 # T.assert_type!(Wizard.delete_all, Integer) # Ignored until we add support
+# Query methods
+T.assert_type!(Wizard.all, Wizard::ActiveRecord_Relation)
+T.assert_type!(Wizard.recent, Wizard::ActiveRecord_Relation) # Named scope
+T.assert_type!(Wizard.Gryffindor, Wizard::ActiveRecord_Relation) # Enum scope
+T.assert_type!(Wizard.Gryffindor.recent, Wizard::ActiveRecord_Relation)
+T.assert_type!(Wizard.Gryffindor.recent.unscoped, Wizard::ActiveRecord_Relation)
+T.assert_type!(Wizard.where(id: 1), Wizard::ActiveRecord_Relation)
+T.assert_type!(Wizard.where(id: 1).recent, Wizard::ActiveRecord_Relation)
+T.assert_type!(Wizard.where.not(id: 1), Wizard::ActiveRecord_Relation)
+T.assert_type!(Wizard.preload(:spell_books), Wizard::ActiveRecord_Relation)
+T.assert_type!(Wizard.eager_load(:spell_books), Wizard::ActiveRecord_Relation)
+T.assert_type!(Wizard.order(:id), Wizard::ActiveRecord_Relation)
 
 # Finder methods -- ActiveRecord::Relation
 T.assert_type!(Wizard.all.exists?(name: 'Harry Potter'), T::Boolean)
@@ -133,6 +125,18 @@ T.assert_type!(Wizard.all.none?, T::Boolean)
 T.assert_type!(Wizard.all.one?, T::Boolean)
 # T.assert_type!(Wizard.all.update_all(name: 'Harry Potter'), Integer) # Ignored until we add support
 # T.assert_type!(Wizard.all.delete_all, Integer) # Ignored until we add support
+# Query methods
+T.assert_type!(Wizard.all.all, Wizard::ActiveRecord_Relation)
+T.assert_type!(Wizard.all.recent, Wizard::ActiveRecord_Relation) # Named scope
+T.assert_type!(Wizard.all.Gryffindor, Wizard::ActiveRecord_Relation) # Enum scope
+T.assert_type!(Wizard.all.Gryffindor.recent, Wizard::ActiveRecord_Relation)
+T.assert_type!(Wizard.all.Gryffindor.recent.unscoped, Wizard::ActiveRecord_Relation)
+T.assert_type!(Wizard.all.where(id: 1), Wizard::ActiveRecord_Relation)
+T.assert_type!(Wizard.all.where(id: 1).recent, Wizard::ActiveRecord_Relation)
+T.assert_type!(Wizard.all.where.not(id: 1), Wizard::ActiveRecord_Relation)
+T.assert_type!(Wizard.all.preload(:spell_books), Wizard::ActiveRecord_Relation)
+T.assert_type!(Wizard.all.eager_load(:spell_books), Wizard::ActiveRecord_Relation)
+T.assert_type!(Wizard.all.order(:id), Wizard::ActiveRecord_Relation)
 # Enumerable methods
 Wizard.all.each { |w| T.assert_type!(w, Wizard) }
 Wizard.all.map { |w| T.assert_type!(w, Wizard) }
@@ -183,13 +187,18 @@ T.assert_type!(spell_books.none?, T::Boolean)
 T.assert_type!(spell_books.one?, T::Boolean)
 # T.assert_type!(spell_books.update_all(name: 'Fantastic Beasts'), Integer) # Ignored until we add support
 # T.assert_type!(spell_books.delete_all, Integer) # Ignored until we add support
-# CollectionProxy query also typed correctly!
+# Query methods
+T.assert_type!(spell_books.all, SpellBook::ActiveRecord_AssociationRelation)
+T.assert_type!(spell_books.recent, SpellBook::ActiveRecord_AssociationRelation) # Named scope
+T.assert_type!(spell_books.unclassified, SpellBook::ActiveRecord_AssociationRelation) # Enum scope
+T.assert_type!(spell_books.unclassified.recent, SpellBook::ActiveRecord_AssociationRelation)
+T.assert_type!(spell_books.unclassified.recent.unscoped, SpellBook::ActiveRecord_Relation) # Turns back into relation
 T.assert_type!(spell_books.where(id: 1), SpellBook::ActiveRecord_AssociationRelation)
+T.assert_type!(spell_books.where(id: 1).recent, SpellBook::ActiveRecord_AssociationRelation)
+T.assert_type!(spell_books.where.not(id: 1), SpellBook::ActiveRecord_AssociationRelation)
 T.assert_type!(spell_books.preload(:wizard), SpellBook::ActiveRecord_AssociationRelation)
 T.assert_type!(spell_books.eager_load(:wizard), SpellBook::ActiveRecord_AssociationRelation)
 T.assert_type!(spell_books.order(:id), SpellBook::ActiveRecord_AssociationRelation)
-T.assert_type!(spell_books.where.not(id: 1), SpellBook::ActiveRecord_AssociationRelation)
-T.assert_type!(spell_books.biology, SpellBook::ActiveRecord_AssociationRelation)
 # Enumerable methods
 spell_books.each { |s| T.assert_type!(s, SpellBook) }
 spell_books.map { |s| T.assert_type!(s, SpellBook) }
@@ -248,12 +257,18 @@ T.assert_type!(spell_books_query.none?, T::Boolean)
 T.assert_type!(spell_books_query.one?, T::Boolean)
 # T.assert_type!(spell_books_query.update_all(name: 'Fantastic Beasts'), Integer) # Ignored until we add support
 # T.assert_type!(spell_books_query.delete_all, Integer) # Ignored until we add support
-# Query chaining
+# Query methods
+T.assert_type!(spell_books_query.all, SpellBook::ActiveRecord_AssociationRelation)
+T.assert_type!(spell_books_query.recent, SpellBook::ActiveRecord_AssociationRelation) # Named scope
+T.assert_type!(spell_books_query.unclassified, SpellBook::ActiveRecord_AssociationRelation) # Enum scope
+T.assert_type!(spell_books_query.unclassified.recent, SpellBook::ActiveRecord_AssociationRelation)
+T.assert_type!(spell_books_query.unclassified.recent.unscoped, SpellBook::ActiveRecord_Relation) # Turns back into relation
+T.assert_type!(spell_books_query.where(id: 1), SpellBook::ActiveRecord_AssociationRelation)
+T.assert_type!(spell_books_query.where(id: 1).recent, SpellBook::ActiveRecord_AssociationRelation)
+T.assert_type!(spell_books_query.where.not(id: 1), SpellBook::ActiveRecord_AssociationRelation)
 T.assert_type!(spell_books_query.preload(:wizard), SpellBook::ActiveRecord_AssociationRelation)
 T.assert_type!(spell_books_query.eager_load(:wizard), SpellBook::ActiveRecord_AssociationRelation)
 T.assert_type!(spell_books_query.order(:id), SpellBook::ActiveRecord_AssociationRelation)
-T.assert_type!(spell_books_query.where.not(id: 1), SpellBook::ActiveRecord_AssociationRelation)
-T.assert_type!(spell_books_query.biology, SpellBook::ActiveRecord_AssociationRelation)
 # Enumerable methods
 spell_books_query.each { |s| T.assert_type!(s, SpellBook) }
 spell_books_query.map { |s| T.assert_type!(s, SpellBook) }

--- a/spec/support/v5.0/app/models/spell_book.rb
+++ b/spec/support/v5.0/app/models/spell_book.rb
@@ -13,4 +13,6 @@ class SpellBook < ApplicationRecord
     biology: 1,
     dark_art: 999,
   }
+
+  scope :recent, -> { where('created_at > ?', 1.month.ago) }
 end

--- a/spec/support/v5.0/app/models/wizard.rb
+++ b/spec/support/v5.0/app/models/wizard.rb
@@ -2,7 +2,7 @@
 class Wizard < ApplicationRecord
   validates :name, length: { minimum: 5 }, presence: true
   # simulate conditional validation
-  validates :parent_email, presence: true, if: -> { false }
+  validates :parent_email, presence: true, if: :Slytherin?
 
   typed_enum house: {
     Gryffindor: 0,

--- a/spec/support/v5.0/sorbet_test_cases.rb
+++ b/spec/support/v5.0/sorbet_test_cases.rb
@@ -29,26 +29,6 @@ T.assert_type!(T.must(wizard.wand).wizard, Wizard)
 T.assert_type!(wizard.spell_books, SpellBook::ActiveRecord_Associations_CollectionProxy)
 T.assert_type!(wizard.spell_book_ids, T::Array[Integer])
 
-# -- model relation
-# default
-T.assert_type!(Wizard.all, Wizard::ActiveRecord_Relation)
-
-# custom scope
-T.assert_type!(Wizard.recent, Wizard::ActiveRecord_Relation)
-
-# enum scope
-T.assert_type!(Wizard.Gryffindor, Wizard::ActiveRecord_Relation)
-
-# ActiveRecord Querying
-T.assert_type!(Wizard.Gryffindor.recent, Wizard::ActiveRecord_Relation)
-T.assert_type!(Wizard.Gryffindor.recent.unscoped, Wizard::ActiveRecord_Relation)
-T.assert_type!(Wizard.where(id: 1), Wizard::ActiveRecord_Relation)
-T.assert_type!(Wizard.where(id: 1).recent, Wizard::ActiveRecord_Relation)
-T.assert_type!(Wizard.where.not(id: 1), Wizard::ActiveRecord_Relation)
-T.assert_type!(Wizard.preload(:spell_books), Wizard::ActiveRecord_Relation)
-T.assert_type!(Wizard.eager_load(:spell_books), Wizard::ActiveRecord_Relation)
-T.assert_type!(Wizard.order(:id), Wizard::ActiveRecord_Relation)
-
 # Finder methods -- Model
 T.assert_type!(Wizard.exists?(name: 'Test'), T::Boolean)
 T.assert_type!(Wizard.find(wizard.id), Wizard)
@@ -90,6 +70,18 @@ T.assert_type!(Wizard.none?, T::Boolean)
 T.assert_type!(Wizard.one?, T::Boolean)
 # T.assert_type!(Wizard.update_all(name: 'Harry Potter'), Integer) # Ignored until we add support
 # T.assert_type!(Wizard.delete_all, Integer) # Ignored until we add support
+# Query methods
+T.assert_type!(Wizard.all, Wizard::ActiveRecord_Relation)
+T.assert_type!(Wizard.recent, Wizard::ActiveRecord_Relation) # Named scope
+T.assert_type!(Wizard.Gryffindor, Wizard::ActiveRecord_Relation) # Enum scope
+T.assert_type!(Wizard.Gryffindor.recent, Wizard::ActiveRecord_Relation)
+T.assert_type!(Wizard.Gryffindor.recent.unscoped, Wizard::ActiveRecord_Relation)
+T.assert_type!(Wizard.where(id: 1), Wizard::ActiveRecord_Relation)
+T.assert_type!(Wizard.where(id: 1).recent, Wizard::ActiveRecord_Relation)
+T.assert_type!(Wizard.where.not(id: 1), Wizard::ActiveRecord_Relation)
+T.assert_type!(Wizard.preload(:spell_books), Wizard::ActiveRecord_Relation)
+T.assert_type!(Wizard.eager_load(:spell_books), Wizard::ActiveRecord_Relation)
+T.assert_type!(Wizard.order(:id), Wizard::ActiveRecord_Relation)
 
 # Finder methods -- ActiveRecord::Relation
 T.assert_type!(Wizard.all.exists?(name: 'Harry Potter'), T::Boolean)
@@ -133,6 +125,18 @@ T.assert_type!(Wizard.all.none?, T::Boolean)
 T.assert_type!(Wizard.all.one?, T::Boolean)
 # T.assert_type!(Wizard.all.update_all(name: 'Harry Potter'), Integer) # Ignored until we add support
 # T.assert_type!(Wizard.all.delete_all, Integer) # Ignored until we add support
+# Query methods
+T.assert_type!(Wizard.all.all, Wizard::ActiveRecord_Relation)
+T.assert_type!(Wizard.all.recent, Wizard::ActiveRecord_Relation) # Named scope
+T.assert_type!(Wizard.all.Gryffindor, Wizard::ActiveRecord_Relation) # Enum scope
+T.assert_type!(Wizard.all.Gryffindor.recent, Wizard::ActiveRecord_Relation)
+T.assert_type!(Wizard.all.Gryffindor.recent.unscoped, Wizard::ActiveRecord_Relation)
+T.assert_type!(Wizard.all.where(id: 1), Wizard::ActiveRecord_Relation)
+T.assert_type!(Wizard.all.where(id: 1).recent, Wizard::ActiveRecord_Relation)
+T.assert_type!(Wizard.all.where.not(id: 1), Wizard::ActiveRecord_Relation)
+T.assert_type!(Wizard.all.preload(:spell_books), Wizard::ActiveRecord_Relation)
+T.assert_type!(Wizard.all.eager_load(:spell_books), Wizard::ActiveRecord_Relation)
+T.assert_type!(Wizard.all.order(:id), Wizard::ActiveRecord_Relation)
 # Enumerable methods
 Wizard.all.each { |w| T.assert_type!(w, Wizard) }
 Wizard.all.map { |w| T.assert_type!(w, Wizard) }
@@ -183,13 +187,18 @@ T.assert_type!(spell_books.none?, T::Boolean)
 T.assert_type!(spell_books.one?, T::Boolean)
 # T.assert_type!(spell_books.update_all(name: 'Fantastic Beasts'), Integer) # Ignored until we add support
 # T.assert_type!(spell_books.delete_all, Integer) # Ignored until we add support
-# CollectionProxy query also typed correctly!
+# Query methods
+T.assert_type!(spell_books.all, SpellBook::ActiveRecord_AssociationRelation)
+T.assert_type!(spell_books.recent, SpellBook::ActiveRecord_AssociationRelation) # Named scope
+T.assert_type!(spell_books.unclassified, SpellBook::ActiveRecord_AssociationRelation) # Enum scope
+T.assert_type!(spell_books.unclassified.recent, SpellBook::ActiveRecord_AssociationRelation)
+T.assert_type!(spell_books.unclassified.recent.unscoped, SpellBook::ActiveRecord_Relation) # Turns back into relation
 T.assert_type!(spell_books.where(id: 1), SpellBook::ActiveRecord_AssociationRelation)
+T.assert_type!(spell_books.where(id: 1).recent, SpellBook::ActiveRecord_AssociationRelation)
+T.assert_type!(spell_books.where.not(id: 1), SpellBook::ActiveRecord_AssociationRelation)
 T.assert_type!(spell_books.preload(:wizard), SpellBook::ActiveRecord_AssociationRelation)
 T.assert_type!(spell_books.eager_load(:wizard), SpellBook::ActiveRecord_AssociationRelation)
 T.assert_type!(spell_books.order(:id), SpellBook::ActiveRecord_AssociationRelation)
-T.assert_type!(spell_books.where.not(id: 1), SpellBook::ActiveRecord_AssociationRelation)
-T.assert_type!(spell_books.biology, SpellBook::ActiveRecord_AssociationRelation)
 # Enumerable methods
 spell_books.each { |s| T.assert_type!(s, SpellBook) }
 spell_books.map { |s| T.assert_type!(s, SpellBook) }
@@ -248,12 +257,18 @@ T.assert_type!(spell_books_query.none?, T::Boolean)
 T.assert_type!(spell_books_query.one?, T::Boolean)
 # T.assert_type!(spell_books_query.update_all(name: 'Fantastic Beasts'), Integer) # Ignored until we add support
 # T.assert_type!(spell_books_query.delete_all, Integer) # Ignored until we add support
-# Query chaining
+# Query methods
+T.assert_type!(spell_books_query.all, SpellBook::ActiveRecord_AssociationRelation)
+T.assert_type!(spell_books_query.recent, SpellBook::ActiveRecord_AssociationRelation) # Named scope
+T.assert_type!(spell_books_query.unclassified, SpellBook::ActiveRecord_AssociationRelation) # Enum scope
+T.assert_type!(spell_books_query.unclassified.recent, SpellBook::ActiveRecord_AssociationRelation)
+T.assert_type!(spell_books_query.unclassified.recent.unscoped, SpellBook::ActiveRecord_Relation) # Turns back into relation
+T.assert_type!(spell_books_query.where(id: 1), SpellBook::ActiveRecord_AssociationRelation)
+T.assert_type!(spell_books_query.where(id: 1).recent, SpellBook::ActiveRecord_AssociationRelation)
+T.assert_type!(spell_books_query.where.not(id: 1), SpellBook::ActiveRecord_AssociationRelation)
 T.assert_type!(spell_books_query.preload(:wizard), SpellBook::ActiveRecord_AssociationRelation)
 T.assert_type!(spell_books_query.eager_load(:wizard), SpellBook::ActiveRecord_AssociationRelation)
 T.assert_type!(spell_books_query.order(:id), SpellBook::ActiveRecord_AssociationRelation)
-T.assert_type!(spell_books_query.where.not(id: 1), SpellBook::ActiveRecord_AssociationRelation)
-T.assert_type!(spell_books_query.biology, SpellBook::ActiveRecord_AssociationRelation)
 # Enumerable methods
 spell_books_query.each { |s| T.assert_type!(s, SpellBook) }
 spell_books_query.map { |s| T.assert_type!(s, SpellBook) }

--- a/spec/support/v5.1/app/models/spell_book.rb
+++ b/spec/support/v5.1/app/models/spell_book.rb
@@ -13,4 +13,6 @@ class SpellBook < ApplicationRecord
     biology: 1,
     dark_art: 999,
   }
+
+  scope :recent, -> { where('created_at > ?', 1.month.ago) }
 end

--- a/spec/support/v5.1/app/models/wizard.rb
+++ b/spec/support/v5.1/app/models/wizard.rb
@@ -2,7 +2,7 @@
 class Wizard < ApplicationRecord
   validates :name, length: { minimum: 5 }, presence: true
   # simulate conditional validation
-  validates :parent_email, presence: true, if: -> { false }
+  validates :parent_email, presence: true, if: :Slytherin?
 
   typed_enum house: {
     Gryffindor: 0,

--- a/spec/support/v5.1/sorbet_test_cases.rb
+++ b/spec/support/v5.1/sorbet_test_cases.rb
@@ -29,26 +29,6 @@ T.assert_type!(T.must(wizard.wand).wizard, Wizard)
 T.assert_type!(wizard.spell_books, SpellBook::ActiveRecord_Associations_CollectionProxy)
 T.assert_type!(wizard.spell_book_ids, T::Array[Integer])
 
-# -- model relation
-# default
-T.assert_type!(Wizard.all, Wizard::ActiveRecord_Relation)
-
-# custom scope
-T.assert_type!(Wizard.recent, Wizard::ActiveRecord_Relation)
-
-# enum scope
-T.assert_type!(Wizard.Gryffindor, Wizard::ActiveRecord_Relation)
-
-# ActiveRecord Querying
-T.assert_type!(Wizard.Gryffindor.recent, Wizard::ActiveRecord_Relation)
-T.assert_type!(Wizard.Gryffindor.recent.unscoped, Wizard::ActiveRecord_Relation)
-T.assert_type!(Wizard.where(id: 1), Wizard::ActiveRecord_Relation)
-T.assert_type!(Wizard.where(id: 1).recent, Wizard::ActiveRecord_Relation)
-T.assert_type!(Wizard.where.not(id: 1), Wizard::ActiveRecord_Relation)
-T.assert_type!(Wizard.preload(:spell_books), Wizard::ActiveRecord_Relation)
-T.assert_type!(Wizard.eager_load(:spell_books), Wizard::ActiveRecord_Relation)
-T.assert_type!(Wizard.order(:id), Wizard::ActiveRecord_Relation)
-
 # Finder methods -- Model
 T.assert_type!(Wizard.exists?(name: 'Test'), T::Boolean)
 T.assert_type!(Wizard.find(wizard.id), Wizard)
@@ -90,6 +70,18 @@ T.assert_type!(Wizard.none?, T::Boolean)
 T.assert_type!(Wizard.one?, T::Boolean)
 # T.assert_type!(Wizard.update_all(name: 'Harry Potter'), Integer) # Ignored until we add support
 # T.assert_type!(Wizard.delete_all, Integer) # Ignored until we add support
+# Query methods
+T.assert_type!(Wizard.all, Wizard::ActiveRecord_Relation)
+T.assert_type!(Wizard.recent, Wizard::ActiveRecord_Relation) # Named scope
+T.assert_type!(Wizard.Gryffindor, Wizard::ActiveRecord_Relation) # Enum scope
+T.assert_type!(Wizard.Gryffindor.recent, Wizard::ActiveRecord_Relation)
+T.assert_type!(Wizard.Gryffindor.recent.unscoped, Wizard::ActiveRecord_Relation)
+T.assert_type!(Wizard.where(id: 1), Wizard::ActiveRecord_Relation)
+T.assert_type!(Wizard.where(id: 1).recent, Wizard::ActiveRecord_Relation)
+T.assert_type!(Wizard.where.not(id: 1), Wizard::ActiveRecord_Relation)
+T.assert_type!(Wizard.preload(:spell_books), Wizard::ActiveRecord_Relation)
+T.assert_type!(Wizard.eager_load(:spell_books), Wizard::ActiveRecord_Relation)
+T.assert_type!(Wizard.order(:id), Wizard::ActiveRecord_Relation)
 
 # Finder methods -- ActiveRecord::Relation
 T.assert_type!(Wizard.all.exists?(name: 'Harry Potter'), T::Boolean)
@@ -133,6 +125,18 @@ T.assert_type!(Wizard.all.none?, T::Boolean)
 T.assert_type!(Wizard.all.one?, T::Boolean)
 # T.assert_type!(Wizard.all.update_all(name: 'Harry Potter'), Integer) # Ignored until we add support
 # T.assert_type!(Wizard.all.delete_all, Integer) # Ignored until we add support
+# Query methods
+T.assert_type!(Wizard.all.all, Wizard::ActiveRecord_Relation)
+T.assert_type!(Wizard.all.recent, Wizard::ActiveRecord_Relation) # Named scope
+T.assert_type!(Wizard.all.Gryffindor, Wizard::ActiveRecord_Relation) # Enum scope
+T.assert_type!(Wizard.all.Gryffindor.recent, Wizard::ActiveRecord_Relation)
+T.assert_type!(Wizard.all.Gryffindor.recent.unscoped, Wizard::ActiveRecord_Relation)
+T.assert_type!(Wizard.all.where(id: 1), Wizard::ActiveRecord_Relation)
+T.assert_type!(Wizard.all.where(id: 1).recent, Wizard::ActiveRecord_Relation)
+T.assert_type!(Wizard.all.where.not(id: 1), Wizard::ActiveRecord_Relation)
+T.assert_type!(Wizard.all.preload(:spell_books), Wizard::ActiveRecord_Relation)
+T.assert_type!(Wizard.all.eager_load(:spell_books), Wizard::ActiveRecord_Relation)
+T.assert_type!(Wizard.all.order(:id), Wizard::ActiveRecord_Relation)
 # Enumerable methods
 Wizard.all.each { |w| T.assert_type!(w, Wizard) }
 Wizard.all.map { |w| T.assert_type!(w, Wizard) }
@@ -183,13 +187,18 @@ T.assert_type!(spell_books.none?, T::Boolean)
 T.assert_type!(spell_books.one?, T::Boolean)
 # T.assert_type!(spell_books.update_all(name: 'Fantastic Beasts'), Integer) # Ignored until we add support
 # T.assert_type!(spell_books.delete_all, Integer) # Ignored until we add support
-# CollectionProxy query also typed correctly!
+# Query methods
+T.assert_type!(spell_books.all, SpellBook::ActiveRecord_AssociationRelation)
+T.assert_type!(spell_books.recent, SpellBook::ActiveRecord_AssociationRelation) # Named scope
+T.assert_type!(spell_books.unclassified, SpellBook::ActiveRecord_AssociationRelation) # Enum scope
+T.assert_type!(spell_books.unclassified.recent, SpellBook::ActiveRecord_AssociationRelation)
+T.assert_type!(spell_books.unclassified.recent.unscoped, SpellBook::ActiveRecord_Relation) # Turns back into relation
 T.assert_type!(spell_books.where(id: 1), SpellBook::ActiveRecord_AssociationRelation)
+T.assert_type!(spell_books.where(id: 1).recent, SpellBook::ActiveRecord_AssociationRelation)
+T.assert_type!(spell_books.where.not(id: 1), SpellBook::ActiveRecord_AssociationRelation)
 T.assert_type!(spell_books.preload(:wizard), SpellBook::ActiveRecord_AssociationRelation)
 T.assert_type!(spell_books.eager_load(:wizard), SpellBook::ActiveRecord_AssociationRelation)
 T.assert_type!(spell_books.order(:id), SpellBook::ActiveRecord_AssociationRelation)
-T.assert_type!(spell_books.where.not(id: 1), SpellBook::ActiveRecord_AssociationRelation)
-T.assert_type!(spell_books.biology, SpellBook::ActiveRecord_AssociationRelation)
 # Enumerable methods
 spell_books.each { |s| T.assert_type!(s, SpellBook) }
 spell_books.map { |s| T.assert_type!(s, SpellBook) }
@@ -248,12 +257,18 @@ T.assert_type!(spell_books_query.none?, T::Boolean)
 T.assert_type!(spell_books_query.one?, T::Boolean)
 # T.assert_type!(spell_books_query.update_all(name: 'Fantastic Beasts'), Integer) # Ignored until we add support
 # T.assert_type!(spell_books_query.delete_all, Integer) # Ignored until we add support
-# Query chaining
+# Query methods
+T.assert_type!(spell_books_query.all, SpellBook::ActiveRecord_AssociationRelation)
+T.assert_type!(spell_books_query.recent, SpellBook::ActiveRecord_AssociationRelation) # Named scope
+T.assert_type!(spell_books_query.unclassified, SpellBook::ActiveRecord_AssociationRelation) # Enum scope
+T.assert_type!(spell_books_query.unclassified.recent, SpellBook::ActiveRecord_AssociationRelation)
+T.assert_type!(spell_books_query.unclassified.recent.unscoped, SpellBook::ActiveRecord_Relation) # Turns back into relation
+T.assert_type!(spell_books_query.where(id: 1), SpellBook::ActiveRecord_AssociationRelation)
+T.assert_type!(spell_books_query.where(id: 1).recent, SpellBook::ActiveRecord_AssociationRelation)
+T.assert_type!(spell_books_query.where.not(id: 1), SpellBook::ActiveRecord_AssociationRelation)
 T.assert_type!(spell_books_query.preload(:wizard), SpellBook::ActiveRecord_AssociationRelation)
 T.assert_type!(spell_books_query.eager_load(:wizard), SpellBook::ActiveRecord_AssociationRelation)
 T.assert_type!(spell_books_query.order(:id), SpellBook::ActiveRecord_AssociationRelation)
-T.assert_type!(spell_books_query.where.not(id: 1), SpellBook::ActiveRecord_AssociationRelation)
-T.assert_type!(spell_books_query.biology, SpellBook::ActiveRecord_AssociationRelation)
 # Enumerable methods
 spell_books_query.each { |s| T.assert_type!(s, SpellBook) }
 spell_books_query.map { |s| T.assert_type!(s, SpellBook) }

--- a/spec/support/v5.2/app/models/spell_book.rb
+++ b/spec/support/v5.2/app/models/spell_book.rb
@@ -13,4 +13,6 @@ class SpellBook < ApplicationRecord
     biology: 1,
     dark_art: 999,
   }
+
+  scope :recent, -> { where('created_at > ?', 1.month.ago) }
 end

--- a/spec/support/v5.2/app/models/wizard.rb
+++ b/spec/support/v5.2/app/models/wizard.rb
@@ -2,7 +2,7 @@
 class Wizard < ApplicationRecord
   validates :name, length: { minimum: 5 }, presence: true
   # simulate conditional validation
-  validates :parent_email, presence: true, if: -> { false }
+  validates :parent_email, presence: true, if: :Slytherin?
 
   typed_enum house: {
     Gryffindor: 0,

--- a/spec/support/v5.2/sorbet_test_cases.rb
+++ b/spec/support/v5.2/sorbet_test_cases.rb
@@ -29,26 +29,6 @@ T.assert_type!(T.must(wizard.wand).wizard, Wizard)
 T.assert_type!(wizard.spell_books, SpellBook::ActiveRecord_Associations_CollectionProxy)
 T.assert_type!(wizard.spell_book_ids, T::Array[Integer])
 
-# -- model relation
-# default
-T.assert_type!(Wizard.all, Wizard::ActiveRecord_Relation)
-
-# custom scope
-T.assert_type!(Wizard.recent, Wizard::ActiveRecord_Relation)
-
-# enum scope
-T.assert_type!(Wizard.Gryffindor, Wizard::ActiveRecord_Relation)
-
-# ActiveRecord Querying
-T.assert_type!(Wizard.Gryffindor.recent, Wizard::ActiveRecord_Relation)
-T.assert_type!(Wizard.Gryffindor.recent.unscoped, Wizard::ActiveRecord_Relation)
-T.assert_type!(Wizard.where(id: 1), Wizard::ActiveRecord_Relation)
-T.assert_type!(Wizard.where(id: 1).recent, Wizard::ActiveRecord_Relation)
-T.assert_type!(Wizard.where.not(id: 1), Wizard::ActiveRecord_Relation)
-T.assert_type!(Wizard.preload(:spell_books), Wizard::ActiveRecord_Relation)
-T.assert_type!(Wizard.eager_load(:spell_books), Wizard::ActiveRecord_Relation)
-T.assert_type!(Wizard.order(:id), Wizard::ActiveRecord_Relation)
-
 # Finder methods -- Model
 T.assert_type!(Wizard.exists?(name: 'Test'), T::Boolean)
 T.assert_type!(Wizard.find(wizard.id), Wizard)
@@ -90,6 +70,18 @@ T.assert_type!(Wizard.none?, T::Boolean)
 T.assert_type!(Wizard.one?, T::Boolean)
 # T.assert_type!(Wizard.update_all(name: 'Harry Potter'), Integer) # Ignored until we add support
 # T.assert_type!(Wizard.delete_all, Integer) # Ignored until we add support
+# Query methods
+T.assert_type!(Wizard.all, Wizard::ActiveRecord_Relation)
+T.assert_type!(Wizard.recent, Wizard::ActiveRecord_Relation) # Named scope
+T.assert_type!(Wizard.Gryffindor, Wizard::ActiveRecord_Relation) # Enum scope
+T.assert_type!(Wizard.Gryffindor.recent, Wizard::ActiveRecord_Relation)
+T.assert_type!(Wizard.Gryffindor.recent.unscoped, Wizard::ActiveRecord_Relation)
+T.assert_type!(Wizard.where(id: 1), Wizard::ActiveRecord_Relation)
+T.assert_type!(Wizard.where(id: 1).recent, Wizard::ActiveRecord_Relation)
+T.assert_type!(Wizard.where.not(id: 1), Wizard::ActiveRecord_Relation)
+T.assert_type!(Wizard.preload(:spell_books), Wizard::ActiveRecord_Relation)
+T.assert_type!(Wizard.eager_load(:spell_books), Wizard::ActiveRecord_Relation)
+T.assert_type!(Wizard.order(:id), Wizard::ActiveRecord_Relation)
 
 # Finder methods -- ActiveRecord::Relation
 T.assert_type!(Wizard.all.exists?(name: 'Harry Potter'), T::Boolean)
@@ -133,6 +125,18 @@ T.assert_type!(Wizard.all.none?, T::Boolean)
 T.assert_type!(Wizard.all.one?, T::Boolean)
 # T.assert_type!(Wizard.all.update_all(name: 'Harry Potter'), Integer) # Ignored until we add support
 # T.assert_type!(Wizard.all.delete_all, Integer) # Ignored until we add support
+# Query methods
+T.assert_type!(Wizard.all.all, Wizard::ActiveRecord_Relation)
+T.assert_type!(Wizard.all.recent, Wizard::ActiveRecord_Relation) # Named scope
+T.assert_type!(Wizard.all.Gryffindor, Wizard::ActiveRecord_Relation) # Enum scope
+T.assert_type!(Wizard.all.Gryffindor.recent, Wizard::ActiveRecord_Relation)
+T.assert_type!(Wizard.all.Gryffindor.recent.unscoped, Wizard::ActiveRecord_Relation)
+T.assert_type!(Wizard.all.where(id: 1), Wizard::ActiveRecord_Relation)
+T.assert_type!(Wizard.all.where(id: 1).recent, Wizard::ActiveRecord_Relation)
+T.assert_type!(Wizard.all.where.not(id: 1), Wizard::ActiveRecord_Relation)
+T.assert_type!(Wizard.all.preload(:spell_books), Wizard::ActiveRecord_Relation)
+T.assert_type!(Wizard.all.eager_load(:spell_books), Wizard::ActiveRecord_Relation)
+T.assert_type!(Wizard.all.order(:id), Wizard::ActiveRecord_Relation)
 # Enumerable methods
 Wizard.all.each { |w| T.assert_type!(w, Wizard) }
 Wizard.all.map { |w| T.assert_type!(w, Wizard) }
@@ -183,13 +187,18 @@ T.assert_type!(spell_books.none?, T::Boolean)
 T.assert_type!(spell_books.one?, T::Boolean)
 # T.assert_type!(spell_books.update_all(name: 'Fantastic Beasts'), Integer) # Ignored until we add support
 # T.assert_type!(spell_books.delete_all, Integer) # Ignored until we add support
-# CollectionProxy query also typed correctly!
+# Query methods
+T.assert_type!(spell_books.all, SpellBook::ActiveRecord_AssociationRelation)
+T.assert_type!(spell_books.recent, SpellBook::ActiveRecord_AssociationRelation) # Named scope
+T.assert_type!(spell_books.unclassified, SpellBook::ActiveRecord_AssociationRelation) # Enum scope
+T.assert_type!(spell_books.unclassified.recent, SpellBook::ActiveRecord_AssociationRelation)
+T.assert_type!(spell_books.unclassified.recent.unscoped, SpellBook::ActiveRecord_Relation) # Turns back into relation
 T.assert_type!(spell_books.where(id: 1), SpellBook::ActiveRecord_AssociationRelation)
+T.assert_type!(spell_books.where(id: 1).recent, SpellBook::ActiveRecord_AssociationRelation)
+T.assert_type!(spell_books.where.not(id: 1), SpellBook::ActiveRecord_AssociationRelation)
 T.assert_type!(spell_books.preload(:wizard), SpellBook::ActiveRecord_AssociationRelation)
 T.assert_type!(spell_books.eager_load(:wizard), SpellBook::ActiveRecord_AssociationRelation)
 T.assert_type!(spell_books.order(:id), SpellBook::ActiveRecord_AssociationRelation)
-T.assert_type!(spell_books.where.not(id: 1), SpellBook::ActiveRecord_AssociationRelation)
-T.assert_type!(spell_books.biology, SpellBook::ActiveRecord_AssociationRelation)
 # Enumerable methods
 spell_books.each { |s| T.assert_type!(s, SpellBook) }
 spell_books.map { |s| T.assert_type!(s, SpellBook) }
@@ -248,12 +257,18 @@ T.assert_type!(spell_books_query.none?, T::Boolean)
 T.assert_type!(spell_books_query.one?, T::Boolean)
 # T.assert_type!(spell_books_query.update_all(name: 'Fantastic Beasts'), Integer) # Ignored until we add support
 # T.assert_type!(spell_books_query.delete_all, Integer) # Ignored until we add support
-# Query chaining
+# Query methods
+T.assert_type!(spell_books_query.all, SpellBook::ActiveRecord_AssociationRelation)
+T.assert_type!(spell_books_query.recent, SpellBook::ActiveRecord_AssociationRelation) # Named scope
+T.assert_type!(spell_books_query.unclassified, SpellBook::ActiveRecord_AssociationRelation) # Enum scope
+T.assert_type!(spell_books_query.unclassified.recent, SpellBook::ActiveRecord_AssociationRelation)
+T.assert_type!(spell_books_query.unclassified.recent.unscoped, SpellBook::ActiveRecord_Relation) # Turns back into relation
+T.assert_type!(spell_books_query.where(id: 1), SpellBook::ActiveRecord_AssociationRelation)
+T.assert_type!(spell_books_query.where(id: 1).recent, SpellBook::ActiveRecord_AssociationRelation)
+T.assert_type!(spell_books_query.where.not(id: 1), SpellBook::ActiveRecord_AssociationRelation)
 T.assert_type!(spell_books_query.preload(:wizard), SpellBook::ActiveRecord_AssociationRelation)
 T.assert_type!(spell_books_query.eager_load(:wizard), SpellBook::ActiveRecord_AssociationRelation)
 T.assert_type!(spell_books_query.order(:id), SpellBook::ActiveRecord_AssociationRelation)
-T.assert_type!(spell_books_query.where.not(id: 1), SpellBook::ActiveRecord_AssociationRelation)
-T.assert_type!(spell_books_query.biology, SpellBook::ActiveRecord_AssociationRelation)
 # Enumerable methods
 spell_books_query.each { |s| T.assert_type!(s, SpellBook) }
 spell_books_query.map { |s| T.assert_type!(s, SpellBook) }

--- a/spec/support/v6.0/app/models/spell_book.rb
+++ b/spec/support/v6.0/app/models/spell_book.rb
@@ -13,4 +13,6 @@ class SpellBook < ApplicationRecord
     biology: 1,
     dark_art: 999,
   }
+
+  scope :recent, -> { where('created_at > ?', 1.month.ago) }
 end

--- a/spec/support/v6.0/app/models/wizard.rb
+++ b/spec/support/v6.0/app/models/wizard.rb
@@ -2,7 +2,7 @@
 class Wizard < ApplicationRecord
   validates :name, length: { minimum: 5 }, presence: true
   # simulate conditional validation
-  validates :parent_email, presence: true, if: -> { false }
+  validates :parent_email, presence: true, if: :Slytherin?
 
   typed_enum house: {
     Gryffindor: 0,

--- a/spec/support/v6.0/sorbet_test_cases.rb
+++ b/spec/support/v6.0/sorbet_test_cases.rb
@@ -29,26 +29,6 @@ T.assert_type!(T.must(wizard.wand).wizard, Wizard)
 T.assert_type!(wizard.spell_books, SpellBook::ActiveRecord_Associations_CollectionProxy)
 T.assert_type!(wizard.spell_book_ids, T::Array[Integer])
 
-# -- model relation
-# default
-T.assert_type!(Wizard.all, Wizard::ActiveRecord_Relation)
-
-# custom scope
-T.assert_type!(Wizard.recent, Wizard::ActiveRecord_Relation)
-
-# enum scope
-T.assert_type!(Wizard.Gryffindor, Wizard::ActiveRecord_Relation)
-
-# ActiveRecord Querying
-T.assert_type!(Wizard.Gryffindor.recent, Wizard::ActiveRecord_Relation)
-T.assert_type!(Wizard.Gryffindor.recent.unscoped, Wizard::ActiveRecord_Relation)
-T.assert_type!(Wizard.where(id: 1), Wizard::ActiveRecord_Relation)
-T.assert_type!(Wizard.where(id: 1).recent, Wizard::ActiveRecord_Relation)
-T.assert_type!(Wizard.where.not(id: 1), Wizard::ActiveRecord_Relation)
-T.assert_type!(Wizard.preload(:spell_books), Wizard::ActiveRecord_Relation)
-T.assert_type!(Wizard.eager_load(:spell_books), Wizard::ActiveRecord_Relation)
-T.assert_type!(Wizard.order(:id), Wizard::ActiveRecord_Relation)
-
 # Finder methods -- Model
 T.assert_type!(Wizard.exists?(name: 'Test'), T::Boolean)
 T.assert_type!(Wizard.find(wizard.id), Wizard)
@@ -90,6 +70,18 @@ T.assert_type!(Wizard.none?, T::Boolean)
 T.assert_type!(Wizard.one?, T::Boolean)
 # T.assert_type!(Wizard.update_all(name: 'Harry Potter'), Integer) # Ignored until we add support
 # T.assert_type!(Wizard.delete_all, Integer) # Ignored until we add support
+# Query methods
+T.assert_type!(Wizard.all, Wizard::ActiveRecord_Relation)
+T.assert_type!(Wizard.recent, Wizard::ActiveRecord_Relation) # Named scope
+T.assert_type!(Wizard.Gryffindor, Wizard::ActiveRecord_Relation) # Enum scope
+T.assert_type!(Wizard.Gryffindor.recent, Wizard::ActiveRecord_Relation)
+T.assert_type!(Wizard.Gryffindor.recent.unscoped, Wizard::ActiveRecord_Relation)
+T.assert_type!(Wizard.where(id: 1), Wizard::ActiveRecord_Relation)
+T.assert_type!(Wizard.where(id: 1).recent, Wizard::ActiveRecord_Relation)
+T.assert_type!(Wizard.where.not(id: 1), Wizard::ActiveRecord_Relation)
+T.assert_type!(Wizard.preload(:spell_books), Wizard::ActiveRecord_Relation)
+T.assert_type!(Wizard.eager_load(:spell_books), Wizard::ActiveRecord_Relation)
+T.assert_type!(Wizard.order(:id), Wizard::ActiveRecord_Relation)
 
 # Finder methods -- ActiveRecord::Relation
 T.assert_type!(Wizard.all.exists?(name: 'Harry Potter'), T::Boolean)
@@ -133,6 +125,18 @@ T.assert_type!(Wizard.all.none?, T::Boolean)
 T.assert_type!(Wizard.all.one?, T::Boolean)
 # T.assert_type!(Wizard.all.update_all(name: 'Harry Potter'), Integer) # Ignored until we add support
 # T.assert_type!(Wizard.all.delete_all, Integer) # Ignored until we add support
+# Query methods
+T.assert_type!(Wizard.all.all, Wizard::ActiveRecord_Relation)
+T.assert_type!(Wizard.all.recent, Wizard::ActiveRecord_Relation) # Named scope
+T.assert_type!(Wizard.all.Gryffindor, Wizard::ActiveRecord_Relation) # Enum scope
+T.assert_type!(Wizard.all.Gryffindor.recent, Wizard::ActiveRecord_Relation)
+T.assert_type!(Wizard.all.Gryffindor.recent.unscoped, Wizard::ActiveRecord_Relation)
+T.assert_type!(Wizard.all.where(id: 1), Wizard::ActiveRecord_Relation)
+T.assert_type!(Wizard.all.where(id: 1).recent, Wizard::ActiveRecord_Relation)
+T.assert_type!(Wizard.all.where.not(id: 1), Wizard::ActiveRecord_Relation)
+T.assert_type!(Wizard.all.preload(:spell_books), Wizard::ActiveRecord_Relation)
+T.assert_type!(Wizard.all.eager_load(:spell_books), Wizard::ActiveRecord_Relation)
+T.assert_type!(Wizard.all.order(:id), Wizard::ActiveRecord_Relation)
 # Enumerable methods
 Wizard.all.each { |w| T.assert_type!(w, Wizard) }
 Wizard.all.map { |w| T.assert_type!(w, Wizard) }
@@ -183,13 +187,18 @@ T.assert_type!(spell_books.none?, T::Boolean)
 T.assert_type!(spell_books.one?, T::Boolean)
 # T.assert_type!(spell_books.update_all(name: 'Fantastic Beasts'), Integer) # Ignored until we add support
 # T.assert_type!(spell_books.delete_all, Integer) # Ignored until we add support
-# CollectionProxy query also typed correctly!
+# Query methods
+T.assert_type!(spell_books.all, SpellBook::ActiveRecord_AssociationRelation)
+T.assert_type!(spell_books.recent, SpellBook::ActiveRecord_AssociationRelation) # Named scope
+T.assert_type!(spell_books.unclassified, SpellBook::ActiveRecord_AssociationRelation) # Enum scope
+T.assert_type!(spell_books.unclassified.recent, SpellBook::ActiveRecord_AssociationRelation)
+T.assert_type!(spell_books.unclassified.recent.unscoped, SpellBook::ActiveRecord_Relation) # Turns back into relation
 T.assert_type!(spell_books.where(id: 1), SpellBook::ActiveRecord_AssociationRelation)
+T.assert_type!(spell_books.where(id: 1).recent, SpellBook::ActiveRecord_AssociationRelation)
+T.assert_type!(spell_books.where.not(id: 1), SpellBook::ActiveRecord_AssociationRelation)
 T.assert_type!(spell_books.preload(:wizard), SpellBook::ActiveRecord_AssociationRelation)
 T.assert_type!(spell_books.eager_load(:wizard), SpellBook::ActiveRecord_AssociationRelation)
 T.assert_type!(spell_books.order(:id), SpellBook::ActiveRecord_AssociationRelation)
-T.assert_type!(spell_books.where.not(id: 1), SpellBook::ActiveRecord_AssociationRelation)
-T.assert_type!(spell_books.biology, SpellBook::ActiveRecord_AssociationRelation)
 # Enumerable methods
 spell_books.each { |s| T.assert_type!(s, SpellBook) }
 spell_books.map { |s| T.assert_type!(s, SpellBook) }
@@ -248,12 +257,18 @@ T.assert_type!(spell_books_query.none?, T::Boolean)
 T.assert_type!(spell_books_query.one?, T::Boolean)
 # T.assert_type!(spell_books_query.update_all(name: 'Fantastic Beasts'), Integer) # Ignored until we add support
 # T.assert_type!(spell_books_query.delete_all, Integer) # Ignored until we add support
-# Query chaining
+# Query methods
+T.assert_type!(spell_books_query.all, SpellBook::ActiveRecord_AssociationRelation)
+T.assert_type!(spell_books_query.recent, SpellBook::ActiveRecord_AssociationRelation) # Named scope
+T.assert_type!(spell_books_query.unclassified, SpellBook::ActiveRecord_AssociationRelation) # Enum scope
+T.assert_type!(spell_books_query.unclassified.recent, SpellBook::ActiveRecord_AssociationRelation)
+T.assert_type!(spell_books_query.unclassified.recent.unscoped, SpellBook::ActiveRecord_Relation) # Turns back into relation
+T.assert_type!(spell_books_query.where(id: 1), SpellBook::ActiveRecord_AssociationRelation)
+T.assert_type!(spell_books_query.where(id: 1).recent, SpellBook::ActiveRecord_AssociationRelation)
+T.assert_type!(spell_books_query.where.not(id: 1), SpellBook::ActiveRecord_AssociationRelation)
 T.assert_type!(spell_books_query.preload(:wizard), SpellBook::ActiveRecord_AssociationRelation)
 T.assert_type!(spell_books_query.eager_load(:wizard), SpellBook::ActiveRecord_AssociationRelation)
 T.assert_type!(spell_books_query.order(:id), SpellBook::ActiveRecord_AssociationRelation)
-T.assert_type!(spell_books_query.where.not(id: 1), SpellBook::ActiveRecord_AssociationRelation)
-T.assert_type!(spell_books_query.biology, SpellBook::ActiveRecord_AssociationRelation)
 # Enumerable methods
 spell_books_query.each { |s| T.assert_type!(s, SpellBook) }
 spell_books_query.map { |s| T.assert_type!(s, SpellBook) }

--- a/spec/test_data/v5.0/expected_headmaster.rbi
+++ b/spec/test_data/v5.0/expected_headmaster.rbi
@@ -8,8 +8,6 @@ module Headmaster::ActiveRelation_WhereNot
 end
 
 module Headmaster::GeneratedAttributeMethods
-  extend T::Sig
-
   sig { returns(Integer) }
   def id; end
 
@@ -39,8 +37,6 @@ module Headmaster::GeneratedAttributeMethods
 end
 
 module Headmaster::GeneratedAssociationMethods
-  extend T::Sig
-
   sig { returns(::School) }
   def school; end
 
@@ -76,8 +72,6 @@ class Headmaster < ApplicationRecord
   include Headmaster::GeneratedAssociationMethods
   extend Headmaster::CustomFinderMethods
   extend Headmaster::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   RelationType = T.type_alias { T.any(Headmaster::ActiveRecord_Relation, Headmaster::ActiveRecord_Associations_CollectionProxy, Headmaster::ActiveRecord_AssociationRelation) }
 end
 
@@ -257,8 +251,6 @@ class Headmaster::ActiveRecord_Relation < ActiveRecord::Relation
   include Headmaster::ActiveRelation_WhereNot
   include Headmaster::CustomFinderMethods
   include Headmaster::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Headmaster)
 end
 
@@ -266,16 +258,12 @@ class Headmaster::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRe
   include Headmaster::ActiveRelation_WhereNot
   include Headmaster::CustomFinderMethods
   include Headmaster::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Headmaster)
 end
 
 class Headmaster::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include Headmaster::CustomFinderMethods
   include Headmaster::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Headmaster)
 
   sig { params(records: T.any(Headmaster, T::Array[Headmaster])).returns(T.self_type) }

--- a/spec/test_data/v5.0/expected_headmaster.rbi
+++ b/spec/test_data/v5.0/expected_headmaster.rbi
@@ -75,368 +75,208 @@ class Headmaster < ApplicationRecord
   include Headmaster::GeneratedAttributeMethods
   include Headmaster::GeneratedAssociationMethods
   extend Headmaster::CustomFinderMethods
+  extend Headmaster::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   RelationType = T.type_alias { T.any(Headmaster::ActiveRecord_Relation, Headmaster::ActiveRecord_Associations_CollectionProxy, Headmaster::ActiveRecord_AssociationRelation) }
+end
 
+module Headmaster::QueryMethodsReturningRelation
   sig { returns(Headmaster::ActiveRecord_Relation) }
-  def self.all; end
+  def all; end
 
   sig { params(block: T.nilable(T.proc.void)).returns(Headmaster::ActiveRecord_Relation) }
-  def self.unscoped(&block); end
+  def unscoped(&block); end
 
   sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def self.select(*args); end
+  def select(*args); end
 
   sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def self.order(*args); end
+  def order(*args); end
 
   sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def self.reorder(*args); end
+  def reorder(*args); end
 
   sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def self.group(*args); end
+  def group(*args); end
 
   sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def self.limit(*args); end
+  def limit(*args); end
 
   sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def self.offset(*args); end
+  def offset(*args); end
 
   sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def self.joins(*args); end
+  def joins(*args); end
 
   sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def self.left_joins(*args); end
+  def left_joins(*args); end
 
   sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def self.left_outer_joins(*args); end
+  def left_outer_joins(*args); end
 
   sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def self.where(*args); end
+  def where(*args); end
 
   sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def self.rewhere(*args); end
+  def rewhere(*args); end
 
   sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def self.preload(*args); end
+  def preload(*args); end
 
   sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def self.eager_load(*args); end
+  def eager_load(*args); end
 
   sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def self.includes(*args); end
+  def includes(*args); end
 
   sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def self.from(*args); end
+  def from(*args); end
 
   sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def self.lock(*args); end
+  def lock(*args); end
 
   sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def self.readonly(*args); end
+  def readonly(*args); end
 
   sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def self.or(*args); end
+  def or(*args); end
 
   sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def self.having(*args); end
+  def having(*args); end
 
   sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def self.create_with(*args); end
+  def create_with(*args); end
 
   sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def self.distinct(*args); end
+  def distinct(*args); end
 
   sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def self.references(*args); end
+  def references(*args); end
 
   sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def self.none(*args); end
+  def none(*args); end
 
   sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def self.unscope(*args); end
+  def unscope(*args); end
 
   sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def self.except(*args); end
+  def except(*args); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Headmaster::ActiveRecord_Relation) }
-  def self.extending(*args, &block); end
+  def extending(*args, &block); end
+end
+
+module Headmaster::QueryMethodsReturningAssociationRelation
+  sig { returns(Headmaster::ActiveRecord_AssociationRelation) }
+  def all; end
+
+  sig { params(block: T.nilable(T.proc.void)).returns(Headmaster::ActiveRecord_Relation) }
+  def unscoped(&block); end
+
+  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
+  def select(*args); end
+
+  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
+  def order(*args); end
+
+  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
+  def reorder(*args); end
+
+  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
+  def group(*args); end
+
+  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
+  def limit(*args); end
+
+  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
+  def offset(*args); end
+
+  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
+  def joins(*args); end
+
+  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
+  def left_joins(*args); end
+
+  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
+  def left_outer_joins(*args); end
+
+  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
+  def where(*args); end
+
+  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
+  def rewhere(*args); end
+
+  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
+  def preload(*args); end
+
+  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
+  def eager_load(*args); end
+
+  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
+  def includes(*args); end
+
+  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
+  def from(*args); end
+
+  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
+  def lock(*args); end
+
+  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
+  def readonly(*args); end
+
+  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
+  def or(*args); end
+
+  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
+  def having(*args); end
+
+  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
+  def create_with(*args); end
+
+  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
+  def distinct(*args); end
+
+  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
+  def references(*args); end
+
+  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
+  def none(*args); end
+
+  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
+  def unscope(*args); end
+
+  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
+  def except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Headmaster::ActiveRecord_AssociationRelation) }
+  def extending(*args, &block); end
 end
 
 class Headmaster::ActiveRecord_Relation < ActiveRecord::Relation
   include Headmaster::ActiveRelation_WhereNot
   include Headmaster::CustomFinderMethods
+  include Headmaster::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: Headmaster)
-
-  sig { returns(Headmaster::ActiveRecord_Relation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Headmaster::ActiveRecord_Relation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Headmaster::ActiveRecord_Relation) }
-  def extending(*args, &block); end
 end
 
 class Headmaster::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
   include Headmaster::ActiveRelation_WhereNot
   include Headmaster::CustomFinderMethods
+  include Headmaster::QueryMethodsReturningAssociationRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: Headmaster)
-
-  sig { returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
 end
 
 class Headmaster::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include Headmaster::CustomFinderMethods
+  include Headmaster::QueryMethodsReturningAssociationRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: Headmaster)
-
-  sig { returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
 
   sig { params(records: T.any(Headmaster, T::Array[Headmaster])).returns(T.self_type) }
   def <<(*records); end

--- a/spec/test_data/v5.0/expected_internal_metadata.rbi
+++ b/spec/test_data/v5.0/expected_internal_metadata.rbi
@@ -8,8 +8,6 @@ module ActiveRecord::InternalMetadata::ActiveRelation_WhereNot
 end
 
 module ActiveRecord::InternalMetadata::GeneratedAttributeMethods
-  extend T::Sig
-
   sig { returns(ActiveSupport::TimeWithZone) }
   def created_at; end
 
@@ -68,8 +66,6 @@ class ActiveRecord::InternalMetadata < ActiveRecord::Base
   include ActiveRecord::InternalMetadata::GeneratedAttributeMethods
   extend ActiveRecord::InternalMetadata::CustomFinderMethods
   extend ActiveRecord::InternalMetadata::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   RelationType = T.type_alias { T.any(ActiveRecord::InternalMetadata::ActiveRecord_Relation, ActiveRecord::InternalMetadata::ActiveRecord_Associations_CollectionProxy, ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
 end
 
@@ -249,8 +245,6 @@ class ActiveRecord::InternalMetadata::ActiveRecord_Relation < ActiveRecord::Rela
   include ActiveRecord::InternalMetadata::ActiveRelation_WhereNot
   include ActiveRecord::InternalMetadata::CustomFinderMethods
   include ActiveRecord::InternalMetadata::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: ActiveRecord::InternalMetadata)
 end
 
@@ -258,16 +252,12 @@ class ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation < ActiveR
   include ActiveRecord::InternalMetadata::ActiveRelation_WhereNot
   include ActiveRecord::InternalMetadata::CustomFinderMethods
   include ActiveRecord::InternalMetadata::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: ActiveRecord::InternalMetadata)
 end
 
 class ActiveRecord::InternalMetadata::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include ActiveRecord::InternalMetadata::CustomFinderMethods
   include ActiveRecord::InternalMetadata::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: ActiveRecord::InternalMetadata)
 
   sig { params(records: T.any(ActiveRecord::InternalMetadata, T::Array[ActiveRecord::InternalMetadata])).returns(T.self_type) }

--- a/spec/test_data/v5.0/expected_internal_metadata.rbi
+++ b/spec/test_data/v5.0/expected_internal_metadata.rbi
@@ -67,368 +67,208 @@ end
 class ActiveRecord::InternalMetadata < ActiveRecord::Base
   include ActiveRecord::InternalMetadata::GeneratedAttributeMethods
   extend ActiveRecord::InternalMetadata::CustomFinderMethods
+  extend ActiveRecord::InternalMetadata::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   RelationType = T.type_alias { T.any(ActiveRecord::InternalMetadata::ActiveRecord_Relation, ActiveRecord::InternalMetadata::ActiveRecord_Associations_CollectionProxy, ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+end
 
+module ActiveRecord::InternalMetadata::QueryMethodsReturningRelation
   sig { returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.all; end
+  def all; end
 
   sig { params(block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.unscoped(&block); end
+  def unscoped(&block); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.select(*args); end
+  def select(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.order(*args); end
+  def order(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.reorder(*args); end
+  def reorder(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.group(*args); end
+  def group(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.limit(*args); end
+  def limit(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.offset(*args); end
+  def offset(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.joins(*args); end
+  def joins(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.left_joins(*args); end
+  def left_joins(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.left_outer_joins(*args); end
+  def left_outer_joins(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.where(*args); end
+  def where(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.rewhere(*args); end
+  def rewhere(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.preload(*args); end
+  def preload(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.eager_load(*args); end
+  def eager_load(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.includes(*args); end
+  def includes(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.from(*args); end
+  def from(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.lock(*args); end
+  def lock(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.readonly(*args); end
+  def readonly(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.or(*args); end
+  def or(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.having(*args); end
+  def having(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.create_with(*args); end
+  def create_with(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.distinct(*args); end
+  def distinct(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.references(*args); end
+  def references(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.none(*args); end
+  def none(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.unscope(*args); end
+  def unscope(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.except(*args); end
+  def except(*args); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.extending(*args, &block); end
+  def extending(*args, &block); end
+end
+
+module ActiveRecord::InternalMetadata::QueryMethodsReturningAssociationRelation
+  sig { returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def all; end
+
+  sig { params(block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def unscoped(&block); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def select(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def order(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def reorder(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def group(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def limit(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def offset(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def joins(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def left_joins(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def left_outer_joins(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def where(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def rewhere(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def preload(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def eager_load(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def includes(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def from(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def lock(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def readonly(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def or(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def having(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def create_with(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def distinct(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def references(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def none(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def unscope(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def extending(*args, &block); end
 end
 
 class ActiveRecord::InternalMetadata::ActiveRecord_Relation < ActiveRecord::Relation
   include ActiveRecord::InternalMetadata::ActiveRelation_WhereNot
   include ActiveRecord::InternalMetadata::CustomFinderMethods
+  include ActiveRecord::InternalMetadata::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: ActiveRecord::InternalMetadata)
-
-  sig { returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def extending(*args, &block); end
 end
 
 class ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
   include ActiveRecord::InternalMetadata::ActiveRelation_WhereNot
   include ActiveRecord::InternalMetadata::CustomFinderMethods
+  include ActiveRecord::InternalMetadata::QueryMethodsReturningAssociationRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: ActiveRecord::InternalMetadata)
-
-  sig { returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
 end
 
 class ActiveRecord::InternalMetadata::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include ActiveRecord::InternalMetadata::CustomFinderMethods
+  include ActiveRecord::InternalMetadata::QueryMethodsReturningAssociationRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: ActiveRecord::InternalMetadata)
-
-  sig { returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
 
   sig { params(records: T.any(ActiveRecord::InternalMetadata, T::Array[ActiveRecord::InternalMetadata])).returns(T.self_type) }
   def <<(*records); end

--- a/spec/test_data/v5.0/expected_potion.rbi
+++ b/spec/test_data/v5.0/expected_potion.rbi
@@ -8,8 +8,6 @@ module Potion::ActiveRelation_WhereNot
 end
 
 module Potion::GeneratedAssociationMethods
-  extend T::Sig
-
   sig { returns(T.nilable(::Wizard)) }
   def wizard; end
 
@@ -38,8 +36,6 @@ class Potion < ApplicationRecord
   include Potion::GeneratedAssociationMethods
   extend Potion::CustomFinderMethods
   extend Potion::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   RelationType = T.type_alias { T.any(Potion::ActiveRecord_Relation, Potion::ActiveRecord_Associations_CollectionProxy, Potion::ActiveRecord_AssociationRelation) }
 end
 
@@ -219,8 +215,6 @@ class Potion::ActiveRecord_Relation < ActiveRecord::Relation
   include Potion::ActiveRelation_WhereNot
   include Potion::CustomFinderMethods
   include Potion::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Potion)
 end
 
@@ -228,16 +222,12 @@ class Potion::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelati
   include Potion::ActiveRelation_WhereNot
   include Potion::CustomFinderMethods
   include Potion::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Potion)
 end
 
 class Potion::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include Potion::CustomFinderMethods
   include Potion::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Potion)
 
   sig { params(records: T.any(Potion, T::Array[Potion])).returns(T.self_type) }

--- a/spec/test_data/v5.0/expected_potion.rbi
+++ b/spec/test_data/v5.0/expected_potion.rbi
@@ -37,368 +37,208 @@ end
 class Potion < ApplicationRecord
   include Potion::GeneratedAssociationMethods
   extend Potion::CustomFinderMethods
+  extend Potion::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   RelationType = T.type_alias { T.any(Potion::ActiveRecord_Relation, Potion::ActiveRecord_Associations_CollectionProxy, Potion::ActiveRecord_AssociationRelation) }
+end
 
+module Potion::QueryMethodsReturningRelation
   sig { returns(Potion::ActiveRecord_Relation) }
-  def self.all; end
+  def all; end
 
   sig { params(block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def self.unscoped(&block); end
+  def unscoped(&block); end
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def self.select(*args); end
+  def select(*args); end
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def self.order(*args); end
+  def order(*args); end
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def self.reorder(*args); end
+  def reorder(*args); end
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def self.group(*args); end
+  def group(*args); end
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def self.limit(*args); end
+  def limit(*args); end
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def self.offset(*args); end
+  def offset(*args); end
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def self.joins(*args); end
+  def joins(*args); end
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def self.left_joins(*args); end
+  def left_joins(*args); end
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def self.left_outer_joins(*args); end
+  def left_outer_joins(*args); end
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def self.where(*args); end
+  def where(*args); end
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def self.rewhere(*args); end
+  def rewhere(*args); end
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def self.preload(*args); end
+  def preload(*args); end
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def self.eager_load(*args); end
+  def eager_load(*args); end
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def self.includes(*args); end
+  def includes(*args); end
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def self.from(*args); end
+  def from(*args); end
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def self.lock(*args); end
+  def lock(*args); end
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def self.readonly(*args); end
+  def readonly(*args); end
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def self.or(*args); end
+  def or(*args); end
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def self.having(*args); end
+  def having(*args); end
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def self.create_with(*args); end
+  def create_with(*args); end
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def self.distinct(*args); end
+  def distinct(*args); end
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def self.references(*args); end
+  def references(*args); end
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def self.none(*args); end
+  def none(*args); end
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def self.unscope(*args); end
+  def unscope(*args); end
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def self.except(*args); end
+  def except(*args); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def self.extending(*args, &block); end
+  def extending(*args, &block); end
+end
+
+module Potion::QueryMethodsReturningAssociationRelation
+  sig { returns(Potion::ActiveRecord_AssociationRelation) }
+  def all; end
+
+  sig { params(block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
+  def unscoped(&block); end
+
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def select(*args); end
+
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def order(*args); end
+
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def reorder(*args); end
+
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def group(*args); end
+
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def limit(*args); end
+
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def offset(*args); end
+
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def joins(*args); end
+
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def left_joins(*args); end
+
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def left_outer_joins(*args); end
+
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def where(*args); end
+
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def rewhere(*args); end
+
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def preload(*args); end
+
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def eager_load(*args); end
+
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def includes(*args); end
+
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def from(*args); end
+
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def lock(*args); end
+
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def readonly(*args); end
+
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def or(*args); end
+
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def having(*args); end
+
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def create_with(*args); end
+
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def distinct(*args); end
+
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def references(*args); end
+
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def none(*args); end
+
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def unscope(*args); end
+
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
+  def extending(*args, &block); end
 end
 
 class Potion::ActiveRecord_Relation < ActiveRecord::Relation
   include Potion::ActiveRelation_WhereNot
   include Potion::CustomFinderMethods
+  include Potion::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: Potion)
-
-  sig { returns(Potion::ActiveRecord_Relation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def extending(*args, &block); end
 end
 
 class Potion::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
   include Potion::ActiveRelation_WhereNot
   include Potion::CustomFinderMethods
+  include Potion::QueryMethodsReturningAssociationRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: Potion)
-
-  sig { returns(Potion::ActiveRecord_AssociationRelation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
 end
 
 class Potion::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include Potion::CustomFinderMethods
+  include Potion::QueryMethodsReturningAssociationRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: Potion)
-
-  sig { returns(Potion::ActiveRecord_AssociationRelation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
 
   sig { params(records: T.any(Potion, T::Array[Potion])).returns(T.self_type) }
   def <<(*records); end

--- a/spec/test_data/v5.0/expected_robe.rbi
+++ b/spec/test_data/v5.0/expected_robe.rbi
@@ -60,368 +60,208 @@ class Robe < ApplicationRecord
   include Robe::GeneratedAttributeMethods
   include Robe::GeneratedAssociationMethods
   extend Robe::CustomFinderMethods
+  extend Robe::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   RelationType = T.type_alias { T.any(Robe::ActiveRecord_Relation, Robe::ActiveRecord_Associations_CollectionProxy, Robe::ActiveRecord_AssociationRelation) }
+end
 
+module Robe::QueryMethodsReturningRelation
   sig { returns(Robe::ActiveRecord_Relation) }
-  def self.all; end
+  def all; end
 
   sig { params(block: T.nilable(T.proc.void)).returns(Robe::ActiveRecord_Relation) }
-  def self.unscoped(&block); end
+  def unscoped(&block); end
 
   sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def self.select(*args); end
+  def select(*args); end
 
   sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def self.order(*args); end
+  def order(*args); end
 
   sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def self.reorder(*args); end
+  def reorder(*args); end
 
   sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def self.group(*args); end
+  def group(*args); end
 
   sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def self.limit(*args); end
+  def limit(*args); end
 
   sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def self.offset(*args); end
+  def offset(*args); end
 
   sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def self.joins(*args); end
+  def joins(*args); end
 
   sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def self.left_joins(*args); end
+  def left_joins(*args); end
 
   sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def self.left_outer_joins(*args); end
+  def left_outer_joins(*args); end
 
   sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def self.where(*args); end
+  def where(*args); end
 
   sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def self.rewhere(*args); end
+  def rewhere(*args); end
 
   sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def self.preload(*args); end
+  def preload(*args); end
 
   sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def self.eager_load(*args); end
+  def eager_load(*args); end
 
   sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def self.includes(*args); end
+  def includes(*args); end
 
   sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def self.from(*args); end
+  def from(*args); end
 
   sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def self.lock(*args); end
+  def lock(*args); end
 
   sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def self.readonly(*args); end
+  def readonly(*args); end
 
   sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def self.or(*args); end
+  def or(*args); end
 
   sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def self.having(*args); end
+  def having(*args); end
 
   sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def self.create_with(*args); end
+  def create_with(*args); end
 
   sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def self.distinct(*args); end
+  def distinct(*args); end
 
   sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def self.references(*args); end
+  def references(*args); end
 
   sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def self.none(*args); end
+  def none(*args); end
 
   sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def self.unscope(*args); end
+  def unscope(*args); end
 
   sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def self.except(*args); end
+  def except(*args); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Robe::ActiveRecord_Relation) }
-  def self.extending(*args, &block); end
+  def extending(*args, &block); end
+end
+
+module Robe::QueryMethodsReturningAssociationRelation
+  sig { returns(Robe::ActiveRecord_AssociationRelation) }
+  def all; end
+
+  sig { params(block: T.nilable(T.proc.void)).returns(Robe::ActiveRecord_Relation) }
+  def unscoped(&block); end
+
+  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
+  def select(*args); end
+
+  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
+  def order(*args); end
+
+  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
+  def reorder(*args); end
+
+  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
+  def group(*args); end
+
+  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
+  def limit(*args); end
+
+  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
+  def offset(*args); end
+
+  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
+  def joins(*args); end
+
+  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
+  def left_joins(*args); end
+
+  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
+  def left_outer_joins(*args); end
+
+  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
+  def where(*args); end
+
+  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
+  def rewhere(*args); end
+
+  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
+  def preload(*args); end
+
+  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
+  def eager_load(*args); end
+
+  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
+  def includes(*args); end
+
+  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
+  def from(*args); end
+
+  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
+  def lock(*args); end
+
+  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
+  def readonly(*args); end
+
+  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
+  def or(*args); end
+
+  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
+  def having(*args); end
+
+  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
+  def create_with(*args); end
+
+  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
+  def distinct(*args); end
+
+  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
+  def references(*args); end
+
+  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
+  def none(*args); end
+
+  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
+  def unscope(*args); end
+
+  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
+  def except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Robe::ActiveRecord_AssociationRelation) }
+  def extending(*args, &block); end
 end
 
 class Robe::ActiveRecord_Relation < ActiveRecord::Relation
   include Robe::ActiveRelation_WhereNot
   include Robe::CustomFinderMethods
+  include Robe::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: Robe)
-
-  sig { returns(Robe::ActiveRecord_Relation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Robe::ActiveRecord_Relation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Robe::ActiveRecord_Relation) }
-  def extending(*args, &block); end
 end
 
 class Robe::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
   include Robe::ActiveRelation_WhereNot
   include Robe::CustomFinderMethods
+  include Robe::QueryMethodsReturningAssociationRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: Robe)
-
-  sig { returns(Robe::ActiveRecord_AssociationRelation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Robe::ActiveRecord_AssociationRelation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Robe::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
 end
 
 class Robe::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include Robe::CustomFinderMethods
+  include Robe::QueryMethodsReturningAssociationRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: Robe)
-
-  sig { returns(Robe::ActiveRecord_AssociationRelation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Robe::ActiveRecord_AssociationRelation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Robe::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
 
   sig { params(records: T.any(Robe, T::Array[Robe])).returns(T.self_type) }
   def <<(*records); end

--- a/spec/test_data/v5.0/expected_robe.rbi
+++ b/spec/test_data/v5.0/expected_robe.rbi
@@ -8,8 +8,6 @@ module Robe::ActiveRelation_WhereNot
 end
 
 module Robe::GeneratedAttributeMethods
-  extend T::Sig
-
   sig { returns(Integer) }
   def id; end
 
@@ -30,8 +28,6 @@ module Robe::GeneratedAttributeMethods
 end
 
 module Robe::GeneratedAssociationMethods
-  extend T::Sig
-
   sig { returns(T.nilable(::Wizard)) }
   def wizard; end
 
@@ -61,8 +57,6 @@ class Robe < ApplicationRecord
   include Robe::GeneratedAssociationMethods
   extend Robe::CustomFinderMethods
   extend Robe::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   RelationType = T.type_alias { T.any(Robe::ActiveRecord_Relation, Robe::ActiveRecord_Associations_CollectionProxy, Robe::ActiveRecord_AssociationRelation) }
 end
 
@@ -242,8 +236,6 @@ class Robe::ActiveRecord_Relation < ActiveRecord::Relation
   include Robe::ActiveRelation_WhereNot
   include Robe::CustomFinderMethods
   include Robe::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Robe)
 end
 
@@ -251,16 +243,12 @@ class Robe::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
   include Robe::ActiveRelation_WhereNot
   include Robe::CustomFinderMethods
   include Robe::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Robe)
 end
 
 class Robe::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include Robe::CustomFinderMethods
   include Robe::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Robe)
 
   sig { params(records: T.any(Robe, T::Array[Robe])).returns(T.self_type) }

--- a/spec/test_data/v5.0/expected_schema_migration.rbi
+++ b/spec/test_data/v5.0/expected_schema_migration.rbi
@@ -40,368 +40,208 @@ end
 class ActiveRecord::SchemaMigration < ActiveRecord::Base
   include ActiveRecord::SchemaMigration::GeneratedAttributeMethods
   extend ActiveRecord::SchemaMigration::CustomFinderMethods
+  extend ActiveRecord::SchemaMigration::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   RelationType = T.type_alias { T.any(ActiveRecord::SchemaMigration::ActiveRecord_Relation, ActiveRecord::SchemaMigration::ActiveRecord_Associations_CollectionProxy, ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+end
 
+module ActiveRecord::SchemaMigration::QueryMethodsReturningRelation
   sig { returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.all; end
+  def all; end
 
   sig { params(block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.unscoped(&block); end
+  def unscoped(&block); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.select(*args); end
+  def select(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.order(*args); end
+  def order(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.reorder(*args); end
+  def reorder(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.group(*args); end
+  def group(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.limit(*args); end
+  def limit(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.offset(*args); end
+  def offset(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.joins(*args); end
+  def joins(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.left_joins(*args); end
+  def left_joins(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.left_outer_joins(*args); end
+  def left_outer_joins(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.where(*args); end
+  def where(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.rewhere(*args); end
+  def rewhere(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.preload(*args); end
+  def preload(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.eager_load(*args); end
+  def eager_load(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.includes(*args); end
+  def includes(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.from(*args); end
+  def from(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.lock(*args); end
+  def lock(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.readonly(*args); end
+  def readonly(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.or(*args); end
+  def or(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.having(*args); end
+  def having(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.create_with(*args); end
+  def create_with(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.distinct(*args); end
+  def distinct(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.references(*args); end
+  def references(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.none(*args); end
+  def none(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.unscope(*args); end
+  def unscope(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.except(*args); end
+  def except(*args); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.extending(*args, &block); end
+  def extending(*args, &block); end
+end
+
+module ActiveRecord::SchemaMigration::QueryMethodsReturningAssociationRelation
+  sig { returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def all; end
+
+  sig { params(block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def unscoped(&block); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def select(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def order(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def reorder(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def group(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def limit(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def offset(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def joins(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def left_joins(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def left_outer_joins(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def where(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def rewhere(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def preload(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def eager_load(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def includes(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def from(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def lock(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def readonly(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def or(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def having(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def create_with(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def distinct(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def references(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def none(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def unscope(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def extending(*args, &block); end
 end
 
 class ActiveRecord::SchemaMigration::ActiveRecord_Relation < ActiveRecord::Relation
   include ActiveRecord::SchemaMigration::ActiveRelation_WhereNot
   include ActiveRecord::SchemaMigration::CustomFinderMethods
+  include ActiveRecord::SchemaMigration::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: ActiveRecord::SchemaMigration)
-
-  sig { returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def extending(*args, &block); end
 end
 
 class ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
   include ActiveRecord::SchemaMigration::ActiveRelation_WhereNot
   include ActiveRecord::SchemaMigration::CustomFinderMethods
+  include ActiveRecord::SchemaMigration::QueryMethodsReturningAssociationRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: ActiveRecord::SchemaMigration)
-
-  sig { returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
 end
 
 class ActiveRecord::SchemaMigration::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include ActiveRecord::SchemaMigration::CustomFinderMethods
+  include ActiveRecord::SchemaMigration::QueryMethodsReturningAssociationRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: ActiveRecord::SchemaMigration)
-
-  sig { returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
 
   sig { params(records: T.any(ActiveRecord::SchemaMigration, T::Array[ActiveRecord::SchemaMigration])).returns(T.self_type) }
   def <<(*records); end

--- a/spec/test_data/v5.0/expected_schema_migration.rbi
+++ b/spec/test_data/v5.0/expected_schema_migration.rbi
@@ -8,8 +8,6 @@ module ActiveRecord::SchemaMigration::ActiveRelation_WhereNot
 end
 
 module ActiveRecord::SchemaMigration::GeneratedAttributeMethods
-  extend T::Sig
-
   sig { returns(String) }
   def version; end
 
@@ -41,8 +39,6 @@ class ActiveRecord::SchemaMigration < ActiveRecord::Base
   include ActiveRecord::SchemaMigration::GeneratedAttributeMethods
   extend ActiveRecord::SchemaMigration::CustomFinderMethods
   extend ActiveRecord::SchemaMigration::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   RelationType = T.type_alias { T.any(ActiveRecord::SchemaMigration::ActiveRecord_Relation, ActiveRecord::SchemaMigration::ActiveRecord_Associations_CollectionProxy, ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
 end
 
@@ -222,8 +218,6 @@ class ActiveRecord::SchemaMigration::ActiveRecord_Relation < ActiveRecord::Relat
   include ActiveRecord::SchemaMigration::ActiveRelation_WhereNot
   include ActiveRecord::SchemaMigration::CustomFinderMethods
   include ActiveRecord::SchemaMigration::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: ActiveRecord::SchemaMigration)
 end
 
@@ -231,16 +225,12 @@ class ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation < ActiveRe
   include ActiveRecord::SchemaMigration::ActiveRelation_WhereNot
   include ActiveRecord::SchemaMigration::CustomFinderMethods
   include ActiveRecord::SchemaMigration::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: ActiveRecord::SchemaMigration)
 end
 
 class ActiveRecord::SchemaMigration::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include ActiveRecord::SchemaMigration::CustomFinderMethods
   include ActiveRecord::SchemaMigration::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: ActiveRecord::SchemaMigration)
 
   sig { params(records: T.any(ActiveRecord::SchemaMigration, T::Array[ActiveRecord::SchemaMigration])).returns(T.self_type) }

--- a/spec/test_data/v5.0/expected_school.rbi
+++ b/spec/test_data/v5.0/expected_school.rbi
@@ -8,8 +8,6 @@ module School::ActiveRelation_WhereNot
 end
 
 module School::GeneratedAttributeMethods
-  extend T::Sig
-
   sig { returns(Integer) }
   def id; end
 
@@ -30,8 +28,6 @@ module School::GeneratedAttributeMethods
 end
 
 module School::GeneratedAssociationMethods
-  extend T::Sig
-
   sig { returns(::Headmaster) }
   def headmaster; end
 
@@ -61,8 +57,6 @@ class School < ApplicationRecord
   include School::GeneratedAssociationMethods
   extend School::CustomFinderMethods
   extend School::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   RelationType = T.type_alias { T.any(School::ActiveRecord_Relation, School::ActiveRecord_Associations_CollectionProxy, School::ActiveRecord_AssociationRelation) }
 end
 
@@ -242,8 +236,6 @@ class School::ActiveRecord_Relation < ActiveRecord::Relation
   include School::ActiveRelation_WhereNot
   include School::CustomFinderMethods
   include School::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: School)
 end
 
@@ -251,16 +243,12 @@ class School::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelati
   include School::ActiveRelation_WhereNot
   include School::CustomFinderMethods
   include School::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: School)
 end
 
 class School::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include School::CustomFinderMethods
   include School::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: School)
 
   sig { params(records: T.any(School, T::Array[School])).returns(T.self_type) }

--- a/spec/test_data/v5.0/expected_school.rbi
+++ b/spec/test_data/v5.0/expected_school.rbi
@@ -60,368 +60,208 @@ class School < ApplicationRecord
   include School::GeneratedAttributeMethods
   include School::GeneratedAssociationMethods
   extend School::CustomFinderMethods
+  extend School::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   RelationType = T.type_alias { T.any(School::ActiveRecord_Relation, School::ActiveRecord_Associations_CollectionProxy, School::ActiveRecord_AssociationRelation) }
+end
 
+module School::QueryMethodsReturningRelation
   sig { returns(School::ActiveRecord_Relation) }
-  def self.all; end
+  def all; end
 
   sig { params(block: T.nilable(T.proc.void)).returns(School::ActiveRecord_Relation) }
-  def self.unscoped(&block); end
+  def unscoped(&block); end
 
   sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def self.select(*args); end
+  def select(*args); end
 
   sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def self.order(*args); end
+  def order(*args); end
 
   sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def self.reorder(*args); end
+  def reorder(*args); end
 
   sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def self.group(*args); end
+  def group(*args); end
 
   sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def self.limit(*args); end
+  def limit(*args); end
 
   sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def self.offset(*args); end
+  def offset(*args); end
 
   sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def self.joins(*args); end
+  def joins(*args); end
 
   sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def self.left_joins(*args); end
+  def left_joins(*args); end
 
   sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def self.left_outer_joins(*args); end
+  def left_outer_joins(*args); end
 
   sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def self.where(*args); end
+  def where(*args); end
 
   sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def self.rewhere(*args); end
+  def rewhere(*args); end
 
   sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def self.preload(*args); end
+  def preload(*args); end
 
   sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def self.eager_load(*args); end
+  def eager_load(*args); end
 
   sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def self.includes(*args); end
+  def includes(*args); end
 
   sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def self.from(*args); end
+  def from(*args); end
 
   sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def self.lock(*args); end
+  def lock(*args); end
 
   sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def self.readonly(*args); end
+  def readonly(*args); end
 
   sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def self.or(*args); end
+  def or(*args); end
 
   sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def self.having(*args); end
+  def having(*args); end
 
   sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def self.create_with(*args); end
+  def create_with(*args); end
 
   sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def self.distinct(*args); end
+  def distinct(*args); end
 
   sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def self.references(*args); end
+  def references(*args); end
 
   sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def self.none(*args); end
+  def none(*args); end
 
   sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def self.unscope(*args); end
+  def unscope(*args); end
 
   sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def self.except(*args); end
+  def except(*args); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(School::ActiveRecord_Relation) }
-  def self.extending(*args, &block); end
+  def extending(*args, &block); end
+end
+
+module School::QueryMethodsReturningAssociationRelation
+  sig { returns(School::ActiveRecord_AssociationRelation) }
+  def all; end
+
+  sig { params(block: T.nilable(T.proc.void)).returns(School::ActiveRecord_Relation) }
+  def unscoped(&block); end
+
+  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
+  def select(*args); end
+
+  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
+  def order(*args); end
+
+  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
+  def reorder(*args); end
+
+  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
+  def group(*args); end
+
+  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
+  def limit(*args); end
+
+  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
+  def offset(*args); end
+
+  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
+  def joins(*args); end
+
+  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
+  def left_joins(*args); end
+
+  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
+  def left_outer_joins(*args); end
+
+  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
+  def where(*args); end
+
+  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
+  def rewhere(*args); end
+
+  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
+  def preload(*args); end
+
+  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
+  def eager_load(*args); end
+
+  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
+  def includes(*args); end
+
+  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
+  def from(*args); end
+
+  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
+  def lock(*args); end
+
+  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
+  def readonly(*args); end
+
+  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
+  def or(*args); end
+
+  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
+  def having(*args); end
+
+  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
+  def create_with(*args); end
+
+  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
+  def distinct(*args); end
+
+  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
+  def references(*args); end
+
+  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
+  def none(*args); end
+
+  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
+  def unscope(*args); end
+
+  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
+  def except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(School::ActiveRecord_AssociationRelation) }
+  def extending(*args, &block); end
 end
 
 class School::ActiveRecord_Relation < ActiveRecord::Relation
   include School::ActiveRelation_WhereNot
   include School::CustomFinderMethods
+  include School::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: School)
-
-  sig { returns(School::ActiveRecord_Relation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(School::ActiveRecord_Relation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(School::ActiveRecord_Relation) }
-  def extending(*args, &block); end
 end
 
 class School::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
   include School::ActiveRelation_WhereNot
   include School::CustomFinderMethods
+  include School::QueryMethodsReturningAssociationRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: School)
-
-  sig { returns(School::ActiveRecord_AssociationRelation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(School::ActiveRecord_AssociationRelation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(School::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
 end
 
 class School::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include School::CustomFinderMethods
+  include School::QueryMethodsReturningAssociationRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: School)
-
-  sig { returns(School::ActiveRecord_AssociationRelation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(School::ActiveRecord_AssociationRelation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(School::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
 
   sig { params(records: T.any(School, T::Array[School])).returns(T.self_type) }
   def <<(*records); end

--- a/spec/test_data/v5.0/expected_spell.rbi
+++ b/spec/test_data/v5.0/expected_spell.rbi
@@ -8,8 +8,6 @@ module Spell::ActiveRelation_WhereNot
 end
 
 module Spell::GeneratedAttributeMethods
-  extend T::Sig
-
   sig { returns(Integer) }
   def id; end
 
@@ -30,8 +28,6 @@ module Spell::GeneratedAttributeMethods
 end
 
 module Spell::GeneratedAssociationMethods
-  extend T::Sig
-
   sig { returns(::SpellBook::ActiveRecord_Associations_CollectionProxy) }
   def spell_books; end
 
@@ -64,8 +60,6 @@ class Spell < ApplicationRecord
   include Spell::GeneratedAssociationMethods
   extend Spell::CustomFinderMethods
   extend Spell::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   RelationType = T.type_alias { T.any(Spell::ActiveRecord_Relation, Spell::ActiveRecord_Associations_CollectionProxy, Spell::ActiveRecord_AssociationRelation) }
 end
 
@@ -245,8 +239,6 @@ class Spell::ActiveRecord_Relation < ActiveRecord::Relation
   include Spell::ActiveRelation_WhereNot
   include Spell::CustomFinderMethods
   include Spell::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Spell)
 end
 
@@ -254,16 +246,12 @@ class Spell::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelatio
   include Spell::ActiveRelation_WhereNot
   include Spell::CustomFinderMethods
   include Spell::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Spell)
 end
 
 class Spell::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include Spell::CustomFinderMethods
   include Spell::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Spell)
 
   sig { params(records: T.any(Spell, T::Array[Spell])).returns(T.self_type) }

--- a/spec/test_data/v5.0/expected_spell.rbi
+++ b/spec/test_data/v5.0/expected_spell.rbi
@@ -63,368 +63,208 @@ class Spell < ApplicationRecord
   include Spell::GeneratedAttributeMethods
   include Spell::GeneratedAssociationMethods
   extend Spell::CustomFinderMethods
+  extend Spell::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   RelationType = T.type_alias { T.any(Spell::ActiveRecord_Relation, Spell::ActiveRecord_Associations_CollectionProxy, Spell::ActiveRecord_AssociationRelation) }
+end
 
+module Spell::QueryMethodsReturningRelation
   sig { returns(Spell::ActiveRecord_Relation) }
-  def self.all; end
+  def all; end
 
   sig { params(block: T.nilable(T.proc.void)).returns(Spell::ActiveRecord_Relation) }
-  def self.unscoped(&block); end
+  def unscoped(&block); end
 
   sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def self.select(*args); end
+  def select(*args); end
 
   sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def self.order(*args); end
+  def order(*args); end
 
   sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def self.reorder(*args); end
+  def reorder(*args); end
 
   sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def self.group(*args); end
+  def group(*args); end
 
   sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def self.limit(*args); end
+  def limit(*args); end
 
   sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def self.offset(*args); end
+  def offset(*args); end
 
   sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def self.joins(*args); end
+  def joins(*args); end
 
   sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def self.left_joins(*args); end
+  def left_joins(*args); end
 
   sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def self.left_outer_joins(*args); end
+  def left_outer_joins(*args); end
 
   sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def self.where(*args); end
+  def where(*args); end
 
   sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def self.rewhere(*args); end
+  def rewhere(*args); end
 
   sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def self.preload(*args); end
+  def preload(*args); end
 
   sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def self.eager_load(*args); end
+  def eager_load(*args); end
 
   sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def self.includes(*args); end
+  def includes(*args); end
 
   sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def self.from(*args); end
+  def from(*args); end
 
   sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def self.lock(*args); end
+  def lock(*args); end
 
   sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def self.readonly(*args); end
+  def readonly(*args); end
 
   sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def self.or(*args); end
+  def or(*args); end
 
   sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def self.having(*args); end
+  def having(*args); end
 
   sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def self.create_with(*args); end
+  def create_with(*args); end
 
   sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def self.distinct(*args); end
+  def distinct(*args); end
 
   sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def self.references(*args); end
+  def references(*args); end
 
   sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def self.none(*args); end
+  def none(*args); end
 
   sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def self.unscope(*args); end
+  def unscope(*args); end
 
   sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def self.except(*args); end
+  def except(*args); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Spell::ActiveRecord_Relation) }
-  def self.extending(*args, &block); end
+  def extending(*args, &block); end
+end
+
+module Spell::QueryMethodsReturningAssociationRelation
+  sig { returns(Spell::ActiveRecord_AssociationRelation) }
+  def all; end
+
+  sig { params(block: T.nilable(T.proc.void)).returns(Spell::ActiveRecord_Relation) }
+  def unscoped(&block); end
+
+  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
+  def select(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
+  def order(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
+  def reorder(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
+  def group(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
+  def limit(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
+  def offset(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
+  def joins(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
+  def left_joins(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
+  def left_outer_joins(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
+  def where(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
+  def rewhere(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
+  def preload(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
+  def eager_load(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
+  def includes(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
+  def from(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
+  def lock(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
+  def readonly(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
+  def or(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
+  def having(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
+  def create_with(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
+  def distinct(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
+  def references(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
+  def none(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
+  def unscope(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
+  def except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Spell::ActiveRecord_AssociationRelation) }
+  def extending(*args, &block); end
 end
 
 class Spell::ActiveRecord_Relation < ActiveRecord::Relation
   include Spell::ActiveRelation_WhereNot
   include Spell::CustomFinderMethods
+  include Spell::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: Spell)
-
-  sig { returns(Spell::ActiveRecord_Relation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Spell::ActiveRecord_Relation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Spell::ActiveRecord_Relation) }
-  def extending(*args, &block); end
 end
 
 class Spell::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
   include Spell::ActiveRelation_WhereNot
   include Spell::CustomFinderMethods
+  include Spell::QueryMethodsReturningAssociationRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: Spell)
-
-  sig { returns(Spell::ActiveRecord_AssociationRelation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Spell::ActiveRecord_AssociationRelation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Spell::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
 end
 
 class Spell::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include Spell::CustomFinderMethods
+  include Spell::QueryMethodsReturningAssociationRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: Spell)
-
-  sig { returns(Spell::ActiveRecord_AssociationRelation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Spell::ActiveRecord_AssociationRelation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Spell::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
 
   sig { params(records: T.any(Spell, T::Array[Spell])).returns(T.self_type) }
   def <<(*records); end

--- a/spec/test_data/v5.0/expected_spell/habtm_spell_books.rbi
+++ b/spec/test_data/v5.0/expected_spell/habtm_spell_books.rbi
@@ -66,368 +66,208 @@ class Spell::HABTM_SpellBooks < ActiveRecord::Base
   include Spell::HABTM_SpellBooks::GeneratedAttributeMethods
   include Spell::HABTM_SpellBooks::GeneratedAssociationMethods
   extend Spell::HABTM_SpellBooks::CustomFinderMethods
+  extend Spell::HABTM_SpellBooks::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   RelationType = T.type_alias { T.any(Spell::HABTM_SpellBooks::ActiveRecord_Relation, Spell::HABTM_SpellBooks::ActiveRecord_Associations_CollectionProxy, Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
+end
 
+module Spell::HABTM_SpellBooks::QueryMethodsReturningRelation
   sig { returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def self.all; end
+  def all; end
 
   sig { params(block: T.nilable(T.proc.void)).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def self.unscoped(&block); end
+  def unscoped(&block); end
 
   sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def self.select(*args); end
+  def select(*args); end
 
   sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def self.order(*args); end
+  def order(*args); end
 
   sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def self.reorder(*args); end
+  def reorder(*args); end
 
   sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def self.group(*args); end
+  def group(*args); end
 
   sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def self.limit(*args); end
+  def limit(*args); end
 
   sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def self.offset(*args); end
+  def offset(*args); end
 
   sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def self.joins(*args); end
+  def joins(*args); end
 
   sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def self.left_joins(*args); end
+  def left_joins(*args); end
 
   sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def self.left_outer_joins(*args); end
+  def left_outer_joins(*args); end
 
   sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def self.where(*args); end
+  def where(*args); end
 
   sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def self.rewhere(*args); end
+  def rewhere(*args); end
 
   sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def self.preload(*args); end
+  def preload(*args); end
 
   sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def self.eager_load(*args); end
+  def eager_load(*args); end
 
   sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def self.includes(*args); end
+  def includes(*args); end
 
   sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def self.from(*args); end
+  def from(*args); end
 
   sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def self.lock(*args); end
+  def lock(*args); end
 
   sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def self.readonly(*args); end
+  def readonly(*args); end
 
   sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def self.or(*args); end
+  def or(*args); end
 
   sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def self.having(*args); end
+  def having(*args); end
 
   sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def self.create_with(*args); end
+  def create_with(*args); end
 
   sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def self.distinct(*args); end
+  def distinct(*args); end
 
   sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def self.references(*args); end
+  def references(*args); end
 
   sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def self.none(*args); end
+  def none(*args); end
 
   sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def self.unscope(*args); end
+  def unscope(*args); end
 
   sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def self.except(*args); end
+  def except(*args); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def self.extending(*args, &block); end
+  def extending(*args, &block); end
+end
+
+module Spell::HABTM_SpellBooks::QueryMethodsReturningAssociationRelation
+  sig { returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
+  def all; end
+
+  sig { params(block: T.nilable(T.proc.void)).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
+  def unscoped(&block); end
+
+  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
+  def select(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
+  def order(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
+  def reorder(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
+  def group(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
+  def limit(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
+  def offset(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
+  def joins(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
+  def left_joins(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
+  def left_outer_joins(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
+  def where(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
+  def rewhere(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
+  def preload(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
+  def eager_load(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
+  def includes(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
+  def from(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
+  def lock(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
+  def readonly(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
+  def or(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
+  def having(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
+  def create_with(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
+  def distinct(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
+  def references(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
+  def none(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
+  def unscope(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
+  def except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
+  def extending(*args, &block); end
 end
 
 class Spell::HABTM_SpellBooks::ActiveRecord_Relation < ActiveRecord::Relation
   include Spell::HABTM_SpellBooks::ActiveRelation_WhereNot
   include Spell::HABTM_SpellBooks::CustomFinderMethods
+  include Spell::HABTM_SpellBooks::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: Spell::HABTM_SpellBooks)
-
-  sig { returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def extending(*args, &block); end
 end
 
 class Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
   include Spell::HABTM_SpellBooks::ActiveRelation_WhereNot
   include Spell::HABTM_SpellBooks::CustomFinderMethods
+  include Spell::HABTM_SpellBooks::QueryMethodsReturningAssociationRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: Spell::HABTM_SpellBooks)
-
-  sig { returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
 end
 
 class Spell::HABTM_SpellBooks::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include Spell::HABTM_SpellBooks::CustomFinderMethods
+  include Spell::HABTM_SpellBooks::QueryMethodsReturningAssociationRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: Spell::HABTM_SpellBooks)
-
-  sig { returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
 
   sig { params(records: T.any(Spell::HABTM_SpellBooks, T::Array[Spell::HABTM_SpellBooks])).returns(T.self_type) }
   def <<(*records); end

--- a/spec/test_data/v5.0/expected_spell/habtm_spell_books.rbi
+++ b/spec/test_data/v5.0/expected_spell/habtm_spell_books.rbi
@@ -8,8 +8,6 @@ module Spell::HABTM_SpellBooks::ActiveRelation_WhereNot
 end
 
 module Spell::HABTM_SpellBooks::GeneratedAttributeMethods
-  extend T::Sig
-
   sig { returns(Integer) }
   def spell_book_id; end
 
@@ -30,8 +28,6 @@ module Spell::HABTM_SpellBooks::GeneratedAttributeMethods
 end
 
 module Spell::HABTM_SpellBooks::GeneratedAssociationMethods
-  extend T::Sig
-
   sig { returns(T.nilable(::Spell)) }
   def left_side; end
 
@@ -67,8 +63,6 @@ class Spell::HABTM_SpellBooks < ActiveRecord::Base
   include Spell::HABTM_SpellBooks::GeneratedAssociationMethods
   extend Spell::HABTM_SpellBooks::CustomFinderMethods
   extend Spell::HABTM_SpellBooks::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   RelationType = T.type_alias { T.any(Spell::HABTM_SpellBooks::ActiveRecord_Relation, Spell::HABTM_SpellBooks::ActiveRecord_Associations_CollectionProxy, Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
 end
 
@@ -248,8 +242,6 @@ class Spell::HABTM_SpellBooks::ActiveRecord_Relation < ActiveRecord::Relation
   include Spell::HABTM_SpellBooks::ActiveRelation_WhereNot
   include Spell::HABTM_SpellBooks::CustomFinderMethods
   include Spell::HABTM_SpellBooks::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Spell::HABTM_SpellBooks)
 end
 
@@ -257,16 +249,12 @@ class Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation < ActiveRecord::
   include Spell::HABTM_SpellBooks::ActiveRelation_WhereNot
   include Spell::HABTM_SpellBooks::CustomFinderMethods
   include Spell::HABTM_SpellBooks::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Spell::HABTM_SpellBooks)
 end
 
 class Spell::HABTM_SpellBooks::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include Spell::HABTM_SpellBooks::CustomFinderMethods
   include Spell::HABTM_SpellBooks::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Spell::HABTM_SpellBooks)
 
   sig { params(records: T.any(Spell::HABTM_SpellBooks, T::Array[Spell::HABTM_SpellBooks])).returns(T.self_type) }

--- a/spec/test_data/v5.0/expected_spell_book.rbi
+++ b/spec/test_data/v5.0/expected_spell_book.rbi
@@ -119,6 +119,7 @@ class SpellBook < ApplicationRecord
   include SpellBook::GeneratedAttributeMethods
   include SpellBook::GeneratedAssociationMethods
   extend SpellBook::CustomFinderMethods
+  extend SpellBook::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   RelationType = T.type_alias { T.any(SpellBook::ActiveRecord_Relation, SpellBook::ActiveRecord_Associations_CollectionProxy, SpellBook::ActiveRecord_AssociationRelation) }
@@ -133,91 +134,10 @@ class SpellBook < ApplicationRecord
   def self.dark_art(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def self.recent(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
   def self.unclassified(*args); end
-
-  sig { returns(SpellBook::ActiveRecord_Relation) }
-  def self.all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def self.unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def self.select(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def self.order(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def self.reorder(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def self.group(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def self.limit(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def self.offset(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def self.joins(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def self.left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def self.left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def self.where(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def self.rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def self.preload(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def self.eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def self.includes(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def self.from(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def self.lock(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def self.readonly(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def self.or(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def self.having(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def self.create_with(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def self.distinct(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def self.references(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def self.none(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def self.unscope(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def self.except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def self.extending(*args, &block); end
 
   sig { returns(SpellBook::BookType) }
   def typed_book_type; end
@@ -229,6 +149,7 @@ end
 class SpellBook::ActiveRecord_Relation < ActiveRecord::Relation
   include SpellBook::ActiveRelation_WhereNot
   include SpellBook::CustomFinderMethods
+  include SpellBook::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: SpellBook)
@@ -240,96 +161,16 @@ class SpellBook::ActiveRecord_Relation < ActiveRecord::Relation
   def dark_art(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def recent(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
   def unclassified(*args); end
-
-  sig { returns(SpellBook::ActiveRecord_Relation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def extending(*args, &block); end
 end
 
 class SpellBook::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
   include SpellBook::ActiveRelation_WhereNot
   include SpellBook::CustomFinderMethods
+  include SpellBook::QueryMethodsReturningAssociationRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: SpellBook)
@@ -341,95 +182,15 @@ class SpellBook::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRel
   def dark_art(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def recent(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
   def unclassified(*args); end
-
-  sig { returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
 end
 
 class SpellBook::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include SpellBook::CustomFinderMethods
+  include SpellBook::QueryMethodsReturningAssociationRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: SpellBook)
@@ -441,91 +202,10 @@ class SpellBook::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Assoc
   def dark_art(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def recent(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
   def unclassified(*args); end
-
-  sig { returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
 
   sig { params(records: T.any(SpellBook, T::Array[SpellBook])).returns(T.self_type) }
   def <<(*records); end
@@ -538,4 +218,176 @@ class SpellBook::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Assoc
 
   sig { params(records: T.any(SpellBook, T::Array[SpellBook])).returns(T.self_type) }
   def concat(*records); end
+end
+
+module SpellBook::QueryMethodsReturningRelation
+  sig { returns(SpellBook::ActiveRecord_Relation) }
+  def all; end
+
+  sig { params(block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
+  def unscoped(&block); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def select(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def order(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def reorder(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def group(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def limit(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def offset(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def joins(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def left_joins(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def left_outer_joins(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def where(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def rewhere(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def preload(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def eager_load(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def includes(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def from(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def lock(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def readonly(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def or(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def having(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def create_with(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def distinct(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def references(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def none(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def unscope(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
+  def extending(*args, &block); end
+end
+
+module SpellBook::QueryMethodsReturningAssociationRelation
+  sig { returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def all; end
+
+  sig { params(block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
+  def unscoped(&block); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def select(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def order(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def reorder(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def group(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def limit(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def offset(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def joins(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def left_joins(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def left_outer_joins(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def where(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def rewhere(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def preload(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def eager_load(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def includes(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def from(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def lock(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def readonly(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def or(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def having(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def create_with(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def distinct(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def references(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def none(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def unscope(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def extending(*args, &block); end
 end

--- a/spec/test_data/v5.0/expected_spell_book.rbi
+++ b/spec/test_data/v5.0/expected_spell_book.rbi
@@ -3,8 +3,6 @@
 
 # typed: strong
 module SpellBook::EnumInstanceMethods
-  extend T::Sig
-
   sig { returns(T::Boolean) }
   def unclassified?; end
 
@@ -30,8 +28,6 @@ module SpellBook::ActiveRelation_WhereNot
 end
 
 module SpellBook::GeneratedAttributeMethods
-  extend T::Sig
-
   sig { returns(String) }
   def book_type; end
 
@@ -79,8 +75,6 @@ class SpellBook::BookType < T::Enum
 end
 
 module SpellBook::GeneratedAssociationMethods
-  extend T::Sig
-
   sig { returns(::Spell::ActiveRecord_Associations_CollectionProxy) }
   def spells; end
 
@@ -120,8 +114,6 @@ class SpellBook < ApplicationRecord
   include SpellBook::GeneratedAssociationMethods
   extend SpellBook::CustomFinderMethods
   extend SpellBook::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   RelationType = T.type_alias { T.any(SpellBook::ActiveRecord_Relation, SpellBook::ActiveRecord_Associations_CollectionProxy, SpellBook::ActiveRecord_AssociationRelation) }
 
   sig { returns(T::Hash[T.any(String, Symbol), Integer]) }
@@ -150,8 +142,6 @@ class SpellBook::ActiveRecord_Relation < ActiveRecord::Relation
   include SpellBook::ActiveRelation_WhereNot
   include SpellBook::CustomFinderMethods
   include SpellBook::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: SpellBook)
 
   sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
@@ -171,8 +161,6 @@ class SpellBook::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRel
   include SpellBook::ActiveRelation_WhereNot
   include SpellBook::CustomFinderMethods
   include SpellBook::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: SpellBook)
 
   sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
@@ -191,8 +179,6 @@ end
 class SpellBook::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include SpellBook::CustomFinderMethods
   include SpellBook::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: SpellBook)
 
   sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }

--- a/spec/test_data/v5.0/expected_spell_book/habtm_spells.rbi
+++ b/spec/test_data/v5.0/expected_spell_book/habtm_spells.rbi
@@ -66,368 +66,208 @@ class SpellBook::HABTM_Spells < ActiveRecord::Base
   include SpellBook::HABTM_Spells::GeneratedAttributeMethods
   include SpellBook::HABTM_Spells::GeneratedAssociationMethods
   extend SpellBook::HABTM_Spells::CustomFinderMethods
+  extend SpellBook::HABTM_Spells::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   RelationType = T.type_alias { T.any(SpellBook::HABTM_Spells::ActiveRecord_Relation, SpellBook::HABTM_Spells::ActiveRecord_Associations_CollectionProxy, SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
+end
 
+module SpellBook::HABTM_Spells::QueryMethodsReturningRelation
   sig { returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def self.all; end
+  def all; end
 
   sig { params(block: T.nilable(T.proc.void)).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def self.unscoped(&block); end
+  def unscoped(&block); end
 
   sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def self.select(*args); end
+  def select(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def self.order(*args); end
+  def order(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def self.reorder(*args); end
+  def reorder(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def self.group(*args); end
+  def group(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def self.limit(*args); end
+  def limit(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def self.offset(*args); end
+  def offset(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def self.joins(*args); end
+  def joins(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def self.left_joins(*args); end
+  def left_joins(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def self.left_outer_joins(*args); end
+  def left_outer_joins(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def self.where(*args); end
+  def where(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def self.rewhere(*args); end
+  def rewhere(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def self.preload(*args); end
+  def preload(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def self.eager_load(*args); end
+  def eager_load(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def self.includes(*args); end
+  def includes(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def self.from(*args); end
+  def from(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def self.lock(*args); end
+  def lock(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def self.readonly(*args); end
+  def readonly(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def self.or(*args); end
+  def or(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def self.having(*args); end
+  def having(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def self.create_with(*args); end
+  def create_with(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def self.distinct(*args); end
+  def distinct(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def self.references(*args); end
+  def references(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def self.none(*args); end
+  def none(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def self.unscope(*args); end
+  def unscope(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def self.except(*args); end
+  def except(*args); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def self.extending(*args, &block); end
+  def extending(*args, &block); end
+end
+
+module SpellBook::HABTM_Spells::QueryMethodsReturningAssociationRelation
+  sig { returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
+  def all; end
+
+  sig { params(block: T.nilable(T.proc.void)).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
+  def unscoped(&block); end
+
+  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
+  def select(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
+  def order(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
+  def reorder(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
+  def group(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
+  def limit(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
+  def offset(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
+  def joins(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
+  def left_joins(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
+  def left_outer_joins(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
+  def where(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
+  def rewhere(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
+  def preload(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
+  def eager_load(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
+  def includes(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
+  def from(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
+  def lock(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
+  def readonly(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
+  def or(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
+  def having(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
+  def create_with(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
+  def distinct(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
+  def references(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
+  def none(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
+  def unscope(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
+  def except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
+  def extending(*args, &block); end
 end
 
 class SpellBook::HABTM_Spells::ActiveRecord_Relation < ActiveRecord::Relation
   include SpellBook::HABTM_Spells::ActiveRelation_WhereNot
   include SpellBook::HABTM_Spells::CustomFinderMethods
+  include SpellBook::HABTM_Spells::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: SpellBook::HABTM_Spells)
-
-  sig { returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def extending(*args, &block); end
 end
 
 class SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
   include SpellBook::HABTM_Spells::ActiveRelation_WhereNot
   include SpellBook::HABTM_Spells::CustomFinderMethods
+  include SpellBook::HABTM_Spells::QueryMethodsReturningAssociationRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: SpellBook::HABTM_Spells)
-
-  sig { returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
 end
 
 class SpellBook::HABTM_Spells::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include SpellBook::HABTM_Spells::CustomFinderMethods
+  include SpellBook::HABTM_Spells::QueryMethodsReturningAssociationRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: SpellBook::HABTM_Spells)
-
-  sig { returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
 
   sig { params(records: T.any(SpellBook::HABTM_Spells, T::Array[SpellBook::HABTM_Spells])).returns(T.self_type) }
   def <<(*records); end

--- a/spec/test_data/v5.0/expected_spell_book/habtm_spells.rbi
+++ b/spec/test_data/v5.0/expected_spell_book/habtm_spells.rbi
@@ -8,8 +8,6 @@ module SpellBook::HABTM_Spells::ActiveRelation_WhereNot
 end
 
 module SpellBook::HABTM_Spells::GeneratedAttributeMethods
-  extend T::Sig
-
   sig { returns(Integer) }
   def spell_book_id; end
 
@@ -30,8 +28,6 @@ module SpellBook::HABTM_Spells::GeneratedAttributeMethods
 end
 
 module SpellBook::HABTM_Spells::GeneratedAssociationMethods
-  extend T::Sig
-
   sig { returns(T.nilable(::SpellBook)) }
   def left_side; end
 
@@ -67,8 +63,6 @@ class SpellBook::HABTM_Spells < ActiveRecord::Base
   include SpellBook::HABTM_Spells::GeneratedAssociationMethods
   extend SpellBook::HABTM_Spells::CustomFinderMethods
   extend SpellBook::HABTM_Spells::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   RelationType = T.type_alias { T.any(SpellBook::HABTM_Spells::ActiveRecord_Relation, SpellBook::HABTM_Spells::ActiveRecord_Associations_CollectionProxy, SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
 end
 
@@ -248,8 +242,6 @@ class SpellBook::HABTM_Spells::ActiveRecord_Relation < ActiveRecord::Relation
   include SpellBook::HABTM_Spells::ActiveRelation_WhereNot
   include SpellBook::HABTM_Spells::CustomFinderMethods
   include SpellBook::HABTM_Spells::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: SpellBook::HABTM_Spells)
 end
 
@@ -257,16 +249,12 @@ class SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation < ActiveRecord::
   include SpellBook::HABTM_Spells::ActiveRelation_WhereNot
   include SpellBook::HABTM_Spells::CustomFinderMethods
   include SpellBook::HABTM_Spells::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: SpellBook::HABTM_Spells)
 end
 
 class SpellBook::HABTM_Spells::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include SpellBook::HABTM_Spells::CustomFinderMethods
   include SpellBook::HABTM_Spells::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: SpellBook::HABTM_Spells)
 
   sig { params(records: T.any(SpellBook::HABTM_Spells, T::Array[SpellBook::HABTM_Spells])).returns(T.self_type) }

--- a/spec/test_data/v5.0/expected_squib.rbi
+++ b/spec/test_data/v5.0/expected_squib.rbi
@@ -308,6 +308,7 @@ class Squib < Wizard
   include Squib::GeneratedAttributeMethods
   include Squib::GeneratedAssociationMethods
   extend Squib::CustomFinderMethods
+  extend Squib::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   RelationType = T.type_alias { T.any(Squib::ActiveRecord_Relation, Squib::ActiveRecord_Associations_CollectionProxy, Squib::ActiveRecord_AssociationRelation) }
@@ -383,95 +384,12 @@ class Squib < Wizard
 
   sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
   def self.recent(*args); end
-
-  sig { returns(Squib::ActiveRecord_Relation) }
-  def self.all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def self.unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.select(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.order(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.group(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.limit(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.offset(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.joins(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.where(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.preload(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.includes(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.from(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.lock(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.or(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.having(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.references(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.none(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def self.extending(*args, &block); end
 end
 
 class Squib::ActiveRecord_Relation < ActiveRecord::Relation
   include Squib::ActiveRelation_WhereNot
   include Squib::CustomFinderMethods
+  include Squib::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: Squib)
@@ -529,95 +447,12 @@ class Squib::ActiveRecord_Relation < ActiveRecord::Relation
 
   sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
   def recent(*args); end
-
-  sig { returns(Squib::ActiveRecord_Relation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def extending(*args, &block); end
 end
 
 class Squib::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
   include Squib::ActiveRelation_WhereNot
   include Squib::CustomFinderMethods
+  include Squib::QueryMethodsReturningAssociationRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: Squib)
@@ -675,94 +510,11 @@ class Squib::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelatio
 
   sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
   def recent(*args); end
-
-  sig { returns(Squib::ActiveRecord_AssociationRelation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
 end
 
 class Squib::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include Squib::CustomFinderMethods
+  include Squib::QueryMethodsReturningAssociationRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: Squib)
@@ -820,90 +572,6 @@ class Squib::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associati
 
   sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
   def recent(*args); end
-
-  sig { returns(Squib::ActiveRecord_AssociationRelation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
 
   sig { params(records: T.any(Squib, T::Array[Squib])).returns(T.self_type) }
   def <<(*records); end
@@ -916,4 +584,176 @@ class Squib::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associati
 
   sig { params(records: T.any(Squib, T::Array[Squib])).returns(T.self_type) }
   def concat(*records); end
+end
+
+module Squib::QueryMethodsReturningRelation
+  sig { returns(Squib::ActiveRecord_Relation) }
+  def all; end
+
+  sig { params(block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
+  def unscoped(&block); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def select(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def order(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def reorder(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def group(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def limit(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def offset(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def joins(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def left_joins(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def left_outer_joins(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def where(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def rewhere(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def preload(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def eager_load(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def includes(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def from(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def lock(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def readonly(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def or(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def having(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def create_with(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def distinct(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def references(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def none(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def unscope(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
+  def extending(*args, &block); end
+end
+
+module Squib::QueryMethodsReturningAssociationRelation
+  sig { returns(Squib::ActiveRecord_AssociationRelation) }
+  def all; end
+
+  sig { params(block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
+  def unscoped(&block); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def select(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def order(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def reorder(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def group(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def limit(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def offset(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def joins(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def left_joins(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def left_outer_joins(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def where(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def rewhere(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def preload(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def eager_load(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def includes(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def from(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def lock(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def readonly(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def or(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def having(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def create_with(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def distinct(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def references(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def none(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def unscope(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
+  def extending(*args, &block); end
 end

--- a/spec/test_data/v5.0/expected_squib.rbi
+++ b/spec/test_data/v5.0/expected_squib.rbi
@@ -3,8 +3,6 @@
 
 # typed: strong
 module Squib::EnumInstanceMethods
-  extend T::Sig
-
   sig { returns(T::Boolean) }
   def broom_nimbus?; end
 
@@ -114,8 +112,6 @@ module Squib::ActiveRelation_WhereNot
 end
 
 module Squib::GeneratedAttributeMethods
-  extend T::Sig
-
   sig { returns(T.nilable(String)) }
   def broom; end
 
@@ -253,8 +249,6 @@ module Squib::GeneratedAttributeMethods
 end
 
 module Squib::GeneratedAssociationMethods
-  extend T::Sig
-
   sig { returns(T.nilable(::School)) }
   def school; end
 
@@ -309,8 +303,6 @@ class Squib < Wizard
   include Squib::GeneratedAssociationMethods
   extend Squib::CustomFinderMethods
   extend Squib::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   RelationType = T.type_alias { T.any(Squib::ActiveRecord_Relation, Squib::ActiveRecord_Associations_CollectionProxy, Squib::ActiveRecord_AssociationRelation) }
 
   sig { returns(T::Hash[T.any(String, Symbol), String]) }
@@ -390,8 +382,6 @@ class Squib::ActiveRecord_Relation < ActiveRecord::Relation
   include Squib::ActiveRelation_WhereNot
   include Squib::CustomFinderMethods
   include Squib::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Squib)
 
   sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
@@ -453,8 +443,6 @@ class Squib::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelatio
   include Squib::ActiveRelation_WhereNot
   include Squib::CustomFinderMethods
   include Squib::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Squib)
 
   sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
@@ -515,8 +503,6 @@ end
 class Squib::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include Squib::CustomFinderMethods
   include Squib::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Squib)
 
   sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }

--- a/spec/test_data/v5.0/expected_subject.rbi
+++ b/spec/test_data/v5.0/expected_subject.rbi
@@ -8,8 +8,6 @@ module Subject::ActiveRelation_WhereNot
 end
 
 module Subject::GeneratedAttributeMethods
-  extend T::Sig
-
   sig { returns(Integer) }
   def id; end
 
@@ -30,8 +28,6 @@ module Subject::GeneratedAttributeMethods
 end
 
 module Subject::GeneratedAssociationMethods
-  extend T::Sig
-
   sig { returns(::Wizard::ActiveRecord_Associations_CollectionProxy) }
   def wizards; end
 
@@ -64,8 +60,6 @@ class Subject < ApplicationRecord
   include Subject::GeneratedAssociationMethods
   extend Subject::CustomFinderMethods
   extend Subject::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   RelationType = T.type_alias { T.any(Subject::ActiveRecord_Relation, Subject::ActiveRecord_Associations_CollectionProxy, Subject::ActiveRecord_AssociationRelation) }
 end
 
@@ -245,8 +239,6 @@ class Subject::ActiveRecord_Relation < ActiveRecord::Relation
   include Subject::ActiveRelation_WhereNot
   include Subject::CustomFinderMethods
   include Subject::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Subject)
 end
 
@@ -254,16 +246,12 @@ class Subject::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelat
   include Subject::ActiveRelation_WhereNot
   include Subject::CustomFinderMethods
   include Subject::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Subject)
 end
 
 class Subject::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include Subject::CustomFinderMethods
   include Subject::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Subject)
 
   sig { params(records: T.any(Subject, T::Array[Subject])).returns(T.self_type) }

--- a/spec/test_data/v5.0/expected_subject.rbi
+++ b/spec/test_data/v5.0/expected_subject.rbi
@@ -63,368 +63,208 @@ class Subject < ApplicationRecord
   include Subject::GeneratedAttributeMethods
   include Subject::GeneratedAssociationMethods
   extend Subject::CustomFinderMethods
+  extend Subject::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   RelationType = T.type_alias { T.any(Subject::ActiveRecord_Relation, Subject::ActiveRecord_Associations_CollectionProxy, Subject::ActiveRecord_AssociationRelation) }
+end
 
+module Subject::QueryMethodsReturningRelation
   sig { returns(Subject::ActiveRecord_Relation) }
-  def self.all; end
+  def all; end
 
   sig { params(block: T.nilable(T.proc.void)).returns(Subject::ActiveRecord_Relation) }
-  def self.unscoped(&block); end
+  def unscoped(&block); end
 
   sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def self.select(*args); end
+  def select(*args); end
 
   sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def self.order(*args); end
+  def order(*args); end
 
   sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def self.reorder(*args); end
+  def reorder(*args); end
 
   sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def self.group(*args); end
+  def group(*args); end
 
   sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def self.limit(*args); end
+  def limit(*args); end
 
   sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def self.offset(*args); end
+  def offset(*args); end
 
   sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def self.joins(*args); end
+  def joins(*args); end
 
   sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def self.left_joins(*args); end
+  def left_joins(*args); end
 
   sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def self.left_outer_joins(*args); end
+  def left_outer_joins(*args); end
 
   sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def self.where(*args); end
+  def where(*args); end
 
   sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def self.rewhere(*args); end
+  def rewhere(*args); end
 
   sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def self.preload(*args); end
+  def preload(*args); end
 
   sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def self.eager_load(*args); end
+  def eager_load(*args); end
 
   sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def self.includes(*args); end
+  def includes(*args); end
 
   sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def self.from(*args); end
+  def from(*args); end
 
   sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def self.lock(*args); end
+  def lock(*args); end
 
   sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def self.readonly(*args); end
+  def readonly(*args); end
 
   sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def self.or(*args); end
+  def or(*args); end
 
   sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def self.having(*args); end
+  def having(*args); end
 
   sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def self.create_with(*args); end
+  def create_with(*args); end
 
   sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def self.distinct(*args); end
+  def distinct(*args); end
 
   sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def self.references(*args); end
+  def references(*args); end
 
   sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def self.none(*args); end
+  def none(*args); end
 
   sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def self.unscope(*args); end
+  def unscope(*args); end
 
   sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def self.except(*args); end
+  def except(*args); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Subject::ActiveRecord_Relation) }
-  def self.extending(*args, &block); end
+  def extending(*args, &block); end
+end
+
+module Subject::QueryMethodsReturningAssociationRelation
+  sig { returns(Subject::ActiveRecord_AssociationRelation) }
+  def all; end
+
+  sig { params(block: T.nilable(T.proc.void)).returns(Subject::ActiveRecord_Relation) }
+  def unscoped(&block); end
+
+  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
+  def select(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
+  def order(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
+  def reorder(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
+  def group(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
+  def limit(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
+  def offset(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
+  def joins(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
+  def left_joins(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
+  def left_outer_joins(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
+  def where(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
+  def rewhere(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
+  def preload(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
+  def eager_load(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
+  def includes(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
+  def from(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
+  def lock(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
+  def readonly(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
+  def or(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
+  def having(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
+  def create_with(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
+  def distinct(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
+  def references(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
+  def none(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
+  def unscope(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
+  def except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Subject::ActiveRecord_AssociationRelation) }
+  def extending(*args, &block); end
 end
 
 class Subject::ActiveRecord_Relation < ActiveRecord::Relation
   include Subject::ActiveRelation_WhereNot
   include Subject::CustomFinderMethods
+  include Subject::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: Subject)
-
-  sig { returns(Subject::ActiveRecord_Relation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Subject::ActiveRecord_Relation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Subject::ActiveRecord_Relation) }
-  def extending(*args, &block); end
 end
 
 class Subject::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
   include Subject::ActiveRelation_WhereNot
   include Subject::CustomFinderMethods
+  include Subject::QueryMethodsReturningAssociationRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: Subject)
-
-  sig { returns(Subject::ActiveRecord_AssociationRelation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Subject::ActiveRecord_AssociationRelation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Subject::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
 end
 
 class Subject::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include Subject::CustomFinderMethods
+  include Subject::QueryMethodsReturningAssociationRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: Subject)
-
-  sig { returns(Subject::ActiveRecord_AssociationRelation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Subject::ActiveRecord_AssociationRelation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Subject::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
 
   sig { params(records: T.any(Subject, T::Array[Subject])).returns(T.self_type) }
   def <<(*records); end

--- a/spec/test_data/v5.0/expected_subject/habtm_wizards.rbi
+++ b/spec/test_data/v5.0/expected_subject/habtm_wizards.rbi
@@ -8,8 +8,6 @@ module Subject::HABTM_Wizards::ActiveRelation_WhereNot
 end
 
 module Subject::HABTM_Wizards::GeneratedAttributeMethods
-  extend T::Sig
-
   sig { returns(T.nilable(Integer)) }
   def subject_id; end
 
@@ -30,8 +28,6 @@ module Subject::HABTM_Wizards::GeneratedAttributeMethods
 end
 
 module Subject::HABTM_Wizards::GeneratedAssociationMethods
-  extend T::Sig
-
   sig { returns(T.nilable(::Subject)) }
   def left_side; end
 
@@ -67,8 +63,6 @@ class Subject::HABTM_Wizards < ActiveRecord::Base
   include Subject::HABTM_Wizards::GeneratedAssociationMethods
   extend Subject::HABTM_Wizards::CustomFinderMethods
   extend Subject::HABTM_Wizards::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   RelationType = T.type_alias { T.any(Subject::HABTM_Wizards::ActiveRecord_Relation, Subject::HABTM_Wizards::ActiveRecord_Associations_CollectionProxy, Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
 end
 
@@ -248,8 +242,6 @@ class Subject::HABTM_Wizards::ActiveRecord_Relation < ActiveRecord::Relation
   include Subject::HABTM_Wizards::ActiveRelation_WhereNot
   include Subject::HABTM_Wizards::CustomFinderMethods
   include Subject::HABTM_Wizards::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Subject::HABTM_Wizards)
 end
 
@@ -257,16 +249,12 @@ class Subject::HABTM_Wizards::ActiveRecord_AssociationRelation < ActiveRecord::A
   include Subject::HABTM_Wizards::ActiveRelation_WhereNot
   include Subject::HABTM_Wizards::CustomFinderMethods
   include Subject::HABTM_Wizards::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Subject::HABTM_Wizards)
 end
 
 class Subject::HABTM_Wizards::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include Subject::HABTM_Wizards::CustomFinderMethods
   include Subject::HABTM_Wizards::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Subject::HABTM_Wizards)
 
   sig { params(records: T.any(Subject::HABTM_Wizards, T::Array[Subject::HABTM_Wizards])).returns(T.self_type) }

--- a/spec/test_data/v5.0/expected_subject/habtm_wizards.rbi
+++ b/spec/test_data/v5.0/expected_subject/habtm_wizards.rbi
@@ -66,368 +66,208 @@ class Subject::HABTM_Wizards < ActiveRecord::Base
   include Subject::HABTM_Wizards::GeneratedAttributeMethods
   include Subject::HABTM_Wizards::GeneratedAssociationMethods
   extend Subject::HABTM_Wizards::CustomFinderMethods
+  extend Subject::HABTM_Wizards::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   RelationType = T.type_alias { T.any(Subject::HABTM_Wizards::ActiveRecord_Relation, Subject::HABTM_Wizards::ActiveRecord_Associations_CollectionProxy, Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
+end
 
+module Subject::HABTM_Wizards::QueryMethodsReturningRelation
   sig { returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def self.all; end
+  def all; end
 
   sig { params(block: T.nilable(T.proc.void)).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def self.unscoped(&block); end
+  def unscoped(&block); end
 
   sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def self.select(*args); end
+  def select(*args); end
 
   sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def self.order(*args); end
+  def order(*args); end
 
   sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def self.reorder(*args); end
+  def reorder(*args); end
 
   sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def self.group(*args); end
+  def group(*args); end
 
   sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def self.limit(*args); end
+  def limit(*args); end
 
   sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def self.offset(*args); end
+  def offset(*args); end
 
   sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def self.joins(*args); end
+  def joins(*args); end
 
   sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def self.left_joins(*args); end
+  def left_joins(*args); end
 
   sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def self.left_outer_joins(*args); end
+  def left_outer_joins(*args); end
 
   sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def self.where(*args); end
+  def where(*args); end
 
   sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def self.rewhere(*args); end
+  def rewhere(*args); end
 
   sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def self.preload(*args); end
+  def preload(*args); end
 
   sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def self.eager_load(*args); end
+  def eager_load(*args); end
 
   sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def self.includes(*args); end
+  def includes(*args); end
 
   sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def self.from(*args); end
+  def from(*args); end
 
   sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def self.lock(*args); end
+  def lock(*args); end
 
   sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def self.readonly(*args); end
+  def readonly(*args); end
 
   sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def self.or(*args); end
+  def or(*args); end
 
   sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def self.having(*args); end
+  def having(*args); end
 
   sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def self.create_with(*args); end
+  def create_with(*args); end
 
   sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def self.distinct(*args); end
+  def distinct(*args); end
 
   sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def self.references(*args); end
+  def references(*args); end
 
   sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def self.none(*args); end
+  def none(*args); end
 
   sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def self.unscope(*args); end
+  def unscope(*args); end
 
   sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def self.except(*args); end
+  def except(*args); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def self.extending(*args, &block); end
+  def extending(*args, &block); end
+end
+
+module Subject::HABTM_Wizards::QueryMethodsReturningAssociationRelation
+  sig { returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
+  def all; end
+
+  sig { params(block: T.nilable(T.proc.void)).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
+  def unscoped(&block); end
+
+  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
+  def select(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
+  def order(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
+  def reorder(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
+  def group(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
+  def limit(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
+  def offset(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
+  def joins(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
+  def left_joins(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
+  def left_outer_joins(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
+  def where(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
+  def rewhere(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
+  def preload(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
+  def eager_load(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
+  def includes(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
+  def from(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
+  def lock(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
+  def readonly(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
+  def or(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
+  def having(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
+  def create_with(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
+  def distinct(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
+  def references(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
+  def none(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
+  def unscope(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
+  def except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
+  def extending(*args, &block); end
 end
 
 class Subject::HABTM_Wizards::ActiveRecord_Relation < ActiveRecord::Relation
   include Subject::HABTM_Wizards::ActiveRelation_WhereNot
   include Subject::HABTM_Wizards::CustomFinderMethods
+  include Subject::HABTM_Wizards::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: Subject::HABTM_Wizards)
-
-  sig { returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def extending(*args, &block); end
 end
 
 class Subject::HABTM_Wizards::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
   include Subject::HABTM_Wizards::ActiveRelation_WhereNot
   include Subject::HABTM_Wizards::CustomFinderMethods
+  include Subject::HABTM_Wizards::QueryMethodsReturningAssociationRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: Subject::HABTM_Wizards)
-
-  sig { returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
 end
 
 class Subject::HABTM_Wizards::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include Subject::HABTM_Wizards::CustomFinderMethods
+  include Subject::HABTM_Wizards::QueryMethodsReturningAssociationRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: Subject::HABTM_Wizards)
-
-  sig { returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
 
   sig { params(records: T.any(Subject::HABTM_Wizards, T::Array[Subject::HABTM_Wizards])).returns(T.self_type) }
   def <<(*records); end

--- a/spec/test_data/v5.0/expected_wand.rbi
+++ b/spec/test_data/v5.0/expected_wand.rbi
@@ -198,6 +198,7 @@ class Wand < ApplicationRecord
   include Wand::GeneratedAttributeMethods
   include Wand::GeneratedAssociationMethods
   extend Wand::CustomFinderMethods
+  extend Wand::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   RelationType = T.type_alias { T.any(Wand::ActiveRecord_Relation, Wand::ActiveRecord_Associations_CollectionProxy, Wand::ActiveRecord_AssociationRelation) }
@@ -217,90 +218,6 @@ class Wand < ApplicationRecord
   sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
   def self.unicorn_tail_hair(*args); end
 
-  sig { returns(Wand::ActiveRecord_Relation) }
-  def self.all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def self.unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
-  def self.select(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
-  def self.order(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
-  def self.reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
-  def self.group(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
-  def self.limit(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
-  def self.offset(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
-  def self.joins(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
-  def self.left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
-  def self.left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
-  def self.where(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
-  def self.rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
-  def self.preload(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
-  def self.eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
-  def self.includes(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
-  def self.from(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
-  def self.lock(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
-  def self.readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
-  def self.or(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
-  def self.having(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
-  def self.create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
-  def self.distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
-  def self.references(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
-  def self.none(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
-  def self.unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
-  def self.except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def self.extending(*args, &block); end
-
   sig { returns(T.nilable(Wand::CoreType)) }
   def typed_core_type; end
 
@@ -314,6 +231,7 @@ end
 class Wand::ActiveRecord_Relation < ActiveRecord::Relation
   include Wand::ActiveRelation_WhereNot
   include Wand::CustomFinderMethods
+  include Wand::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: Wand)
@@ -329,7 +247,62 @@ class Wand::ActiveRecord_Relation < ActiveRecord::Relation
 
   sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
   def unicorn_tail_hair(*args); end
+end
 
+class Wand::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
+  include Wand::ActiveRelation_WhereNot
+  include Wand::CustomFinderMethods
+  include Wand::QueryMethodsReturningAssociationRelation
+  extend T::Sig
+  extend T::Generic
+  Elem = type_member(fixed: Wand)
+
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def basilisk_horn(*args); end
+
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def dragon_heartstring(*args); end
+
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def phoenix_feather(*args); end
+
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def unicorn_tail_hair(*args); end
+end
+
+class Wand::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
+  include Wand::CustomFinderMethods
+  include Wand::QueryMethodsReturningAssociationRelation
+  extend T::Sig
+  extend T::Generic
+  Elem = type_member(fixed: Wand)
+
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def basilisk_horn(*args); end
+
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def dragon_heartstring(*args); end
+
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def phoenix_feather(*args); end
+
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def unicorn_tail_hair(*args); end
+
+  sig { params(records: T.any(Wand, T::Array[Wand])).returns(T.self_type) }
+  def <<(*records); end
+
+  sig { params(records: T.any(Wand, T::Array[Wand])).returns(T.self_type) }
+  def append(*records); end
+
+  sig { params(records: T.any(Wand, T::Array[Wand])).returns(T.self_type) }
+  def push(*records); end
+
+  sig { params(records: T.any(Wand, T::Array[Wand])).returns(T.self_type) }
+  def concat(*records); end
+end
+
+module Wand::QueryMethodsReturningRelation
   sig { returns(Wand::ActiveRecord_Relation) }
   def all; end
 
@@ -415,29 +388,11 @@ class Wand::ActiveRecord_Relation < ActiveRecord::Relation
   def extending(*args, &block); end
 end
 
-class Wand::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
-  include Wand::ActiveRelation_WhereNot
-  include Wand::CustomFinderMethods
-  extend T::Sig
-  extend T::Generic
-  Elem = type_member(fixed: Wand)
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def basilisk_horn(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def dragon_heartstring(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def phoenix_feather(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def unicorn_tail_hair(*args); end
-
+module Wand::QueryMethodsReturningAssociationRelation
   sig { returns(Wand::ActiveRecord_AssociationRelation) }
   def all; end
 
-  sig { params(block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
+  sig { params(block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def unscoped(&block); end
 
   sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
@@ -517,119 +472,4 @@ class Wand::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
   def extending(*args, &block); end
-end
-
-class Wand::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
-  include Wand::CustomFinderMethods
-  extend T::Sig
-  extend T::Generic
-  Elem = type_member(fixed: Wand)
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def basilisk_horn(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def dragon_heartstring(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def phoenix_feather(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def unicorn_tail_hair(*args); end
-
-  sig { returns(Wand::ActiveRecord_AssociationRelation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
-
-  sig { params(records: T.any(Wand, T::Array[Wand])).returns(T.self_type) }
-  def <<(*records); end
-
-  sig { params(records: T.any(Wand, T::Array[Wand])).returns(T.self_type) }
-  def append(*records); end
-
-  sig { params(records: T.any(Wand, T::Array[Wand])).returns(T.self_type) }
-  def push(*records); end
-
-  sig { params(records: T.any(Wand, T::Array[Wand])).returns(T.self_type) }
-  def concat(*records); end
 end

--- a/spec/test_data/v5.0/expected_wand.rbi
+++ b/spec/test_data/v5.0/expected_wand.rbi
@@ -3,8 +3,6 @@
 
 # typed: strong
 module Wand::EnumInstanceMethods
-  extend T::Sig
-
   sig { returns(T::Boolean) }
   def phoenix_feather?; end
 
@@ -36,8 +34,6 @@ module Wand::ActiveRelation_WhereNot
 end
 
 module Wand::GeneratedAttributeMethods
-  extend T::Sig
-
   sig { returns(T::Boolean) }
   def broken; end
 
@@ -167,8 +163,6 @@ class Wand::CoreType < T::Enum
 end
 
 module Wand::GeneratedAssociationMethods
-  extend T::Sig
-
   sig { returns(::Wizard) }
   def wizard; end
 
@@ -199,8 +193,6 @@ class Wand < ApplicationRecord
   include Wand::GeneratedAssociationMethods
   extend Wand::CustomFinderMethods
   extend Wand::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   RelationType = T.type_alias { T.any(Wand::ActiveRecord_Relation, Wand::ActiveRecord_Associations_CollectionProxy, Wand::ActiveRecord_AssociationRelation) }
 
   sig { returns(T::Hash[T.any(String, Symbol), Integer]) }
@@ -232,8 +224,6 @@ class Wand::ActiveRecord_Relation < ActiveRecord::Relation
   include Wand::ActiveRelation_WhereNot
   include Wand::CustomFinderMethods
   include Wand::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Wand)
 
   sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
@@ -253,8 +243,6 @@ class Wand::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
   include Wand::ActiveRelation_WhereNot
   include Wand::CustomFinderMethods
   include Wand::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Wand)
 
   sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
@@ -273,8 +261,6 @@ end
 class Wand::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include Wand::CustomFinderMethods
   include Wand::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Wand)
 
   sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }

--- a/spec/test_data/v5.0/expected_wizard.rbi
+++ b/spec/test_data/v5.0/expected_wizard.rbi
@@ -3,8 +3,6 @@
 
 # typed: strong
 module Wizard::EnumInstanceMethods
-  extend T::Sig
-
   sig { returns(T::Boolean) }
   def broom_nimbus?; end
 
@@ -114,8 +112,6 @@ module Wizard::ActiveRelation_WhereNot
 end
 
 module Wizard::GeneratedAttributeMethods
-  extend T::Sig
-
   sig { returns(T::Boolean) }
   def broom?; end
 
@@ -293,8 +289,6 @@ class Wizard::QuidditchPosition < T::Enum
 end
 
 module Wizard::GeneratedAssociationMethods
-  extend T::Sig
-
   sig { returns(T.nilable(::School)) }
   def school; end
 
@@ -349,8 +343,6 @@ class Wizard < ApplicationRecord
   include Wizard::GeneratedAssociationMethods
   extend Wizard::CustomFinderMethods
   extend Wizard::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   RelationType = T.type_alias { T.any(Wizard::ActiveRecord_Relation, Wizard::ActiveRecord_Associations_CollectionProxy, Wizard::ActiveRecord_AssociationRelation) }
 
   sig { returns(T::Hash[T.any(String, Symbol), String]) }
@@ -466,8 +458,6 @@ class Wizard::ActiveRecord_Relation < ActiveRecord::Relation
   include Wizard::ActiveRelation_WhereNot
   include Wizard::CustomFinderMethods
   include Wizard::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Wizard)
 
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
@@ -529,8 +519,6 @@ class Wizard::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelati
   include Wizard::ActiveRelation_WhereNot
   include Wizard::CustomFinderMethods
   include Wizard::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Wizard)
 
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
@@ -591,8 +579,6 @@ end
 class Wizard::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include Wizard::CustomFinderMethods
   include Wizard::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Wizard)
 
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }

--- a/spec/test_data/v5.0/expected_wizard.rbi
+++ b/spec/test_data/v5.0/expected_wizard.rbi
@@ -348,6 +348,7 @@ class Wizard < ApplicationRecord
   include Wizard::GeneratedAttributeMethods
   include Wizard::GeneratedAssociationMethods
   extend Wizard::CustomFinderMethods
+  extend Wizard::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   RelationType = T.type_alias { T.any(Wizard::ActiveRecord_Relation, Wizard::ActiveRecord_Associations_CollectionProxy, Wizard::ActiveRecord_AssociationRelation) }
@@ -424,90 +425,6 @@ class Wizard < ApplicationRecord
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
   def self.recent(*args); end
 
-  sig { returns(Wizard::ActiveRecord_Relation) }
-  def self.all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.select(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.order(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.group(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.limit(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.offset(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.joins(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.where(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.preload(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.includes(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.from(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.lock(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.or(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.having(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.references(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.none(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.extending(*args, &block); end
-
   sig { returns(T.nilable(Wizard::Broom)) }
   def typed_broom; end
 
@@ -548,6 +465,7 @@ end
 class Wizard::ActiveRecord_Relation < ActiveRecord::Relation
   include Wizard::ActiveRelation_WhereNot
   include Wizard::CustomFinderMethods
+  include Wizard::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: Wizard)
@@ -605,7 +523,146 @@ class Wizard::ActiveRecord_Relation < ActiveRecord::Relation
 
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
   def recent(*args); end
+end
 
+class Wizard::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
+  include Wizard::ActiveRelation_WhereNot
+  include Wizard::CustomFinderMethods
+  include Wizard::QueryMethodsReturningAssociationRelation
+  extend T::Sig
+  extend T::Generic
+  Elem = type_member(fixed: Wizard)
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def Gryffindor(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def Hagrid(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def Hufflepuff(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def Ravenclaw(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def Slytherin(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def black_hair(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def blonde_hair(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def broom_firebolt(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def broom_nimbus(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def brown_hair(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def color_blue_eyes(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def color_brown_eyes(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def color_green_eyes(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def quidditch_beater(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def quidditch_chaser(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def quidditch_keeper(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def quidditch_seeker(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def recent(*args); end
+end
+
+class Wizard::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
+  include Wizard::CustomFinderMethods
+  include Wizard::QueryMethodsReturningAssociationRelation
+  extend T::Sig
+  extend T::Generic
+  Elem = type_member(fixed: Wizard)
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def Gryffindor(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def Hagrid(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def Hufflepuff(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def Ravenclaw(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def Slytherin(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def black_hair(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def blonde_hair(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def broom_firebolt(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def broom_nimbus(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def brown_hair(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def color_blue_eyes(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def color_brown_eyes(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def color_green_eyes(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def quidditch_beater(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def quidditch_chaser(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def quidditch_keeper(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def quidditch_seeker(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def recent(*args); end
+
+  sig { params(records: T.any(Wizard, T::Array[Wizard])).returns(T.self_type) }
+  def <<(*records); end
+
+  sig { params(records: T.any(Wizard, T::Array[Wizard])).returns(T.self_type) }
+  def append(*records); end
+
+  sig { params(records: T.any(Wizard, T::Array[Wizard])).returns(T.self_type) }
+  def push(*records); end
+
+  sig { params(records: T.any(Wizard, T::Array[Wizard])).returns(T.self_type) }
+  def concat(*records); end
+end
+
+module Wizard::QueryMethodsReturningRelation
   sig { returns(Wizard::ActiveRecord_Relation) }
   def all; end
 
@@ -691,71 +748,11 @@ class Wizard::ActiveRecord_Relation < ActiveRecord::Relation
   def extending(*args, &block); end
 end
 
-class Wizard::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
-  include Wizard::ActiveRelation_WhereNot
-  include Wizard::CustomFinderMethods
-  extend T::Sig
-  extend T::Generic
-  Elem = type_member(fixed: Wizard)
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def Gryffindor(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def Hagrid(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def Hufflepuff(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def Ravenclaw(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def Slytherin(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def black_hair(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def blonde_hair(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def broom_firebolt(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def broom_nimbus(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def brown_hair(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def color_blue_eyes(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def color_brown_eyes(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def color_green_eyes(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def quidditch_beater(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def quidditch_chaser(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def quidditch_keeper(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def quidditch_seeker(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def recent(*args); end
-
+module Wizard::QueryMethodsReturningAssociationRelation
   sig { returns(Wizard::ActiveRecord_AssociationRelation) }
   def all; end
 
-  sig { params(block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
+  sig { params(block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def unscoped(&block); end
 
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
@@ -835,161 +832,4 @@ class Wizard::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelati
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
   def extending(*args, &block); end
-end
-
-class Wizard::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
-  include Wizard::CustomFinderMethods
-  extend T::Sig
-  extend T::Generic
-  Elem = type_member(fixed: Wizard)
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def Gryffindor(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def Hagrid(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def Hufflepuff(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def Ravenclaw(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def Slytherin(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def black_hair(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def blonde_hair(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def broom_firebolt(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def broom_nimbus(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def brown_hair(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def color_blue_eyes(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def color_brown_eyes(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def color_green_eyes(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def quidditch_beater(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def quidditch_chaser(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def quidditch_keeper(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def quidditch_seeker(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def recent(*args); end
-
-  sig { returns(Wizard::ActiveRecord_AssociationRelation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
-
-  sig { params(records: T.any(Wizard, T::Array[Wizard])).returns(T.self_type) }
-  def <<(*records); end
-
-  sig { params(records: T.any(Wizard, T::Array[Wizard])).returns(T.self_type) }
-  def append(*records); end
-
-  sig { params(records: T.any(Wizard, T::Array[Wizard])).returns(T.self_type) }
-  def push(*records); end
-
-  sig { params(records: T.any(Wizard, T::Array[Wizard])).returns(T.self_type) }
-  def concat(*records); end
 end

--- a/spec/test_data/v5.0/expected_wizard/habtm_subjects.rbi
+++ b/spec/test_data/v5.0/expected_wizard/habtm_subjects.rbi
@@ -8,8 +8,6 @@ module Wizard::HABTM_Subjects::ActiveRelation_WhereNot
 end
 
 module Wizard::HABTM_Subjects::GeneratedAttributeMethods
-  extend T::Sig
-
   sig { returns(T.nilable(Integer)) }
   def subject_id; end
 
@@ -30,8 +28,6 @@ module Wizard::HABTM_Subjects::GeneratedAttributeMethods
 end
 
 module Wizard::HABTM_Subjects::GeneratedAssociationMethods
-  extend T::Sig
-
   sig { returns(T.nilable(::Wizard)) }
   def left_side; end
 
@@ -67,8 +63,6 @@ class Wizard::HABTM_Subjects < ActiveRecord::Base
   include Wizard::HABTM_Subjects::GeneratedAssociationMethods
   extend Wizard::HABTM_Subjects::CustomFinderMethods
   extend Wizard::HABTM_Subjects::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   RelationType = T.type_alias { T.any(Wizard::HABTM_Subjects::ActiveRecord_Relation, Wizard::HABTM_Subjects::ActiveRecord_Associations_CollectionProxy, Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
 end
 
@@ -248,8 +242,6 @@ class Wizard::HABTM_Subjects::ActiveRecord_Relation < ActiveRecord::Relation
   include Wizard::HABTM_Subjects::ActiveRelation_WhereNot
   include Wizard::HABTM_Subjects::CustomFinderMethods
   include Wizard::HABTM_Subjects::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Wizard::HABTM_Subjects)
 end
 
@@ -257,16 +249,12 @@ class Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation < ActiveRecord::A
   include Wizard::HABTM_Subjects::ActiveRelation_WhereNot
   include Wizard::HABTM_Subjects::CustomFinderMethods
   include Wizard::HABTM_Subjects::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Wizard::HABTM_Subjects)
 end
 
 class Wizard::HABTM_Subjects::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include Wizard::HABTM_Subjects::CustomFinderMethods
   include Wizard::HABTM_Subjects::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Wizard::HABTM_Subjects)
 
   sig { params(records: T.any(Wizard::HABTM_Subjects, T::Array[Wizard::HABTM_Subjects])).returns(T.self_type) }

--- a/spec/test_data/v5.0/expected_wizard/habtm_subjects.rbi
+++ b/spec/test_data/v5.0/expected_wizard/habtm_subjects.rbi
@@ -66,368 +66,208 @@ class Wizard::HABTM_Subjects < ActiveRecord::Base
   include Wizard::HABTM_Subjects::GeneratedAttributeMethods
   include Wizard::HABTM_Subjects::GeneratedAssociationMethods
   extend Wizard::HABTM_Subjects::CustomFinderMethods
+  extend Wizard::HABTM_Subjects::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   RelationType = T.type_alias { T.any(Wizard::HABTM_Subjects::ActiveRecord_Relation, Wizard::HABTM_Subjects::ActiveRecord_Associations_CollectionProxy, Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
+end
 
+module Wizard::HABTM_Subjects::QueryMethodsReturningRelation
   sig { returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def self.all; end
+  def all; end
 
   sig { params(block: T.nilable(T.proc.void)).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def self.unscoped(&block); end
+  def unscoped(&block); end
 
   sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def self.select(*args); end
+  def select(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def self.order(*args); end
+  def order(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def self.reorder(*args); end
+  def reorder(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def self.group(*args); end
+  def group(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def self.limit(*args); end
+  def limit(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def self.offset(*args); end
+  def offset(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def self.joins(*args); end
+  def joins(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def self.left_joins(*args); end
+  def left_joins(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def self.left_outer_joins(*args); end
+  def left_outer_joins(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def self.where(*args); end
+  def where(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def self.rewhere(*args); end
+  def rewhere(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def self.preload(*args); end
+  def preload(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def self.eager_load(*args); end
+  def eager_load(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def self.includes(*args); end
+  def includes(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def self.from(*args); end
+  def from(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def self.lock(*args); end
+  def lock(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def self.readonly(*args); end
+  def readonly(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def self.or(*args); end
+  def or(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def self.having(*args); end
+  def having(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def self.create_with(*args); end
+  def create_with(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def self.distinct(*args); end
+  def distinct(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def self.references(*args); end
+  def references(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def self.none(*args); end
+  def none(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def self.unscope(*args); end
+  def unscope(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def self.except(*args); end
+  def except(*args); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def self.extending(*args, &block); end
+  def extending(*args, &block); end
+end
+
+module Wizard::HABTM_Subjects::QueryMethodsReturningAssociationRelation
+  sig { returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
+  def all; end
+
+  sig { params(block: T.nilable(T.proc.void)).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
+  def unscoped(&block); end
+
+  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
+  def select(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
+  def order(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
+  def reorder(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
+  def group(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
+  def limit(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
+  def offset(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
+  def joins(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
+  def left_joins(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
+  def left_outer_joins(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
+  def where(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
+  def rewhere(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
+  def preload(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
+  def eager_load(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
+  def includes(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
+  def from(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
+  def lock(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
+  def readonly(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
+  def or(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
+  def having(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
+  def create_with(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
+  def distinct(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
+  def references(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
+  def none(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
+  def unscope(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
+  def except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
+  def extending(*args, &block); end
 end
 
 class Wizard::HABTM_Subjects::ActiveRecord_Relation < ActiveRecord::Relation
   include Wizard::HABTM_Subjects::ActiveRelation_WhereNot
   include Wizard::HABTM_Subjects::CustomFinderMethods
+  include Wizard::HABTM_Subjects::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: Wizard::HABTM_Subjects)
-
-  sig { returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def extending(*args, &block); end
 end
 
 class Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
   include Wizard::HABTM_Subjects::ActiveRelation_WhereNot
   include Wizard::HABTM_Subjects::CustomFinderMethods
+  include Wizard::HABTM_Subjects::QueryMethodsReturningAssociationRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: Wizard::HABTM_Subjects)
-
-  sig { returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
 end
 
 class Wizard::HABTM_Subjects::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include Wizard::HABTM_Subjects::CustomFinderMethods
+  include Wizard::HABTM_Subjects::QueryMethodsReturningAssociationRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: Wizard::HABTM_Subjects)
-
-  sig { returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
 
   sig { params(records: T.any(Wizard::HABTM_Subjects, T::Array[Wizard::HABTM_Subjects])).returns(T.self_type) }
   def <<(*records); end

--- a/spec/test_data/v5.0/expected_wizard_wo_spellbook.rbi
+++ b/spec/test_data/v5.0/expected_wizard_wo_spellbook.rbi
@@ -3,8 +3,6 @@
 
 # typed: strong
 module Wizard::EnumInstanceMethods
-  extend T::Sig
-
   sig { returns(T::Boolean) }
   def broom_nimbus?; end
 
@@ -114,8 +112,6 @@ module Wizard::ActiveRelation_WhereNot
 end
 
 module Wizard::GeneratedAttributeMethods
-  extend T::Sig
-
   sig { returns(T::Boolean) }
   def broom?; end
 
@@ -293,8 +289,6 @@ class Wizard::QuidditchPosition < T::Enum
 end
 
 module Wizard::GeneratedAssociationMethods
-  extend T::Sig
-
   sig { returns(T.nilable(T.untyped)) }
   def school; end
 
@@ -343,8 +337,6 @@ class Wizard < ApplicationRecord
   include Wizard::GeneratedAssociationMethods
   extend Wizard::CustomFinderMethods
   extend Wizard::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   RelationType = T.type_alias { T.any(Wizard::ActiveRecord_Relation, Wizard::ActiveRecord_Associations_CollectionProxy, Wizard::ActiveRecord_AssociationRelation) }
 
   sig { returns(T::Hash[T.any(String, Symbol), String]) }
@@ -460,8 +452,6 @@ class Wizard::ActiveRecord_Relation < ActiveRecord::Relation
   include Wizard::ActiveRelation_WhereNot
   include Wizard::CustomFinderMethods
   include Wizard::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Wizard)
 
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
@@ -523,8 +513,6 @@ class Wizard::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelati
   include Wizard::ActiveRelation_WhereNot
   include Wizard::CustomFinderMethods
   include Wizard::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Wizard)
 
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
@@ -585,8 +573,6 @@ end
 class Wizard::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include Wizard::CustomFinderMethods
   include Wizard::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Wizard)
 
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }

--- a/spec/test_data/v5.0/expected_wizard_wo_spellbook.rbi
+++ b/spec/test_data/v5.0/expected_wizard_wo_spellbook.rbi
@@ -342,6 +342,7 @@ class Wizard < ApplicationRecord
   include Wizard::GeneratedAttributeMethods
   include Wizard::GeneratedAssociationMethods
   extend Wizard::CustomFinderMethods
+  extend Wizard::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   RelationType = T.type_alias { T.any(Wizard::ActiveRecord_Relation, Wizard::ActiveRecord_Associations_CollectionProxy, Wizard::ActiveRecord_AssociationRelation) }
@@ -418,90 +419,6 @@ class Wizard < ApplicationRecord
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
   def self.recent(*args); end
 
-  sig { returns(Wizard::ActiveRecord_Relation) }
-  def self.all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.select(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.order(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.group(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.limit(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.offset(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.joins(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.where(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.preload(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.includes(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.from(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.lock(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.or(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.having(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.references(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.none(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.extending(*args, &block); end
-
   sig { returns(T.nilable(Wizard::Broom)) }
   def typed_broom; end
 
@@ -542,6 +459,7 @@ end
 class Wizard::ActiveRecord_Relation < ActiveRecord::Relation
   include Wizard::ActiveRelation_WhereNot
   include Wizard::CustomFinderMethods
+  include Wizard::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: Wizard)
@@ -599,7 +517,146 @@ class Wizard::ActiveRecord_Relation < ActiveRecord::Relation
 
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
   def recent(*args); end
+end
 
+class Wizard::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
+  include Wizard::ActiveRelation_WhereNot
+  include Wizard::CustomFinderMethods
+  include Wizard::QueryMethodsReturningAssociationRelation
+  extend T::Sig
+  extend T::Generic
+  Elem = type_member(fixed: Wizard)
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def Gryffindor(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def Hagrid(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def Hufflepuff(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def Ravenclaw(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def Slytherin(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def black_hair(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def blonde_hair(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def broom_firebolt(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def broom_nimbus(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def brown_hair(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def color_blue_eyes(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def color_brown_eyes(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def color_green_eyes(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def quidditch_beater(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def quidditch_chaser(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def quidditch_keeper(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def quidditch_seeker(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def recent(*args); end
+end
+
+class Wizard::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
+  include Wizard::CustomFinderMethods
+  include Wizard::QueryMethodsReturningAssociationRelation
+  extend T::Sig
+  extend T::Generic
+  Elem = type_member(fixed: Wizard)
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def Gryffindor(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def Hagrid(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def Hufflepuff(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def Ravenclaw(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def Slytherin(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def black_hair(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def blonde_hair(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def broom_firebolt(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def broom_nimbus(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def brown_hair(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def color_blue_eyes(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def color_brown_eyes(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def color_green_eyes(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def quidditch_beater(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def quidditch_chaser(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def quidditch_keeper(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def quidditch_seeker(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def recent(*args); end
+
+  sig { params(records: T.any(Wizard, T::Array[Wizard])).returns(T.self_type) }
+  def <<(*records); end
+
+  sig { params(records: T.any(Wizard, T::Array[Wizard])).returns(T.self_type) }
+  def append(*records); end
+
+  sig { params(records: T.any(Wizard, T::Array[Wizard])).returns(T.self_type) }
+  def push(*records); end
+
+  sig { params(records: T.any(Wizard, T::Array[Wizard])).returns(T.self_type) }
+  def concat(*records); end
+end
+
+module Wizard::QueryMethodsReturningRelation
   sig { returns(Wizard::ActiveRecord_Relation) }
   def all; end
 
@@ -685,71 +742,11 @@ class Wizard::ActiveRecord_Relation < ActiveRecord::Relation
   def extending(*args, &block); end
 end
 
-class Wizard::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
-  include Wizard::ActiveRelation_WhereNot
-  include Wizard::CustomFinderMethods
-  extend T::Sig
-  extend T::Generic
-  Elem = type_member(fixed: Wizard)
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def Gryffindor(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def Hagrid(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def Hufflepuff(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def Ravenclaw(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def Slytherin(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def black_hair(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def blonde_hair(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def broom_firebolt(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def broom_nimbus(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def brown_hair(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def color_blue_eyes(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def color_brown_eyes(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def color_green_eyes(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def quidditch_beater(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def quidditch_chaser(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def quidditch_keeper(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def quidditch_seeker(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def recent(*args); end
-
+module Wizard::QueryMethodsReturningAssociationRelation
   sig { returns(Wizard::ActiveRecord_AssociationRelation) }
   def all; end
 
-  sig { params(block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
+  sig { params(block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def unscoped(&block); end
 
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
@@ -829,161 +826,4 @@ class Wizard::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelati
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
   def extending(*args, &block); end
-end
-
-class Wizard::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
-  include Wizard::CustomFinderMethods
-  extend T::Sig
-  extend T::Generic
-  Elem = type_member(fixed: Wizard)
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def Gryffindor(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def Hagrid(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def Hufflepuff(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def Ravenclaw(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def Slytherin(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def black_hair(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def blonde_hair(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def broom_firebolt(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def broom_nimbus(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def brown_hair(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def color_blue_eyes(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def color_brown_eyes(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def color_green_eyes(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def quidditch_beater(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def quidditch_chaser(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def quidditch_keeper(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def quidditch_seeker(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def recent(*args); end
-
-  sig { returns(Wizard::ActiveRecord_AssociationRelation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
-
-  sig { params(records: T.any(Wizard, T::Array[Wizard])).returns(T.self_type) }
-  def <<(*records); end
-
-  sig { params(records: T.any(Wizard, T::Array[Wizard])).returns(T.self_type) }
-  def append(*records); end
-
-  sig { params(records: T.any(Wizard, T::Array[Wizard])).returns(T.self_type) }
-  def push(*records); end
-
-  sig { params(records: T.any(Wizard, T::Array[Wizard])).returns(T.self_type) }
-  def concat(*records); end
 end

--- a/spec/test_data/v5.1/expected_headmaster.rbi
+++ b/spec/test_data/v5.1/expected_headmaster.rbi
@@ -8,8 +8,6 @@ module Headmaster::ActiveRelation_WhereNot
 end
 
 module Headmaster::GeneratedAttributeMethods
-  extend T::Sig
-
   sig { returns(Integer) }
   def id; end
 
@@ -39,8 +37,6 @@ module Headmaster::GeneratedAttributeMethods
 end
 
 module Headmaster::GeneratedAssociationMethods
-  extend T::Sig
-
   sig { returns(::School) }
   def school; end
 
@@ -76,8 +72,6 @@ class Headmaster < ApplicationRecord
   include Headmaster::GeneratedAssociationMethods
   extend Headmaster::CustomFinderMethods
   extend Headmaster::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   RelationType = T.type_alias { T.any(Headmaster::ActiveRecord_Relation, Headmaster::ActiveRecord_Associations_CollectionProxy, Headmaster::ActiveRecord_AssociationRelation) }
 end
 
@@ -263,8 +257,6 @@ class Headmaster::ActiveRecord_Relation < ActiveRecord::Relation
   include Headmaster::ActiveRelation_WhereNot
   include Headmaster::CustomFinderMethods
   include Headmaster::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Headmaster)
 end
 
@@ -272,16 +264,12 @@ class Headmaster::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRe
   include Headmaster::ActiveRelation_WhereNot
   include Headmaster::CustomFinderMethods
   include Headmaster::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Headmaster)
 end
 
 class Headmaster::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include Headmaster::CustomFinderMethods
   include Headmaster::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Headmaster)
 
   sig { params(records: T.any(Headmaster, T::Array[Headmaster])).returns(T.self_type) }

--- a/spec/test_data/v5.1/expected_headmaster.rbi
+++ b/spec/test_data/v5.1/expected_headmaster.rbi
@@ -75,380 +75,214 @@ class Headmaster < ApplicationRecord
   include Headmaster::GeneratedAttributeMethods
   include Headmaster::GeneratedAssociationMethods
   extend Headmaster::CustomFinderMethods
+  extend Headmaster::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   RelationType = T.type_alias { T.any(Headmaster::ActiveRecord_Relation, Headmaster::ActiveRecord_Associations_CollectionProxy, Headmaster::ActiveRecord_AssociationRelation) }
+end
 
+module Headmaster::QueryMethodsReturningRelation
   sig { returns(Headmaster::ActiveRecord_Relation) }
-  def self.all; end
+  def all; end
 
   sig { params(block: T.nilable(T.proc.void)).returns(Headmaster::ActiveRecord_Relation) }
-  def self.unscoped(&block); end
+  def unscoped(&block); end
 
   sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def self.select(*args); end
+  def select(*args); end
 
   sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def self.order(*args); end
+  def order(*args); end
 
   sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def self.reorder(*args); end
+  def reorder(*args); end
 
   sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def self.group(*args); end
+  def group(*args); end
 
   sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def self.limit(*args); end
+  def limit(*args); end
 
   sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def self.offset(*args); end
+  def offset(*args); end
 
   sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def self.joins(*args); end
+  def joins(*args); end
 
   sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def self.left_joins(*args); end
+  def left_joins(*args); end
 
   sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def self.left_outer_joins(*args); end
+  def left_outer_joins(*args); end
 
   sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def self.where(*args); end
+  def where(*args); end
 
   sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def self.rewhere(*args); end
+  def rewhere(*args); end
 
   sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def self.preload(*args); end
+  def preload(*args); end
 
   sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def self.eager_load(*args); end
+  def eager_load(*args); end
 
   sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def self.includes(*args); end
+  def includes(*args); end
 
   sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def self.from(*args); end
+  def from(*args); end
 
   sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def self.lock(*args); end
+  def lock(*args); end
 
   sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def self.readonly(*args); end
+  def readonly(*args); end
 
   sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def self.or(*args); end
+  def or(*args); end
 
   sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def self.having(*args); end
+  def having(*args); end
 
   sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def self.create_with(*args); end
+  def create_with(*args); end
 
   sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def self.distinct(*args); end
+  def distinct(*args); end
 
   sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def self.references(*args); end
+  def references(*args); end
 
   sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def self.none(*args); end
+  def none(*args); end
 
   sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def self.unscope(*args); end
+  def unscope(*args); end
 
   sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def self.merge(*args); end
+  def merge(*args); end
 
   sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def self.except(*args); end
+  def except(*args); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Headmaster::ActiveRecord_Relation) }
-  def self.extending(*args, &block); end
+  def extending(*args, &block); end
+end
+
+module Headmaster::QueryMethodsReturningAssociationRelation
+  sig { returns(Headmaster::ActiveRecord_AssociationRelation) }
+  def all; end
+
+  sig { params(block: T.nilable(T.proc.void)).returns(Headmaster::ActiveRecord_Relation) }
+  def unscoped(&block); end
+
+  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
+  def select(*args); end
+
+  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
+  def order(*args); end
+
+  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
+  def reorder(*args); end
+
+  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
+  def group(*args); end
+
+  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
+  def limit(*args); end
+
+  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
+  def offset(*args); end
+
+  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
+  def joins(*args); end
+
+  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
+  def left_joins(*args); end
+
+  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
+  def left_outer_joins(*args); end
+
+  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
+  def where(*args); end
+
+  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
+  def rewhere(*args); end
+
+  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
+  def preload(*args); end
+
+  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
+  def eager_load(*args); end
+
+  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
+  def includes(*args); end
+
+  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
+  def from(*args); end
+
+  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
+  def lock(*args); end
+
+  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
+  def readonly(*args); end
+
+  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
+  def or(*args); end
+
+  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
+  def having(*args); end
+
+  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
+  def create_with(*args); end
+
+  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
+  def distinct(*args); end
+
+  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
+  def references(*args); end
+
+  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
+  def none(*args); end
+
+  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
+  def unscope(*args); end
+
+  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
+  def merge(*args); end
+
+  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
+  def except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Headmaster::ActiveRecord_AssociationRelation) }
+  def extending(*args, &block); end
 end
 
 class Headmaster::ActiveRecord_Relation < ActiveRecord::Relation
   include Headmaster::ActiveRelation_WhereNot
   include Headmaster::CustomFinderMethods
+  include Headmaster::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: Headmaster)
-
-  sig { returns(Headmaster::ActiveRecord_Relation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Headmaster::ActiveRecord_Relation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Headmaster::ActiveRecord_Relation) }
-  def extending(*args, &block); end
 end
 
 class Headmaster::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
   include Headmaster::ActiveRelation_WhereNot
   include Headmaster::CustomFinderMethods
+  include Headmaster::QueryMethodsReturningAssociationRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: Headmaster)
-
-  sig { returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
 end
 
 class Headmaster::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include Headmaster::CustomFinderMethods
+  include Headmaster::QueryMethodsReturningAssociationRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: Headmaster)
-
-  sig { returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
 
   sig { params(records: T.any(Headmaster, T::Array[Headmaster])).returns(T.self_type) }
   def <<(*records); end

--- a/spec/test_data/v5.1/expected_internal_metadata.rbi
+++ b/spec/test_data/v5.1/expected_internal_metadata.rbi
@@ -8,8 +8,6 @@ module ActiveRecord::InternalMetadata::ActiveRelation_WhereNot
 end
 
 module ActiveRecord::InternalMetadata::GeneratedAttributeMethods
-  extend T::Sig
-
   sig { returns(ActiveSupport::TimeWithZone) }
   def created_at; end
 
@@ -68,8 +66,6 @@ class ActiveRecord::InternalMetadata < ActiveRecord::Base
   include ActiveRecord::InternalMetadata::GeneratedAttributeMethods
   extend ActiveRecord::InternalMetadata::CustomFinderMethods
   extend ActiveRecord::InternalMetadata::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   RelationType = T.type_alias { T.any(ActiveRecord::InternalMetadata::ActiveRecord_Relation, ActiveRecord::InternalMetadata::ActiveRecord_Associations_CollectionProxy, ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
 end
 
@@ -255,8 +251,6 @@ class ActiveRecord::InternalMetadata::ActiveRecord_Relation < ActiveRecord::Rela
   include ActiveRecord::InternalMetadata::ActiveRelation_WhereNot
   include ActiveRecord::InternalMetadata::CustomFinderMethods
   include ActiveRecord::InternalMetadata::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: ActiveRecord::InternalMetadata)
 end
 
@@ -264,16 +258,12 @@ class ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation < ActiveR
   include ActiveRecord::InternalMetadata::ActiveRelation_WhereNot
   include ActiveRecord::InternalMetadata::CustomFinderMethods
   include ActiveRecord::InternalMetadata::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: ActiveRecord::InternalMetadata)
 end
 
 class ActiveRecord::InternalMetadata::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include ActiveRecord::InternalMetadata::CustomFinderMethods
   include ActiveRecord::InternalMetadata::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: ActiveRecord::InternalMetadata)
 
   sig { params(records: T.any(ActiveRecord::InternalMetadata, T::Array[ActiveRecord::InternalMetadata])).returns(T.self_type) }

--- a/spec/test_data/v5.1/expected_internal_metadata.rbi
+++ b/spec/test_data/v5.1/expected_internal_metadata.rbi
@@ -67,380 +67,214 @@ end
 class ActiveRecord::InternalMetadata < ActiveRecord::Base
   include ActiveRecord::InternalMetadata::GeneratedAttributeMethods
   extend ActiveRecord::InternalMetadata::CustomFinderMethods
+  extend ActiveRecord::InternalMetadata::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   RelationType = T.type_alias { T.any(ActiveRecord::InternalMetadata::ActiveRecord_Relation, ActiveRecord::InternalMetadata::ActiveRecord_Associations_CollectionProxy, ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+end
 
+module ActiveRecord::InternalMetadata::QueryMethodsReturningRelation
   sig { returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.all; end
+  def all; end
 
   sig { params(block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.unscoped(&block); end
+  def unscoped(&block); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.select(*args); end
+  def select(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.order(*args); end
+  def order(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.reorder(*args); end
+  def reorder(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.group(*args); end
+  def group(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.limit(*args); end
+  def limit(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.offset(*args); end
+  def offset(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.joins(*args); end
+  def joins(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.left_joins(*args); end
+  def left_joins(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.left_outer_joins(*args); end
+  def left_outer_joins(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.where(*args); end
+  def where(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.rewhere(*args); end
+  def rewhere(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.preload(*args); end
+  def preload(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.eager_load(*args); end
+  def eager_load(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.includes(*args); end
+  def includes(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.from(*args); end
+  def from(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.lock(*args); end
+  def lock(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.readonly(*args); end
+  def readonly(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.or(*args); end
+  def or(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.having(*args); end
+  def having(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.create_with(*args); end
+  def create_with(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.distinct(*args); end
+  def distinct(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.references(*args); end
+  def references(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.none(*args); end
+  def none(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.unscope(*args); end
+  def unscope(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.merge(*args); end
+  def merge(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.except(*args); end
+  def except(*args); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.extending(*args, &block); end
+  def extending(*args, &block); end
+end
+
+module ActiveRecord::InternalMetadata::QueryMethodsReturningAssociationRelation
+  sig { returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def all; end
+
+  sig { params(block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def unscoped(&block); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def select(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def order(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def reorder(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def group(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def limit(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def offset(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def joins(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def left_joins(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def left_outer_joins(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def where(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def rewhere(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def preload(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def eager_load(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def includes(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def from(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def lock(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def readonly(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def or(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def having(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def create_with(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def distinct(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def references(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def none(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def unscope(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def merge(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def extending(*args, &block); end
 end
 
 class ActiveRecord::InternalMetadata::ActiveRecord_Relation < ActiveRecord::Relation
   include ActiveRecord::InternalMetadata::ActiveRelation_WhereNot
   include ActiveRecord::InternalMetadata::CustomFinderMethods
+  include ActiveRecord::InternalMetadata::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: ActiveRecord::InternalMetadata)
-
-  sig { returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def extending(*args, &block); end
 end
 
 class ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
   include ActiveRecord::InternalMetadata::ActiveRelation_WhereNot
   include ActiveRecord::InternalMetadata::CustomFinderMethods
+  include ActiveRecord::InternalMetadata::QueryMethodsReturningAssociationRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: ActiveRecord::InternalMetadata)
-
-  sig { returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
 end
 
 class ActiveRecord::InternalMetadata::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include ActiveRecord::InternalMetadata::CustomFinderMethods
+  include ActiveRecord::InternalMetadata::QueryMethodsReturningAssociationRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: ActiveRecord::InternalMetadata)
-
-  sig { returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
 
   sig { params(records: T.any(ActiveRecord::InternalMetadata, T::Array[ActiveRecord::InternalMetadata])).returns(T.self_type) }
   def <<(*records); end

--- a/spec/test_data/v5.1/expected_potion.rbi
+++ b/spec/test_data/v5.1/expected_potion.rbi
@@ -8,8 +8,6 @@ module Potion::ActiveRelation_WhereNot
 end
 
 module Potion::GeneratedAssociationMethods
-  extend T::Sig
-
   sig { returns(T.nilable(::Wizard)) }
   def wizard; end
 
@@ -38,8 +36,6 @@ class Potion < ApplicationRecord
   include Potion::GeneratedAssociationMethods
   extend Potion::CustomFinderMethods
   extend Potion::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   RelationType = T.type_alias { T.any(Potion::ActiveRecord_Relation, Potion::ActiveRecord_Associations_CollectionProxy, Potion::ActiveRecord_AssociationRelation) }
 end
 
@@ -225,8 +221,6 @@ class Potion::ActiveRecord_Relation < ActiveRecord::Relation
   include Potion::ActiveRelation_WhereNot
   include Potion::CustomFinderMethods
   include Potion::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Potion)
 end
 
@@ -234,16 +228,12 @@ class Potion::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelati
   include Potion::ActiveRelation_WhereNot
   include Potion::CustomFinderMethods
   include Potion::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Potion)
 end
 
 class Potion::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include Potion::CustomFinderMethods
   include Potion::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Potion)
 
   sig { params(records: T.any(Potion, T::Array[Potion])).returns(T.self_type) }

--- a/spec/test_data/v5.1/expected_potion.rbi
+++ b/spec/test_data/v5.1/expected_potion.rbi
@@ -37,380 +37,214 @@ end
 class Potion < ApplicationRecord
   include Potion::GeneratedAssociationMethods
   extend Potion::CustomFinderMethods
+  extend Potion::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   RelationType = T.type_alias { T.any(Potion::ActiveRecord_Relation, Potion::ActiveRecord_Associations_CollectionProxy, Potion::ActiveRecord_AssociationRelation) }
+end
 
+module Potion::QueryMethodsReturningRelation
   sig { returns(Potion::ActiveRecord_Relation) }
-  def self.all; end
+  def all; end
 
   sig { params(block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def self.unscoped(&block); end
+  def unscoped(&block); end
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def self.select(*args); end
+  def select(*args); end
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def self.order(*args); end
+  def order(*args); end
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def self.reorder(*args); end
+  def reorder(*args); end
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def self.group(*args); end
+  def group(*args); end
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def self.limit(*args); end
+  def limit(*args); end
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def self.offset(*args); end
+  def offset(*args); end
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def self.joins(*args); end
+  def joins(*args); end
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def self.left_joins(*args); end
+  def left_joins(*args); end
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def self.left_outer_joins(*args); end
+  def left_outer_joins(*args); end
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def self.where(*args); end
+  def where(*args); end
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def self.rewhere(*args); end
+  def rewhere(*args); end
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def self.preload(*args); end
+  def preload(*args); end
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def self.eager_load(*args); end
+  def eager_load(*args); end
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def self.includes(*args); end
+  def includes(*args); end
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def self.from(*args); end
+  def from(*args); end
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def self.lock(*args); end
+  def lock(*args); end
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def self.readonly(*args); end
+  def readonly(*args); end
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def self.or(*args); end
+  def or(*args); end
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def self.having(*args); end
+  def having(*args); end
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def self.create_with(*args); end
+  def create_with(*args); end
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def self.distinct(*args); end
+  def distinct(*args); end
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def self.references(*args); end
+  def references(*args); end
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def self.none(*args); end
+  def none(*args); end
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def self.unscope(*args); end
+  def unscope(*args); end
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def self.merge(*args); end
+  def merge(*args); end
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def self.except(*args); end
+  def except(*args); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def self.extending(*args, &block); end
+  def extending(*args, &block); end
+end
+
+module Potion::QueryMethodsReturningAssociationRelation
+  sig { returns(Potion::ActiveRecord_AssociationRelation) }
+  def all; end
+
+  sig { params(block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
+  def unscoped(&block); end
+
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def select(*args); end
+
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def order(*args); end
+
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def reorder(*args); end
+
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def group(*args); end
+
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def limit(*args); end
+
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def offset(*args); end
+
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def joins(*args); end
+
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def left_joins(*args); end
+
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def left_outer_joins(*args); end
+
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def where(*args); end
+
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def rewhere(*args); end
+
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def preload(*args); end
+
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def eager_load(*args); end
+
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def includes(*args); end
+
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def from(*args); end
+
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def lock(*args); end
+
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def readonly(*args); end
+
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def or(*args); end
+
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def having(*args); end
+
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def create_with(*args); end
+
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def distinct(*args); end
+
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def references(*args); end
+
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def none(*args); end
+
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def unscope(*args); end
+
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def merge(*args); end
+
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
+  def extending(*args, &block); end
 end
 
 class Potion::ActiveRecord_Relation < ActiveRecord::Relation
   include Potion::ActiveRelation_WhereNot
   include Potion::CustomFinderMethods
+  include Potion::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: Potion)
-
-  sig { returns(Potion::ActiveRecord_Relation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def extending(*args, &block); end
 end
 
 class Potion::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
   include Potion::ActiveRelation_WhereNot
   include Potion::CustomFinderMethods
+  include Potion::QueryMethodsReturningAssociationRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: Potion)
-
-  sig { returns(Potion::ActiveRecord_AssociationRelation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
 end
 
 class Potion::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include Potion::CustomFinderMethods
+  include Potion::QueryMethodsReturningAssociationRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: Potion)
-
-  sig { returns(Potion::ActiveRecord_AssociationRelation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
 
   sig { params(records: T.any(Potion, T::Array[Potion])).returns(T.self_type) }
   def <<(*records); end

--- a/spec/test_data/v5.1/expected_robe.rbi
+++ b/spec/test_data/v5.1/expected_robe.rbi
@@ -60,380 +60,214 @@ class Robe < ApplicationRecord
   include Robe::GeneratedAttributeMethods
   include Robe::GeneratedAssociationMethods
   extend Robe::CustomFinderMethods
+  extend Robe::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   RelationType = T.type_alias { T.any(Robe::ActiveRecord_Relation, Robe::ActiveRecord_Associations_CollectionProxy, Robe::ActiveRecord_AssociationRelation) }
+end
 
+module Robe::QueryMethodsReturningRelation
   sig { returns(Robe::ActiveRecord_Relation) }
-  def self.all; end
+  def all; end
 
   sig { params(block: T.nilable(T.proc.void)).returns(Robe::ActiveRecord_Relation) }
-  def self.unscoped(&block); end
+  def unscoped(&block); end
 
   sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def self.select(*args); end
+  def select(*args); end
 
   sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def self.order(*args); end
+  def order(*args); end
 
   sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def self.reorder(*args); end
+  def reorder(*args); end
 
   sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def self.group(*args); end
+  def group(*args); end
 
   sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def self.limit(*args); end
+  def limit(*args); end
 
   sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def self.offset(*args); end
+  def offset(*args); end
 
   sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def self.joins(*args); end
+  def joins(*args); end
 
   sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def self.left_joins(*args); end
+  def left_joins(*args); end
 
   sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def self.left_outer_joins(*args); end
+  def left_outer_joins(*args); end
 
   sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def self.where(*args); end
+  def where(*args); end
 
   sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def self.rewhere(*args); end
+  def rewhere(*args); end
 
   sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def self.preload(*args); end
+  def preload(*args); end
 
   sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def self.eager_load(*args); end
+  def eager_load(*args); end
 
   sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def self.includes(*args); end
+  def includes(*args); end
 
   sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def self.from(*args); end
+  def from(*args); end
 
   sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def self.lock(*args); end
+  def lock(*args); end
 
   sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def self.readonly(*args); end
+  def readonly(*args); end
 
   sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def self.or(*args); end
+  def or(*args); end
 
   sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def self.having(*args); end
+  def having(*args); end
 
   sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def self.create_with(*args); end
+  def create_with(*args); end
 
   sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def self.distinct(*args); end
+  def distinct(*args); end
 
   sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def self.references(*args); end
+  def references(*args); end
 
   sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def self.none(*args); end
+  def none(*args); end
 
   sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def self.unscope(*args); end
+  def unscope(*args); end
 
   sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def self.merge(*args); end
+  def merge(*args); end
 
   sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def self.except(*args); end
+  def except(*args); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Robe::ActiveRecord_Relation) }
-  def self.extending(*args, &block); end
+  def extending(*args, &block); end
+end
+
+module Robe::QueryMethodsReturningAssociationRelation
+  sig { returns(Robe::ActiveRecord_AssociationRelation) }
+  def all; end
+
+  sig { params(block: T.nilable(T.proc.void)).returns(Robe::ActiveRecord_Relation) }
+  def unscoped(&block); end
+
+  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
+  def select(*args); end
+
+  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
+  def order(*args); end
+
+  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
+  def reorder(*args); end
+
+  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
+  def group(*args); end
+
+  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
+  def limit(*args); end
+
+  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
+  def offset(*args); end
+
+  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
+  def joins(*args); end
+
+  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
+  def left_joins(*args); end
+
+  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
+  def left_outer_joins(*args); end
+
+  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
+  def where(*args); end
+
+  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
+  def rewhere(*args); end
+
+  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
+  def preload(*args); end
+
+  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
+  def eager_load(*args); end
+
+  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
+  def includes(*args); end
+
+  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
+  def from(*args); end
+
+  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
+  def lock(*args); end
+
+  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
+  def readonly(*args); end
+
+  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
+  def or(*args); end
+
+  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
+  def having(*args); end
+
+  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
+  def create_with(*args); end
+
+  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
+  def distinct(*args); end
+
+  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
+  def references(*args); end
+
+  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
+  def none(*args); end
+
+  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
+  def unscope(*args); end
+
+  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
+  def merge(*args); end
+
+  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
+  def except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Robe::ActiveRecord_AssociationRelation) }
+  def extending(*args, &block); end
 end
 
 class Robe::ActiveRecord_Relation < ActiveRecord::Relation
   include Robe::ActiveRelation_WhereNot
   include Robe::CustomFinderMethods
+  include Robe::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: Robe)
-
-  sig { returns(Robe::ActiveRecord_Relation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Robe::ActiveRecord_Relation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Robe::ActiveRecord_Relation) }
-  def extending(*args, &block); end
 end
 
 class Robe::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
   include Robe::ActiveRelation_WhereNot
   include Robe::CustomFinderMethods
+  include Robe::QueryMethodsReturningAssociationRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: Robe)
-
-  sig { returns(Robe::ActiveRecord_AssociationRelation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Robe::ActiveRecord_AssociationRelation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Robe::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
 end
 
 class Robe::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include Robe::CustomFinderMethods
+  include Robe::QueryMethodsReturningAssociationRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: Robe)
-
-  sig { returns(Robe::ActiveRecord_AssociationRelation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Robe::ActiveRecord_AssociationRelation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Robe::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
 
   sig { params(records: T.any(Robe, T::Array[Robe])).returns(T.self_type) }
   def <<(*records); end

--- a/spec/test_data/v5.1/expected_robe.rbi
+++ b/spec/test_data/v5.1/expected_robe.rbi
@@ -8,8 +8,6 @@ module Robe::ActiveRelation_WhereNot
 end
 
 module Robe::GeneratedAttributeMethods
-  extend T::Sig
-
   sig { returns(Integer) }
   def id; end
 
@@ -30,8 +28,6 @@ module Robe::GeneratedAttributeMethods
 end
 
 module Robe::GeneratedAssociationMethods
-  extend T::Sig
-
   sig { returns(T.nilable(::Wizard)) }
   def wizard; end
 
@@ -61,8 +57,6 @@ class Robe < ApplicationRecord
   include Robe::GeneratedAssociationMethods
   extend Robe::CustomFinderMethods
   extend Robe::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   RelationType = T.type_alias { T.any(Robe::ActiveRecord_Relation, Robe::ActiveRecord_Associations_CollectionProxy, Robe::ActiveRecord_AssociationRelation) }
 end
 
@@ -248,8 +242,6 @@ class Robe::ActiveRecord_Relation < ActiveRecord::Relation
   include Robe::ActiveRelation_WhereNot
   include Robe::CustomFinderMethods
   include Robe::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Robe)
 end
 
@@ -257,16 +249,12 @@ class Robe::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
   include Robe::ActiveRelation_WhereNot
   include Robe::CustomFinderMethods
   include Robe::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Robe)
 end
 
 class Robe::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include Robe::CustomFinderMethods
   include Robe::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Robe)
 
   sig { params(records: T.any(Robe, T::Array[Robe])).returns(T.self_type) }

--- a/spec/test_data/v5.1/expected_schema_migration.rbi
+++ b/spec/test_data/v5.1/expected_schema_migration.rbi
@@ -40,380 +40,214 @@ end
 class ActiveRecord::SchemaMigration < ActiveRecord::Base
   include ActiveRecord::SchemaMigration::GeneratedAttributeMethods
   extend ActiveRecord::SchemaMigration::CustomFinderMethods
+  extend ActiveRecord::SchemaMigration::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   RelationType = T.type_alias { T.any(ActiveRecord::SchemaMigration::ActiveRecord_Relation, ActiveRecord::SchemaMigration::ActiveRecord_Associations_CollectionProxy, ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+end
 
+module ActiveRecord::SchemaMigration::QueryMethodsReturningRelation
   sig { returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.all; end
+  def all; end
 
   sig { params(block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.unscoped(&block); end
+  def unscoped(&block); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.select(*args); end
+  def select(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.order(*args); end
+  def order(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.reorder(*args); end
+  def reorder(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.group(*args); end
+  def group(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.limit(*args); end
+  def limit(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.offset(*args); end
+  def offset(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.joins(*args); end
+  def joins(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.left_joins(*args); end
+  def left_joins(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.left_outer_joins(*args); end
+  def left_outer_joins(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.where(*args); end
+  def where(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.rewhere(*args); end
+  def rewhere(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.preload(*args); end
+  def preload(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.eager_load(*args); end
+  def eager_load(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.includes(*args); end
+  def includes(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.from(*args); end
+  def from(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.lock(*args); end
+  def lock(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.readonly(*args); end
+  def readonly(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.or(*args); end
+  def or(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.having(*args); end
+  def having(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.create_with(*args); end
+  def create_with(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.distinct(*args); end
+  def distinct(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.references(*args); end
+  def references(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.none(*args); end
+  def none(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.unscope(*args); end
+  def unscope(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.merge(*args); end
+  def merge(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.except(*args); end
+  def except(*args); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.extending(*args, &block); end
+  def extending(*args, &block); end
+end
+
+module ActiveRecord::SchemaMigration::QueryMethodsReturningAssociationRelation
+  sig { returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def all; end
+
+  sig { params(block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def unscoped(&block); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def select(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def order(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def reorder(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def group(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def limit(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def offset(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def joins(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def left_joins(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def left_outer_joins(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def where(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def rewhere(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def preload(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def eager_load(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def includes(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def from(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def lock(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def readonly(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def or(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def having(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def create_with(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def distinct(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def references(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def none(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def unscope(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def merge(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def extending(*args, &block); end
 end
 
 class ActiveRecord::SchemaMigration::ActiveRecord_Relation < ActiveRecord::Relation
   include ActiveRecord::SchemaMigration::ActiveRelation_WhereNot
   include ActiveRecord::SchemaMigration::CustomFinderMethods
+  include ActiveRecord::SchemaMigration::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: ActiveRecord::SchemaMigration)
-
-  sig { returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def extending(*args, &block); end
 end
 
 class ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
   include ActiveRecord::SchemaMigration::ActiveRelation_WhereNot
   include ActiveRecord::SchemaMigration::CustomFinderMethods
+  include ActiveRecord::SchemaMigration::QueryMethodsReturningAssociationRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: ActiveRecord::SchemaMigration)
-
-  sig { returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
 end
 
 class ActiveRecord::SchemaMigration::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include ActiveRecord::SchemaMigration::CustomFinderMethods
+  include ActiveRecord::SchemaMigration::QueryMethodsReturningAssociationRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: ActiveRecord::SchemaMigration)
-
-  sig { returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
 
   sig { params(records: T.any(ActiveRecord::SchemaMigration, T::Array[ActiveRecord::SchemaMigration])).returns(T.self_type) }
   def <<(*records); end

--- a/spec/test_data/v5.1/expected_schema_migration.rbi
+++ b/spec/test_data/v5.1/expected_schema_migration.rbi
@@ -8,8 +8,6 @@ module ActiveRecord::SchemaMigration::ActiveRelation_WhereNot
 end
 
 module ActiveRecord::SchemaMigration::GeneratedAttributeMethods
-  extend T::Sig
-
   sig { returns(String) }
   def version; end
 
@@ -41,8 +39,6 @@ class ActiveRecord::SchemaMigration < ActiveRecord::Base
   include ActiveRecord::SchemaMigration::GeneratedAttributeMethods
   extend ActiveRecord::SchemaMigration::CustomFinderMethods
   extend ActiveRecord::SchemaMigration::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   RelationType = T.type_alias { T.any(ActiveRecord::SchemaMigration::ActiveRecord_Relation, ActiveRecord::SchemaMigration::ActiveRecord_Associations_CollectionProxy, ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
 end
 
@@ -228,8 +224,6 @@ class ActiveRecord::SchemaMigration::ActiveRecord_Relation < ActiveRecord::Relat
   include ActiveRecord::SchemaMigration::ActiveRelation_WhereNot
   include ActiveRecord::SchemaMigration::CustomFinderMethods
   include ActiveRecord::SchemaMigration::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: ActiveRecord::SchemaMigration)
 end
 
@@ -237,16 +231,12 @@ class ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation < ActiveRe
   include ActiveRecord::SchemaMigration::ActiveRelation_WhereNot
   include ActiveRecord::SchemaMigration::CustomFinderMethods
   include ActiveRecord::SchemaMigration::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: ActiveRecord::SchemaMigration)
 end
 
 class ActiveRecord::SchemaMigration::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include ActiveRecord::SchemaMigration::CustomFinderMethods
   include ActiveRecord::SchemaMigration::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: ActiveRecord::SchemaMigration)
 
   sig { params(records: T.any(ActiveRecord::SchemaMigration, T::Array[ActiveRecord::SchemaMigration])).returns(T.self_type) }

--- a/spec/test_data/v5.1/expected_school.rbi
+++ b/spec/test_data/v5.1/expected_school.rbi
@@ -8,8 +8,6 @@ module School::ActiveRelation_WhereNot
 end
 
 module School::GeneratedAttributeMethods
-  extend T::Sig
-
   sig { returns(Integer) }
   def id; end
 
@@ -30,8 +28,6 @@ module School::GeneratedAttributeMethods
 end
 
 module School::GeneratedAssociationMethods
-  extend T::Sig
-
   sig { returns(::Headmaster) }
   def headmaster; end
 
@@ -61,8 +57,6 @@ class School < ApplicationRecord
   include School::GeneratedAssociationMethods
   extend School::CustomFinderMethods
   extend School::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   RelationType = T.type_alias { T.any(School::ActiveRecord_Relation, School::ActiveRecord_Associations_CollectionProxy, School::ActiveRecord_AssociationRelation) }
 end
 
@@ -248,8 +242,6 @@ class School::ActiveRecord_Relation < ActiveRecord::Relation
   include School::ActiveRelation_WhereNot
   include School::CustomFinderMethods
   include School::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: School)
 end
 
@@ -257,16 +249,12 @@ class School::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelati
   include School::ActiveRelation_WhereNot
   include School::CustomFinderMethods
   include School::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: School)
 end
 
 class School::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include School::CustomFinderMethods
   include School::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: School)
 
   sig { params(records: T.any(School, T::Array[School])).returns(T.self_type) }

--- a/spec/test_data/v5.1/expected_school.rbi
+++ b/spec/test_data/v5.1/expected_school.rbi
@@ -60,380 +60,214 @@ class School < ApplicationRecord
   include School::GeneratedAttributeMethods
   include School::GeneratedAssociationMethods
   extend School::CustomFinderMethods
+  extend School::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   RelationType = T.type_alias { T.any(School::ActiveRecord_Relation, School::ActiveRecord_Associations_CollectionProxy, School::ActiveRecord_AssociationRelation) }
+end
 
+module School::QueryMethodsReturningRelation
   sig { returns(School::ActiveRecord_Relation) }
-  def self.all; end
+  def all; end
 
   sig { params(block: T.nilable(T.proc.void)).returns(School::ActiveRecord_Relation) }
-  def self.unscoped(&block); end
+  def unscoped(&block); end
 
   sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def self.select(*args); end
+  def select(*args); end
 
   sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def self.order(*args); end
+  def order(*args); end
 
   sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def self.reorder(*args); end
+  def reorder(*args); end
 
   sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def self.group(*args); end
+  def group(*args); end
 
   sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def self.limit(*args); end
+  def limit(*args); end
 
   sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def self.offset(*args); end
+  def offset(*args); end
 
   sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def self.joins(*args); end
+  def joins(*args); end
 
   sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def self.left_joins(*args); end
+  def left_joins(*args); end
 
   sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def self.left_outer_joins(*args); end
+  def left_outer_joins(*args); end
 
   sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def self.where(*args); end
+  def where(*args); end
 
   sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def self.rewhere(*args); end
+  def rewhere(*args); end
 
   sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def self.preload(*args); end
+  def preload(*args); end
 
   sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def self.eager_load(*args); end
+  def eager_load(*args); end
 
   sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def self.includes(*args); end
+  def includes(*args); end
 
   sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def self.from(*args); end
+  def from(*args); end
 
   sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def self.lock(*args); end
+  def lock(*args); end
 
   sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def self.readonly(*args); end
+  def readonly(*args); end
 
   sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def self.or(*args); end
+  def or(*args); end
 
   sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def self.having(*args); end
+  def having(*args); end
 
   sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def self.create_with(*args); end
+  def create_with(*args); end
 
   sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def self.distinct(*args); end
+  def distinct(*args); end
 
   sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def self.references(*args); end
+  def references(*args); end
 
   sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def self.none(*args); end
+  def none(*args); end
 
   sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def self.unscope(*args); end
+  def unscope(*args); end
 
   sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def self.merge(*args); end
+  def merge(*args); end
 
   sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def self.except(*args); end
+  def except(*args); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(School::ActiveRecord_Relation) }
-  def self.extending(*args, &block); end
+  def extending(*args, &block); end
+end
+
+module School::QueryMethodsReturningAssociationRelation
+  sig { returns(School::ActiveRecord_AssociationRelation) }
+  def all; end
+
+  sig { params(block: T.nilable(T.proc.void)).returns(School::ActiveRecord_Relation) }
+  def unscoped(&block); end
+
+  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
+  def select(*args); end
+
+  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
+  def order(*args); end
+
+  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
+  def reorder(*args); end
+
+  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
+  def group(*args); end
+
+  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
+  def limit(*args); end
+
+  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
+  def offset(*args); end
+
+  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
+  def joins(*args); end
+
+  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
+  def left_joins(*args); end
+
+  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
+  def left_outer_joins(*args); end
+
+  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
+  def where(*args); end
+
+  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
+  def rewhere(*args); end
+
+  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
+  def preload(*args); end
+
+  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
+  def eager_load(*args); end
+
+  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
+  def includes(*args); end
+
+  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
+  def from(*args); end
+
+  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
+  def lock(*args); end
+
+  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
+  def readonly(*args); end
+
+  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
+  def or(*args); end
+
+  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
+  def having(*args); end
+
+  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
+  def create_with(*args); end
+
+  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
+  def distinct(*args); end
+
+  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
+  def references(*args); end
+
+  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
+  def none(*args); end
+
+  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
+  def unscope(*args); end
+
+  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
+  def merge(*args); end
+
+  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
+  def except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(School::ActiveRecord_AssociationRelation) }
+  def extending(*args, &block); end
 end
 
 class School::ActiveRecord_Relation < ActiveRecord::Relation
   include School::ActiveRelation_WhereNot
   include School::CustomFinderMethods
+  include School::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: School)
-
-  sig { returns(School::ActiveRecord_Relation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(School::ActiveRecord_Relation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(School::ActiveRecord_Relation) }
-  def extending(*args, &block); end
 end
 
 class School::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
   include School::ActiveRelation_WhereNot
   include School::CustomFinderMethods
+  include School::QueryMethodsReturningAssociationRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: School)
-
-  sig { returns(School::ActiveRecord_AssociationRelation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(School::ActiveRecord_AssociationRelation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(School::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
 end
 
 class School::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include School::CustomFinderMethods
+  include School::QueryMethodsReturningAssociationRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: School)
-
-  sig { returns(School::ActiveRecord_AssociationRelation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(School::ActiveRecord_AssociationRelation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(School::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
 
   sig { params(records: T.any(School, T::Array[School])).returns(T.self_type) }
   def <<(*records); end

--- a/spec/test_data/v5.1/expected_spell.rbi
+++ b/spec/test_data/v5.1/expected_spell.rbi
@@ -63,380 +63,214 @@ class Spell < ApplicationRecord
   include Spell::GeneratedAttributeMethods
   include Spell::GeneratedAssociationMethods
   extend Spell::CustomFinderMethods
+  extend Spell::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   RelationType = T.type_alias { T.any(Spell::ActiveRecord_Relation, Spell::ActiveRecord_Associations_CollectionProxy, Spell::ActiveRecord_AssociationRelation) }
+end
 
+module Spell::QueryMethodsReturningRelation
   sig { returns(Spell::ActiveRecord_Relation) }
-  def self.all; end
+  def all; end
 
   sig { params(block: T.nilable(T.proc.void)).returns(Spell::ActiveRecord_Relation) }
-  def self.unscoped(&block); end
+  def unscoped(&block); end
 
   sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def self.select(*args); end
+  def select(*args); end
 
   sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def self.order(*args); end
+  def order(*args); end
 
   sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def self.reorder(*args); end
+  def reorder(*args); end
 
   sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def self.group(*args); end
+  def group(*args); end
 
   sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def self.limit(*args); end
+  def limit(*args); end
 
   sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def self.offset(*args); end
+  def offset(*args); end
 
   sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def self.joins(*args); end
+  def joins(*args); end
 
   sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def self.left_joins(*args); end
+  def left_joins(*args); end
 
   sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def self.left_outer_joins(*args); end
+  def left_outer_joins(*args); end
 
   sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def self.where(*args); end
+  def where(*args); end
 
   sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def self.rewhere(*args); end
+  def rewhere(*args); end
 
   sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def self.preload(*args); end
+  def preload(*args); end
 
   sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def self.eager_load(*args); end
+  def eager_load(*args); end
 
   sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def self.includes(*args); end
+  def includes(*args); end
 
   sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def self.from(*args); end
+  def from(*args); end
 
   sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def self.lock(*args); end
+  def lock(*args); end
 
   sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def self.readonly(*args); end
+  def readonly(*args); end
 
   sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def self.or(*args); end
+  def or(*args); end
 
   sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def self.having(*args); end
+  def having(*args); end
 
   sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def self.create_with(*args); end
+  def create_with(*args); end
 
   sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def self.distinct(*args); end
+  def distinct(*args); end
 
   sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def self.references(*args); end
+  def references(*args); end
 
   sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def self.none(*args); end
+  def none(*args); end
 
   sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def self.unscope(*args); end
+  def unscope(*args); end
 
   sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def self.merge(*args); end
+  def merge(*args); end
 
   sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def self.except(*args); end
+  def except(*args); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Spell::ActiveRecord_Relation) }
-  def self.extending(*args, &block); end
+  def extending(*args, &block); end
+end
+
+module Spell::QueryMethodsReturningAssociationRelation
+  sig { returns(Spell::ActiveRecord_AssociationRelation) }
+  def all; end
+
+  sig { params(block: T.nilable(T.proc.void)).returns(Spell::ActiveRecord_Relation) }
+  def unscoped(&block); end
+
+  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
+  def select(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
+  def order(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
+  def reorder(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
+  def group(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
+  def limit(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
+  def offset(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
+  def joins(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
+  def left_joins(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
+  def left_outer_joins(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
+  def where(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
+  def rewhere(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
+  def preload(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
+  def eager_load(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
+  def includes(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
+  def from(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
+  def lock(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
+  def readonly(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
+  def or(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
+  def having(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
+  def create_with(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
+  def distinct(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
+  def references(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
+  def none(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
+  def unscope(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
+  def merge(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
+  def except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Spell::ActiveRecord_AssociationRelation) }
+  def extending(*args, &block); end
 end
 
 class Spell::ActiveRecord_Relation < ActiveRecord::Relation
   include Spell::ActiveRelation_WhereNot
   include Spell::CustomFinderMethods
+  include Spell::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: Spell)
-
-  sig { returns(Spell::ActiveRecord_Relation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Spell::ActiveRecord_Relation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Spell::ActiveRecord_Relation) }
-  def extending(*args, &block); end
 end
 
 class Spell::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
   include Spell::ActiveRelation_WhereNot
   include Spell::CustomFinderMethods
+  include Spell::QueryMethodsReturningAssociationRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: Spell)
-
-  sig { returns(Spell::ActiveRecord_AssociationRelation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Spell::ActiveRecord_AssociationRelation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Spell::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
 end
 
 class Spell::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include Spell::CustomFinderMethods
+  include Spell::QueryMethodsReturningAssociationRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: Spell)
-
-  sig { returns(Spell::ActiveRecord_AssociationRelation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Spell::ActiveRecord_AssociationRelation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Spell::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
 
   sig { params(records: T.any(Spell, T::Array[Spell])).returns(T.self_type) }
   def <<(*records); end

--- a/spec/test_data/v5.1/expected_spell.rbi
+++ b/spec/test_data/v5.1/expected_spell.rbi
@@ -8,8 +8,6 @@ module Spell::ActiveRelation_WhereNot
 end
 
 module Spell::GeneratedAttributeMethods
-  extend T::Sig
-
   sig { returns(Integer) }
   def id; end
 
@@ -30,8 +28,6 @@ module Spell::GeneratedAttributeMethods
 end
 
 module Spell::GeneratedAssociationMethods
-  extend T::Sig
-
   sig { returns(::SpellBook::ActiveRecord_Associations_CollectionProxy) }
   def spell_books; end
 
@@ -64,8 +60,6 @@ class Spell < ApplicationRecord
   include Spell::GeneratedAssociationMethods
   extend Spell::CustomFinderMethods
   extend Spell::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   RelationType = T.type_alias { T.any(Spell::ActiveRecord_Relation, Spell::ActiveRecord_Associations_CollectionProxy, Spell::ActiveRecord_AssociationRelation) }
 end
 
@@ -251,8 +245,6 @@ class Spell::ActiveRecord_Relation < ActiveRecord::Relation
   include Spell::ActiveRelation_WhereNot
   include Spell::CustomFinderMethods
   include Spell::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Spell)
 end
 
@@ -260,16 +252,12 @@ class Spell::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelatio
   include Spell::ActiveRelation_WhereNot
   include Spell::CustomFinderMethods
   include Spell::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Spell)
 end
 
 class Spell::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include Spell::CustomFinderMethods
   include Spell::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Spell)
 
   sig { params(records: T.any(Spell, T::Array[Spell])).returns(T.self_type) }

--- a/spec/test_data/v5.1/expected_spell/habtm_spell_books.rbi
+++ b/spec/test_data/v5.1/expected_spell/habtm_spell_books.rbi
@@ -8,8 +8,6 @@ module Spell::HABTM_SpellBooks::ActiveRelation_WhereNot
 end
 
 module Spell::HABTM_SpellBooks::GeneratedAttributeMethods
-  extend T::Sig
-
   sig { returns(Integer) }
   def spell_book_id; end
 
@@ -30,8 +28,6 @@ module Spell::HABTM_SpellBooks::GeneratedAttributeMethods
 end
 
 module Spell::HABTM_SpellBooks::GeneratedAssociationMethods
-  extend T::Sig
-
   sig { returns(T.nilable(::Spell)) }
   def left_side; end
 
@@ -67,8 +63,6 @@ class Spell::HABTM_SpellBooks < ActiveRecord::Base
   include Spell::HABTM_SpellBooks::GeneratedAssociationMethods
   extend Spell::HABTM_SpellBooks::CustomFinderMethods
   extend Spell::HABTM_SpellBooks::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   RelationType = T.type_alias { T.any(Spell::HABTM_SpellBooks::ActiveRecord_Relation, Spell::HABTM_SpellBooks::ActiveRecord_Associations_CollectionProxy, Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
 end
 
@@ -254,8 +248,6 @@ class Spell::HABTM_SpellBooks::ActiveRecord_Relation < ActiveRecord::Relation
   include Spell::HABTM_SpellBooks::ActiveRelation_WhereNot
   include Spell::HABTM_SpellBooks::CustomFinderMethods
   include Spell::HABTM_SpellBooks::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Spell::HABTM_SpellBooks)
 end
 
@@ -263,16 +255,12 @@ class Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation < ActiveRecord::
   include Spell::HABTM_SpellBooks::ActiveRelation_WhereNot
   include Spell::HABTM_SpellBooks::CustomFinderMethods
   include Spell::HABTM_SpellBooks::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Spell::HABTM_SpellBooks)
 end
 
 class Spell::HABTM_SpellBooks::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include Spell::HABTM_SpellBooks::CustomFinderMethods
   include Spell::HABTM_SpellBooks::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Spell::HABTM_SpellBooks)
 
   sig { params(records: T.any(Spell::HABTM_SpellBooks, T::Array[Spell::HABTM_SpellBooks])).returns(T.self_type) }

--- a/spec/test_data/v5.1/expected_spell/habtm_spell_books.rbi
+++ b/spec/test_data/v5.1/expected_spell/habtm_spell_books.rbi
@@ -66,380 +66,214 @@ class Spell::HABTM_SpellBooks < ActiveRecord::Base
   include Spell::HABTM_SpellBooks::GeneratedAttributeMethods
   include Spell::HABTM_SpellBooks::GeneratedAssociationMethods
   extend Spell::HABTM_SpellBooks::CustomFinderMethods
+  extend Spell::HABTM_SpellBooks::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   RelationType = T.type_alias { T.any(Spell::HABTM_SpellBooks::ActiveRecord_Relation, Spell::HABTM_SpellBooks::ActiveRecord_Associations_CollectionProxy, Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
+end
 
+module Spell::HABTM_SpellBooks::QueryMethodsReturningRelation
   sig { returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def self.all; end
+  def all; end
 
   sig { params(block: T.nilable(T.proc.void)).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def self.unscoped(&block); end
+  def unscoped(&block); end
 
   sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def self.select(*args); end
+  def select(*args); end
 
   sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def self.order(*args); end
+  def order(*args); end
 
   sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def self.reorder(*args); end
+  def reorder(*args); end
 
   sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def self.group(*args); end
+  def group(*args); end
 
   sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def self.limit(*args); end
+  def limit(*args); end
 
   sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def self.offset(*args); end
+  def offset(*args); end
 
   sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def self.joins(*args); end
+  def joins(*args); end
 
   sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def self.left_joins(*args); end
+  def left_joins(*args); end
 
   sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def self.left_outer_joins(*args); end
+  def left_outer_joins(*args); end
 
   sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def self.where(*args); end
+  def where(*args); end
 
   sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def self.rewhere(*args); end
+  def rewhere(*args); end
 
   sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def self.preload(*args); end
+  def preload(*args); end
 
   sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def self.eager_load(*args); end
+  def eager_load(*args); end
 
   sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def self.includes(*args); end
+  def includes(*args); end
 
   sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def self.from(*args); end
+  def from(*args); end
 
   sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def self.lock(*args); end
+  def lock(*args); end
 
   sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def self.readonly(*args); end
+  def readonly(*args); end
 
   sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def self.or(*args); end
+  def or(*args); end
 
   sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def self.having(*args); end
+  def having(*args); end
 
   sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def self.create_with(*args); end
+  def create_with(*args); end
 
   sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def self.distinct(*args); end
+  def distinct(*args); end
 
   sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def self.references(*args); end
+  def references(*args); end
 
   sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def self.none(*args); end
+  def none(*args); end
 
   sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def self.unscope(*args); end
+  def unscope(*args); end
 
   sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def self.merge(*args); end
+  def merge(*args); end
 
   sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def self.except(*args); end
+  def except(*args); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def self.extending(*args, &block); end
+  def extending(*args, &block); end
+end
+
+module Spell::HABTM_SpellBooks::QueryMethodsReturningAssociationRelation
+  sig { returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
+  def all; end
+
+  sig { params(block: T.nilable(T.proc.void)).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
+  def unscoped(&block); end
+
+  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
+  def select(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
+  def order(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
+  def reorder(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
+  def group(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
+  def limit(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
+  def offset(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
+  def joins(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
+  def left_joins(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
+  def left_outer_joins(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
+  def where(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
+  def rewhere(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
+  def preload(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
+  def eager_load(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
+  def includes(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
+  def from(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
+  def lock(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
+  def readonly(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
+  def or(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
+  def having(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
+  def create_with(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
+  def distinct(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
+  def references(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
+  def none(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
+  def unscope(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
+  def merge(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
+  def except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
+  def extending(*args, &block); end
 end
 
 class Spell::HABTM_SpellBooks::ActiveRecord_Relation < ActiveRecord::Relation
   include Spell::HABTM_SpellBooks::ActiveRelation_WhereNot
   include Spell::HABTM_SpellBooks::CustomFinderMethods
+  include Spell::HABTM_SpellBooks::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: Spell::HABTM_SpellBooks)
-
-  sig { returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def extending(*args, &block); end
 end
 
 class Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
   include Spell::HABTM_SpellBooks::ActiveRelation_WhereNot
   include Spell::HABTM_SpellBooks::CustomFinderMethods
+  include Spell::HABTM_SpellBooks::QueryMethodsReturningAssociationRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: Spell::HABTM_SpellBooks)
-
-  sig { returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
 end
 
 class Spell::HABTM_SpellBooks::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include Spell::HABTM_SpellBooks::CustomFinderMethods
+  include Spell::HABTM_SpellBooks::QueryMethodsReturningAssociationRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: Spell::HABTM_SpellBooks)
-
-  sig { returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
 
   sig { params(records: T.any(Spell::HABTM_SpellBooks, T::Array[Spell::HABTM_SpellBooks])).returns(T.self_type) }
   def <<(*records); end

--- a/spec/test_data/v5.1/expected_spell_book.rbi
+++ b/spec/test_data/v5.1/expected_spell_book.rbi
@@ -119,6 +119,7 @@ class SpellBook < ApplicationRecord
   include SpellBook::GeneratedAttributeMethods
   include SpellBook::GeneratedAssociationMethods
   extend SpellBook::CustomFinderMethods
+  extend SpellBook::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   RelationType = T.type_alias { T.any(SpellBook::ActiveRecord_Relation, SpellBook::ActiveRecord_Associations_CollectionProxy, SpellBook::ActiveRecord_AssociationRelation) }
@@ -133,94 +134,10 @@ class SpellBook < ApplicationRecord
   def self.dark_art(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def self.recent(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
   def self.unclassified(*args); end
-
-  sig { returns(SpellBook::ActiveRecord_Relation) }
-  def self.all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def self.unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def self.select(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def self.order(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def self.reorder(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def self.group(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def self.limit(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def self.offset(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def self.joins(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def self.left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def self.left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def self.where(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def self.rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def self.preload(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def self.eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def self.includes(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def self.from(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def self.lock(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def self.readonly(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def self.or(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def self.having(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def self.create_with(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def self.distinct(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def self.references(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def self.none(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def self.unscope(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def self.merge(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def self.except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def self.extending(*args, &block); end
 
   sig { returns(SpellBook::BookType) }
   def typed_book_type; end
@@ -232,6 +149,7 @@ end
 class SpellBook::ActiveRecord_Relation < ActiveRecord::Relation
   include SpellBook::ActiveRelation_WhereNot
   include SpellBook::CustomFinderMethods
+  include SpellBook::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: SpellBook)
@@ -243,99 +161,16 @@ class SpellBook::ActiveRecord_Relation < ActiveRecord::Relation
   def dark_art(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def recent(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
   def unclassified(*args); end
-
-  sig { returns(SpellBook::ActiveRecord_Relation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def extending(*args, &block); end
 end
 
 class SpellBook::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
   include SpellBook::ActiveRelation_WhereNot
   include SpellBook::CustomFinderMethods
+  include SpellBook::QueryMethodsReturningAssociationRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: SpellBook)
@@ -347,98 +182,15 @@ class SpellBook::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRel
   def dark_art(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def recent(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
   def unclassified(*args); end
-
-  sig { returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
 end
 
 class SpellBook::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include SpellBook::CustomFinderMethods
+  include SpellBook::QueryMethodsReturningAssociationRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: SpellBook)
@@ -450,94 +202,10 @@ class SpellBook::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Assoc
   def dark_art(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def recent(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
   def unclassified(*args); end
-
-  sig { returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
 
   sig { params(records: T.any(SpellBook, T::Array[SpellBook])).returns(T.self_type) }
   def <<(*records); end
@@ -550,4 +218,182 @@ class SpellBook::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Assoc
 
   sig { params(records: T.any(SpellBook, T::Array[SpellBook])).returns(T.self_type) }
   def concat(*records); end
+end
+
+module SpellBook::QueryMethodsReturningRelation
+  sig { returns(SpellBook::ActiveRecord_Relation) }
+  def all; end
+
+  sig { params(block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
+  def unscoped(&block); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def select(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def order(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def reorder(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def group(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def limit(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def offset(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def joins(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def left_joins(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def left_outer_joins(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def where(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def rewhere(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def preload(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def eager_load(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def includes(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def from(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def lock(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def readonly(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def or(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def having(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def create_with(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def distinct(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def references(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def none(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def unscope(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def merge(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
+  def extending(*args, &block); end
+end
+
+module SpellBook::QueryMethodsReturningAssociationRelation
+  sig { returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def all; end
+
+  sig { params(block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
+  def unscoped(&block); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def select(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def order(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def reorder(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def group(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def limit(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def offset(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def joins(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def left_joins(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def left_outer_joins(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def where(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def rewhere(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def preload(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def eager_load(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def includes(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def from(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def lock(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def readonly(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def or(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def having(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def create_with(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def distinct(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def references(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def none(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def unscope(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def merge(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def extending(*args, &block); end
 end

--- a/spec/test_data/v5.1/expected_spell_book.rbi
+++ b/spec/test_data/v5.1/expected_spell_book.rbi
@@ -3,8 +3,6 @@
 
 # typed: strong
 module SpellBook::EnumInstanceMethods
-  extend T::Sig
-
   sig { returns(T::Boolean) }
   def unclassified?; end
 
@@ -30,8 +28,6 @@ module SpellBook::ActiveRelation_WhereNot
 end
 
 module SpellBook::GeneratedAttributeMethods
-  extend T::Sig
-
   sig { returns(String) }
   def book_type; end
 
@@ -79,8 +75,6 @@ class SpellBook::BookType < T::Enum
 end
 
 module SpellBook::GeneratedAssociationMethods
-  extend T::Sig
-
   sig { returns(::Spell::ActiveRecord_Associations_CollectionProxy) }
   def spells; end
 
@@ -120,8 +114,6 @@ class SpellBook < ApplicationRecord
   include SpellBook::GeneratedAssociationMethods
   extend SpellBook::CustomFinderMethods
   extend SpellBook::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   RelationType = T.type_alias { T.any(SpellBook::ActiveRecord_Relation, SpellBook::ActiveRecord_Associations_CollectionProxy, SpellBook::ActiveRecord_AssociationRelation) }
 
   sig { returns(T::Hash[T.any(String, Symbol), Integer]) }
@@ -150,8 +142,6 @@ class SpellBook::ActiveRecord_Relation < ActiveRecord::Relation
   include SpellBook::ActiveRelation_WhereNot
   include SpellBook::CustomFinderMethods
   include SpellBook::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: SpellBook)
 
   sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
@@ -171,8 +161,6 @@ class SpellBook::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRel
   include SpellBook::ActiveRelation_WhereNot
   include SpellBook::CustomFinderMethods
   include SpellBook::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: SpellBook)
 
   sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
@@ -191,8 +179,6 @@ end
 class SpellBook::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include SpellBook::CustomFinderMethods
   include SpellBook::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: SpellBook)
 
   sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }

--- a/spec/test_data/v5.1/expected_spell_book/habtm_spells.rbi
+++ b/spec/test_data/v5.1/expected_spell_book/habtm_spells.rbi
@@ -8,8 +8,6 @@ module SpellBook::HABTM_Spells::ActiveRelation_WhereNot
 end
 
 module SpellBook::HABTM_Spells::GeneratedAttributeMethods
-  extend T::Sig
-
   sig { returns(Integer) }
   def spell_book_id; end
 
@@ -30,8 +28,6 @@ module SpellBook::HABTM_Spells::GeneratedAttributeMethods
 end
 
 module SpellBook::HABTM_Spells::GeneratedAssociationMethods
-  extend T::Sig
-
   sig { returns(T.nilable(::SpellBook)) }
   def left_side; end
 
@@ -67,8 +63,6 @@ class SpellBook::HABTM_Spells < ActiveRecord::Base
   include SpellBook::HABTM_Spells::GeneratedAssociationMethods
   extend SpellBook::HABTM_Spells::CustomFinderMethods
   extend SpellBook::HABTM_Spells::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   RelationType = T.type_alias { T.any(SpellBook::HABTM_Spells::ActiveRecord_Relation, SpellBook::HABTM_Spells::ActiveRecord_Associations_CollectionProxy, SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
 end
 
@@ -254,8 +248,6 @@ class SpellBook::HABTM_Spells::ActiveRecord_Relation < ActiveRecord::Relation
   include SpellBook::HABTM_Spells::ActiveRelation_WhereNot
   include SpellBook::HABTM_Spells::CustomFinderMethods
   include SpellBook::HABTM_Spells::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: SpellBook::HABTM_Spells)
 end
 
@@ -263,16 +255,12 @@ class SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation < ActiveRecord::
   include SpellBook::HABTM_Spells::ActiveRelation_WhereNot
   include SpellBook::HABTM_Spells::CustomFinderMethods
   include SpellBook::HABTM_Spells::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: SpellBook::HABTM_Spells)
 end
 
 class SpellBook::HABTM_Spells::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include SpellBook::HABTM_Spells::CustomFinderMethods
   include SpellBook::HABTM_Spells::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: SpellBook::HABTM_Spells)
 
   sig { params(records: T.any(SpellBook::HABTM_Spells, T::Array[SpellBook::HABTM_Spells])).returns(T.self_type) }

--- a/spec/test_data/v5.1/expected_spell_book/habtm_spells.rbi
+++ b/spec/test_data/v5.1/expected_spell_book/habtm_spells.rbi
@@ -66,380 +66,214 @@ class SpellBook::HABTM_Spells < ActiveRecord::Base
   include SpellBook::HABTM_Spells::GeneratedAttributeMethods
   include SpellBook::HABTM_Spells::GeneratedAssociationMethods
   extend SpellBook::HABTM_Spells::CustomFinderMethods
+  extend SpellBook::HABTM_Spells::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   RelationType = T.type_alias { T.any(SpellBook::HABTM_Spells::ActiveRecord_Relation, SpellBook::HABTM_Spells::ActiveRecord_Associations_CollectionProxy, SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
+end
 
+module SpellBook::HABTM_Spells::QueryMethodsReturningRelation
   sig { returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def self.all; end
+  def all; end
 
   sig { params(block: T.nilable(T.proc.void)).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def self.unscoped(&block); end
+  def unscoped(&block); end
 
   sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def self.select(*args); end
+  def select(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def self.order(*args); end
+  def order(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def self.reorder(*args); end
+  def reorder(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def self.group(*args); end
+  def group(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def self.limit(*args); end
+  def limit(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def self.offset(*args); end
+  def offset(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def self.joins(*args); end
+  def joins(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def self.left_joins(*args); end
+  def left_joins(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def self.left_outer_joins(*args); end
+  def left_outer_joins(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def self.where(*args); end
+  def where(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def self.rewhere(*args); end
+  def rewhere(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def self.preload(*args); end
+  def preload(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def self.eager_load(*args); end
+  def eager_load(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def self.includes(*args); end
+  def includes(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def self.from(*args); end
+  def from(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def self.lock(*args); end
+  def lock(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def self.readonly(*args); end
+  def readonly(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def self.or(*args); end
+  def or(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def self.having(*args); end
+  def having(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def self.create_with(*args); end
+  def create_with(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def self.distinct(*args); end
+  def distinct(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def self.references(*args); end
+  def references(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def self.none(*args); end
+  def none(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def self.unscope(*args); end
+  def unscope(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def self.merge(*args); end
+  def merge(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def self.except(*args); end
+  def except(*args); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def self.extending(*args, &block); end
+  def extending(*args, &block); end
+end
+
+module SpellBook::HABTM_Spells::QueryMethodsReturningAssociationRelation
+  sig { returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
+  def all; end
+
+  sig { params(block: T.nilable(T.proc.void)).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
+  def unscoped(&block); end
+
+  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
+  def select(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
+  def order(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
+  def reorder(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
+  def group(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
+  def limit(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
+  def offset(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
+  def joins(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
+  def left_joins(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
+  def left_outer_joins(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
+  def where(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
+  def rewhere(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
+  def preload(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
+  def eager_load(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
+  def includes(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
+  def from(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
+  def lock(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
+  def readonly(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
+  def or(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
+  def having(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
+  def create_with(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
+  def distinct(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
+  def references(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
+  def none(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
+  def unscope(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
+  def merge(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
+  def except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
+  def extending(*args, &block); end
 end
 
 class SpellBook::HABTM_Spells::ActiveRecord_Relation < ActiveRecord::Relation
   include SpellBook::HABTM_Spells::ActiveRelation_WhereNot
   include SpellBook::HABTM_Spells::CustomFinderMethods
+  include SpellBook::HABTM_Spells::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: SpellBook::HABTM_Spells)
-
-  sig { returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def extending(*args, &block); end
 end
 
 class SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
   include SpellBook::HABTM_Spells::ActiveRelation_WhereNot
   include SpellBook::HABTM_Spells::CustomFinderMethods
+  include SpellBook::HABTM_Spells::QueryMethodsReturningAssociationRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: SpellBook::HABTM_Spells)
-
-  sig { returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
 end
 
 class SpellBook::HABTM_Spells::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include SpellBook::HABTM_Spells::CustomFinderMethods
+  include SpellBook::HABTM_Spells::QueryMethodsReturningAssociationRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: SpellBook::HABTM_Spells)
-
-  sig { returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
 
   sig { params(records: T.any(SpellBook::HABTM_Spells, T::Array[SpellBook::HABTM_Spells])).returns(T.self_type) }
   def <<(*records); end

--- a/spec/test_data/v5.1/expected_squib.rbi
+++ b/spec/test_data/v5.1/expected_squib.rbi
@@ -308,6 +308,7 @@ class Squib < Wizard
   include Squib::GeneratedAttributeMethods
   include Squib::GeneratedAssociationMethods
   extend Squib::CustomFinderMethods
+  extend Squib::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   RelationType = T.type_alias { T.any(Squib::ActiveRecord_Relation, Squib::ActiveRecord_Associations_CollectionProxy, Squib::ActiveRecord_AssociationRelation) }
@@ -383,98 +384,12 @@ class Squib < Wizard
 
   sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
   def self.recent(*args); end
-
-  sig { returns(Squib::ActiveRecord_Relation) }
-  def self.all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def self.unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.select(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.order(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.group(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.limit(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.offset(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.joins(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.where(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.preload(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.includes(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.from(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.lock(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.or(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.having(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.references(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.none(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.merge(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def self.extending(*args, &block); end
 end
 
 class Squib::ActiveRecord_Relation < ActiveRecord::Relation
   include Squib::ActiveRelation_WhereNot
   include Squib::CustomFinderMethods
+  include Squib::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: Squib)
@@ -532,98 +447,12 @@ class Squib::ActiveRecord_Relation < ActiveRecord::Relation
 
   sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
   def recent(*args); end
-
-  sig { returns(Squib::ActiveRecord_Relation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def extending(*args, &block); end
 end
 
 class Squib::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
   include Squib::ActiveRelation_WhereNot
   include Squib::CustomFinderMethods
+  include Squib::QueryMethodsReturningAssociationRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: Squib)
@@ -681,97 +510,11 @@ class Squib::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelatio
 
   sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
   def recent(*args); end
-
-  sig { returns(Squib::ActiveRecord_AssociationRelation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
 end
 
 class Squib::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include Squib::CustomFinderMethods
+  include Squib::QueryMethodsReturningAssociationRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: Squib)
@@ -829,93 +572,6 @@ class Squib::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associati
 
   sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
   def recent(*args); end
-
-  sig { returns(Squib::ActiveRecord_AssociationRelation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
 
   sig { params(records: T.any(Squib, T::Array[Squib])).returns(T.self_type) }
   def <<(*records); end
@@ -928,4 +584,182 @@ class Squib::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associati
 
   sig { params(records: T.any(Squib, T::Array[Squib])).returns(T.self_type) }
   def concat(*records); end
+end
+
+module Squib::QueryMethodsReturningRelation
+  sig { returns(Squib::ActiveRecord_Relation) }
+  def all; end
+
+  sig { params(block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
+  def unscoped(&block); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def select(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def order(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def reorder(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def group(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def limit(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def offset(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def joins(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def left_joins(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def left_outer_joins(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def where(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def rewhere(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def preload(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def eager_load(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def includes(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def from(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def lock(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def readonly(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def or(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def having(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def create_with(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def distinct(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def references(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def none(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def unscope(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def merge(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
+  def extending(*args, &block); end
+end
+
+module Squib::QueryMethodsReturningAssociationRelation
+  sig { returns(Squib::ActiveRecord_AssociationRelation) }
+  def all; end
+
+  sig { params(block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
+  def unscoped(&block); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def select(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def order(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def reorder(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def group(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def limit(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def offset(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def joins(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def left_joins(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def left_outer_joins(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def where(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def rewhere(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def preload(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def eager_load(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def includes(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def from(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def lock(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def readonly(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def or(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def having(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def create_with(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def distinct(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def references(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def none(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def unscope(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def merge(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
+  def extending(*args, &block); end
 end

--- a/spec/test_data/v5.1/expected_squib.rbi
+++ b/spec/test_data/v5.1/expected_squib.rbi
@@ -3,8 +3,6 @@
 
 # typed: strong
 module Squib::EnumInstanceMethods
-  extend T::Sig
-
   sig { returns(T::Boolean) }
   def broom_nimbus?; end
 
@@ -114,8 +112,6 @@ module Squib::ActiveRelation_WhereNot
 end
 
 module Squib::GeneratedAttributeMethods
-  extend T::Sig
-
   sig { returns(T.nilable(String)) }
   def broom; end
 
@@ -253,8 +249,6 @@ module Squib::GeneratedAttributeMethods
 end
 
 module Squib::GeneratedAssociationMethods
-  extend T::Sig
-
   sig { returns(T.nilable(::School)) }
   def school; end
 
@@ -309,8 +303,6 @@ class Squib < Wizard
   include Squib::GeneratedAssociationMethods
   extend Squib::CustomFinderMethods
   extend Squib::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   RelationType = T.type_alias { T.any(Squib::ActiveRecord_Relation, Squib::ActiveRecord_Associations_CollectionProxy, Squib::ActiveRecord_AssociationRelation) }
 
   sig { returns(T::Hash[T.any(String, Symbol), String]) }
@@ -390,8 +382,6 @@ class Squib::ActiveRecord_Relation < ActiveRecord::Relation
   include Squib::ActiveRelation_WhereNot
   include Squib::CustomFinderMethods
   include Squib::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Squib)
 
   sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
@@ -453,8 +443,6 @@ class Squib::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelatio
   include Squib::ActiveRelation_WhereNot
   include Squib::CustomFinderMethods
   include Squib::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Squib)
 
   sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
@@ -515,8 +503,6 @@ end
 class Squib::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include Squib::CustomFinderMethods
   include Squib::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Squib)
 
   sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }

--- a/spec/test_data/v5.1/expected_subject.rbi
+++ b/spec/test_data/v5.1/expected_subject.rbi
@@ -63,380 +63,214 @@ class Subject < ApplicationRecord
   include Subject::GeneratedAttributeMethods
   include Subject::GeneratedAssociationMethods
   extend Subject::CustomFinderMethods
+  extend Subject::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   RelationType = T.type_alias { T.any(Subject::ActiveRecord_Relation, Subject::ActiveRecord_Associations_CollectionProxy, Subject::ActiveRecord_AssociationRelation) }
+end
 
+module Subject::QueryMethodsReturningRelation
   sig { returns(Subject::ActiveRecord_Relation) }
-  def self.all; end
+  def all; end
 
   sig { params(block: T.nilable(T.proc.void)).returns(Subject::ActiveRecord_Relation) }
-  def self.unscoped(&block); end
+  def unscoped(&block); end
 
   sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def self.select(*args); end
+  def select(*args); end
 
   sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def self.order(*args); end
+  def order(*args); end
 
   sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def self.reorder(*args); end
+  def reorder(*args); end
 
   sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def self.group(*args); end
+  def group(*args); end
 
   sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def self.limit(*args); end
+  def limit(*args); end
 
   sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def self.offset(*args); end
+  def offset(*args); end
 
   sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def self.joins(*args); end
+  def joins(*args); end
 
   sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def self.left_joins(*args); end
+  def left_joins(*args); end
 
   sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def self.left_outer_joins(*args); end
+  def left_outer_joins(*args); end
 
   sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def self.where(*args); end
+  def where(*args); end
 
   sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def self.rewhere(*args); end
+  def rewhere(*args); end
 
   sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def self.preload(*args); end
+  def preload(*args); end
 
   sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def self.eager_load(*args); end
+  def eager_load(*args); end
 
   sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def self.includes(*args); end
+  def includes(*args); end
 
   sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def self.from(*args); end
+  def from(*args); end
 
   sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def self.lock(*args); end
+  def lock(*args); end
 
   sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def self.readonly(*args); end
+  def readonly(*args); end
 
   sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def self.or(*args); end
+  def or(*args); end
 
   sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def self.having(*args); end
+  def having(*args); end
 
   sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def self.create_with(*args); end
+  def create_with(*args); end
 
   sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def self.distinct(*args); end
+  def distinct(*args); end
 
   sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def self.references(*args); end
+  def references(*args); end
 
   sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def self.none(*args); end
+  def none(*args); end
 
   sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def self.unscope(*args); end
+  def unscope(*args); end
 
   sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def self.merge(*args); end
+  def merge(*args); end
 
   sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def self.except(*args); end
+  def except(*args); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Subject::ActiveRecord_Relation) }
-  def self.extending(*args, &block); end
+  def extending(*args, &block); end
+end
+
+module Subject::QueryMethodsReturningAssociationRelation
+  sig { returns(Subject::ActiveRecord_AssociationRelation) }
+  def all; end
+
+  sig { params(block: T.nilable(T.proc.void)).returns(Subject::ActiveRecord_Relation) }
+  def unscoped(&block); end
+
+  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
+  def select(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
+  def order(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
+  def reorder(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
+  def group(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
+  def limit(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
+  def offset(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
+  def joins(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
+  def left_joins(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
+  def left_outer_joins(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
+  def where(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
+  def rewhere(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
+  def preload(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
+  def eager_load(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
+  def includes(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
+  def from(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
+  def lock(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
+  def readonly(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
+  def or(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
+  def having(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
+  def create_with(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
+  def distinct(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
+  def references(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
+  def none(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
+  def unscope(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
+  def merge(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
+  def except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Subject::ActiveRecord_AssociationRelation) }
+  def extending(*args, &block); end
 end
 
 class Subject::ActiveRecord_Relation < ActiveRecord::Relation
   include Subject::ActiveRelation_WhereNot
   include Subject::CustomFinderMethods
+  include Subject::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: Subject)
-
-  sig { returns(Subject::ActiveRecord_Relation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Subject::ActiveRecord_Relation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Subject::ActiveRecord_Relation) }
-  def extending(*args, &block); end
 end
 
 class Subject::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
   include Subject::ActiveRelation_WhereNot
   include Subject::CustomFinderMethods
+  include Subject::QueryMethodsReturningAssociationRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: Subject)
-
-  sig { returns(Subject::ActiveRecord_AssociationRelation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Subject::ActiveRecord_AssociationRelation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Subject::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
 end
 
 class Subject::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include Subject::CustomFinderMethods
+  include Subject::QueryMethodsReturningAssociationRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: Subject)
-
-  sig { returns(Subject::ActiveRecord_AssociationRelation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Subject::ActiveRecord_AssociationRelation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Subject::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
 
   sig { params(records: T.any(Subject, T::Array[Subject])).returns(T.self_type) }
   def <<(*records); end

--- a/spec/test_data/v5.1/expected_subject.rbi
+++ b/spec/test_data/v5.1/expected_subject.rbi
@@ -8,8 +8,6 @@ module Subject::ActiveRelation_WhereNot
 end
 
 module Subject::GeneratedAttributeMethods
-  extend T::Sig
-
   sig { returns(Integer) }
   def id; end
 
@@ -30,8 +28,6 @@ module Subject::GeneratedAttributeMethods
 end
 
 module Subject::GeneratedAssociationMethods
-  extend T::Sig
-
   sig { returns(::Wizard::ActiveRecord_Associations_CollectionProxy) }
   def wizards; end
 
@@ -64,8 +60,6 @@ class Subject < ApplicationRecord
   include Subject::GeneratedAssociationMethods
   extend Subject::CustomFinderMethods
   extend Subject::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   RelationType = T.type_alias { T.any(Subject::ActiveRecord_Relation, Subject::ActiveRecord_Associations_CollectionProxy, Subject::ActiveRecord_AssociationRelation) }
 end
 
@@ -251,8 +245,6 @@ class Subject::ActiveRecord_Relation < ActiveRecord::Relation
   include Subject::ActiveRelation_WhereNot
   include Subject::CustomFinderMethods
   include Subject::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Subject)
 end
 
@@ -260,16 +252,12 @@ class Subject::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelat
   include Subject::ActiveRelation_WhereNot
   include Subject::CustomFinderMethods
   include Subject::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Subject)
 end
 
 class Subject::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include Subject::CustomFinderMethods
   include Subject::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Subject)
 
   sig { params(records: T.any(Subject, T::Array[Subject])).returns(T.self_type) }

--- a/spec/test_data/v5.1/expected_subject/habtm_wizards.rbi
+++ b/spec/test_data/v5.1/expected_subject/habtm_wizards.rbi
@@ -8,8 +8,6 @@ module Subject::HABTM_Wizards::ActiveRelation_WhereNot
 end
 
 module Subject::HABTM_Wizards::GeneratedAttributeMethods
-  extend T::Sig
-
   sig { returns(T.nilable(Integer)) }
   def subject_id; end
 
@@ -30,8 +28,6 @@ module Subject::HABTM_Wizards::GeneratedAttributeMethods
 end
 
 module Subject::HABTM_Wizards::GeneratedAssociationMethods
-  extend T::Sig
-
   sig { returns(T.nilable(::Subject)) }
   def left_side; end
 
@@ -67,8 +63,6 @@ class Subject::HABTM_Wizards < ActiveRecord::Base
   include Subject::HABTM_Wizards::GeneratedAssociationMethods
   extend Subject::HABTM_Wizards::CustomFinderMethods
   extend Subject::HABTM_Wizards::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   RelationType = T.type_alias { T.any(Subject::HABTM_Wizards::ActiveRecord_Relation, Subject::HABTM_Wizards::ActiveRecord_Associations_CollectionProxy, Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
 end
 
@@ -254,8 +248,6 @@ class Subject::HABTM_Wizards::ActiveRecord_Relation < ActiveRecord::Relation
   include Subject::HABTM_Wizards::ActiveRelation_WhereNot
   include Subject::HABTM_Wizards::CustomFinderMethods
   include Subject::HABTM_Wizards::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Subject::HABTM_Wizards)
 end
 
@@ -263,16 +255,12 @@ class Subject::HABTM_Wizards::ActiveRecord_AssociationRelation < ActiveRecord::A
   include Subject::HABTM_Wizards::ActiveRelation_WhereNot
   include Subject::HABTM_Wizards::CustomFinderMethods
   include Subject::HABTM_Wizards::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Subject::HABTM_Wizards)
 end
 
 class Subject::HABTM_Wizards::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include Subject::HABTM_Wizards::CustomFinderMethods
   include Subject::HABTM_Wizards::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Subject::HABTM_Wizards)
 
   sig { params(records: T.any(Subject::HABTM_Wizards, T::Array[Subject::HABTM_Wizards])).returns(T.self_type) }

--- a/spec/test_data/v5.1/expected_subject/habtm_wizards.rbi
+++ b/spec/test_data/v5.1/expected_subject/habtm_wizards.rbi
@@ -66,380 +66,214 @@ class Subject::HABTM_Wizards < ActiveRecord::Base
   include Subject::HABTM_Wizards::GeneratedAttributeMethods
   include Subject::HABTM_Wizards::GeneratedAssociationMethods
   extend Subject::HABTM_Wizards::CustomFinderMethods
+  extend Subject::HABTM_Wizards::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   RelationType = T.type_alias { T.any(Subject::HABTM_Wizards::ActiveRecord_Relation, Subject::HABTM_Wizards::ActiveRecord_Associations_CollectionProxy, Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
+end
 
+module Subject::HABTM_Wizards::QueryMethodsReturningRelation
   sig { returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def self.all; end
+  def all; end
 
   sig { params(block: T.nilable(T.proc.void)).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def self.unscoped(&block); end
+  def unscoped(&block); end
 
   sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def self.select(*args); end
+  def select(*args); end
 
   sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def self.order(*args); end
+  def order(*args); end
 
   sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def self.reorder(*args); end
+  def reorder(*args); end
 
   sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def self.group(*args); end
+  def group(*args); end
 
   sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def self.limit(*args); end
+  def limit(*args); end
 
   sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def self.offset(*args); end
+  def offset(*args); end
 
   sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def self.joins(*args); end
+  def joins(*args); end
 
   sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def self.left_joins(*args); end
+  def left_joins(*args); end
 
   sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def self.left_outer_joins(*args); end
+  def left_outer_joins(*args); end
 
   sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def self.where(*args); end
+  def where(*args); end
 
   sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def self.rewhere(*args); end
+  def rewhere(*args); end
 
   sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def self.preload(*args); end
+  def preload(*args); end
 
   sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def self.eager_load(*args); end
+  def eager_load(*args); end
 
   sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def self.includes(*args); end
+  def includes(*args); end
 
   sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def self.from(*args); end
+  def from(*args); end
 
   sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def self.lock(*args); end
+  def lock(*args); end
 
   sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def self.readonly(*args); end
+  def readonly(*args); end
 
   sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def self.or(*args); end
+  def or(*args); end
 
   sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def self.having(*args); end
+  def having(*args); end
 
   sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def self.create_with(*args); end
+  def create_with(*args); end
 
   sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def self.distinct(*args); end
+  def distinct(*args); end
 
   sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def self.references(*args); end
+  def references(*args); end
 
   sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def self.none(*args); end
+  def none(*args); end
 
   sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def self.unscope(*args); end
+  def unscope(*args); end
 
   sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def self.merge(*args); end
+  def merge(*args); end
 
   sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def self.except(*args); end
+  def except(*args); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def self.extending(*args, &block); end
+  def extending(*args, &block); end
+end
+
+module Subject::HABTM_Wizards::QueryMethodsReturningAssociationRelation
+  sig { returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
+  def all; end
+
+  sig { params(block: T.nilable(T.proc.void)).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
+  def unscoped(&block); end
+
+  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
+  def select(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
+  def order(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
+  def reorder(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
+  def group(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
+  def limit(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
+  def offset(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
+  def joins(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
+  def left_joins(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
+  def left_outer_joins(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
+  def where(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
+  def rewhere(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
+  def preload(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
+  def eager_load(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
+  def includes(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
+  def from(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
+  def lock(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
+  def readonly(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
+  def or(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
+  def having(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
+  def create_with(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
+  def distinct(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
+  def references(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
+  def none(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
+  def unscope(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
+  def merge(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
+  def except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
+  def extending(*args, &block); end
 end
 
 class Subject::HABTM_Wizards::ActiveRecord_Relation < ActiveRecord::Relation
   include Subject::HABTM_Wizards::ActiveRelation_WhereNot
   include Subject::HABTM_Wizards::CustomFinderMethods
+  include Subject::HABTM_Wizards::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: Subject::HABTM_Wizards)
-
-  sig { returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def extending(*args, &block); end
 end
 
 class Subject::HABTM_Wizards::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
   include Subject::HABTM_Wizards::ActiveRelation_WhereNot
   include Subject::HABTM_Wizards::CustomFinderMethods
+  include Subject::HABTM_Wizards::QueryMethodsReturningAssociationRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: Subject::HABTM_Wizards)
-
-  sig { returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
 end
 
 class Subject::HABTM_Wizards::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include Subject::HABTM_Wizards::CustomFinderMethods
+  include Subject::HABTM_Wizards::QueryMethodsReturningAssociationRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: Subject::HABTM_Wizards)
-
-  sig { returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
 
   sig { params(records: T.any(Subject::HABTM_Wizards, T::Array[Subject::HABTM_Wizards])).returns(T.self_type) }
   def <<(*records); end

--- a/spec/test_data/v5.1/expected_wand.rbi
+++ b/spec/test_data/v5.1/expected_wand.rbi
@@ -198,6 +198,7 @@ class Wand < ApplicationRecord
   include Wand::GeneratedAttributeMethods
   include Wand::GeneratedAssociationMethods
   extend Wand::CustomFinderMethods
+  extend Wand::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   RelationType = T.type_alias { T.any(Wand::ActiveRecord_Relation, Wand::ActiveRecord_Associations_CollectionProxy, Wand::ActiveRecord_AssociationRelation) }
@@ -217,93 +218,6 @@ class Wand < ApplicationRecord
   sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
   def self.unicorn_tail_hair(*args); end
 
-  sig { returns(Wand::ActiveRecord_Relation) }
-  def self.all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def self.unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
-  def self.select(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
-  def self.order(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
-  def self.reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
-  def self.group(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
-  def self.limit(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
-  def self.offset(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
-  def self.joins(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
-  def self.left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
-  def self.left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
-  def self.where(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
-  def self.rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
-  def self.preload(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
-  def self.eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
-  def self.includes(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
-  def self.from(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
-  def self.lock(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
-  def self.readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
-  def self.or(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
-  def self.having(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
-  def self.create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
-  def self.distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
-  def self.references(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
-  def self.none(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
-  def self.unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
-  def self.merge(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
-  def self.except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def self.extending(*args, &block); end
-
   sig { returns(T.nilable(Wand::CoreType)) }
   def typed_core_type; end
 
@@ -317,6 +231,7 @@ end
 class Wand::ActiveRecord_Relation < ActiveRecord::Relation
   include Wand::ActiveRelation_WhereNot
   include Wand::CustomFinderMethods
+  include Wand::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: Wand)
@@ -332,7 +247,62 @@ class Wand::ActiveRecord_Relation < ActiveRecord::Relation
 
   sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
   def unicorn_tail_hair(*args); end
+end
 
+class Wand::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
+  include Wand::ActiveRelation_WhereNot
+  include Wand::CustomFinderMethods
+  include Wand::QueryMethodsReturningAssociationRelation
+  extend T::Sig
+  extend T::Generic
+  Elem = type_member(fixed: Wand)
+
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def basilisk_horn(*args); end
+
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def dragon_heartstring(*args); end
+
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def phoenix_feather(*args); end
+
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def unicorn_tail_hair(*args); end
+end
+
+class Wand::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
+  include Wand::CustomFinderMethods
+  include Wand::QueryMethodsReturningAssociationRelation
+  extend T::Sig
+  extend T::Generic
+  Elem = type_member(fixed: Wand)
+
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def basilisk_horn(*args); end
+
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def dragon_heartstring(*args); end
+
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def phoenix_feather(*args); end
+
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def unicorn_tail_hair(*args); end
+
+  sig { params(records: T.any(Wand, T::Array[Wand])).returns(T.self_type) }
+  def <<(*records); end
+
+  sig { params(records: T.any(Wand, T::Array[Wand])).returns(T.self_type) }
+  def append(*records); end
+
+  sig { params(records: T.any(Wand, T::Array[Wand])).returns(T.self_type) }
+  def push(*records); end
+
+  sig { params(records: T.any(Wand, T::Array[Wand])).returns(T.self_type) }
+  def concat(*records); end
+end
+
+module Wand::QueryMethodsReturningRelation
   sig { returns(Wand::ActiveRecord_Relation) }
   def all; end
 
@@ -421,29 +391,11 @@ class Wand::ActiveRecord_Relation < ActiveRecord::Relation
   def extending(*args, &block); end
 end
 
-class Wand::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
-  include Wand::ActiveRelation_WhereNot
-  include Wand::CustomFinderMethods
-  extend T::Sig
-  extend T::Generic
-  Elem = type_member(fixed: Wand)
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def basilisk_horn(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def dragon_heartstring(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def phoenix_feather(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def unicorn_tail_hair(*args); end
-
+module Wand::QueryMethodsReturningAssociationRelation
   sig { returns(Wand::ActiveRecord_AssociationRelation) }
   def all; end
 
-  sig { params(block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
+  sig { params(block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def unscoped(&block); end
 
   sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
@@ -526,122 +478,4 @@ class Wand::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
   def extending(*args, &block); end
-end
-
-class Wand::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
-  include Wand::CustomFinderMethods
-  extend T::Sig
-  extend T::Generic
-  Elem = type_member(fixed: Wand)
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def basilisk_horn(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def dragon_heartstring(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def phoenix_feather(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def unicorn_tail_hair(*args); end
-
-  sig { returns(Wand::ActiveRecord_AssociationRelation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
-
-  sig { params(records: T.any(Wand, T::Array[Wand])).returns(T.self_type) }
-  def <<(*records); end
-
-  sig { params(records: T.any(Wand, T::Array[Wand])).returns(T.self_type) }
-  def append(*records); end
-
-  sig { params(records: T.any(Wand, T::Array[Wand])).returns(T.self_type) }
-  def push(*records); end
-
-  sig { params(records: T.any(Wand, T::Array[Wand])).returns(T.self_type) }
-  def concat(*records); end
 end

--- a/spec/test_data/v5.1/expected_wand.rbi
+++ b/spec/test_data/v5.1/expected_wand.rbi
@@ -3,8 +3,6 @@
 
 # typed: strong
 module Wand::EnumInstanceMethods
-  extend T::Sig
-
   sig { returns(T::Boolean) }
   def phoenix_feather?; end
 
@@ -36,8 +34,6 @@ module Wand::ActiveRelation_WhereNot
 end
 
 module Wand::GeneratedAttributeMethods
-  extend T::Sig
-
   sig { returns(T::Boolean) }
   def broken; end
 
@@ -167,8 +163,6 @@ class Wand::CoreType < T::Enum
 end
 
 module Wand::GeneratedAssociationMethods
-  extend T::Sig
-
   sig { returns(::Wizard) }
   def wizard; end
 
@@ -199,8 +193,6 @@ class Wand < ApplicationRecord
   include Wand::GeneratedAssociationMethods
   extend Wand::CustomFinderMethods
   extend Wand::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   RelationType = T.type_alias { T.any(Wand::ActiveRecord_Relation, Wand::ActiveRecord_Associations_CollectionProxy, Wand::ActiveRecord_AssociationRelation) }
 
   sig { returns(T::Hash[T.any(String, Symbol), Integer]) }
@@ -232,8 +224,6 @@ class Wand::ActiveRecord_Relation < ActiveRecord::Relation
   include Wand::ActiveRelation_WhereNot
   include Wand::CustomFinderMethods
   include Wand::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Wand)
 
   sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
@@ -253,8 +243,6 @@ class Wand::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
   include Wand::ActiveRelation_WhereNot
   include Wand::CustomFinderMethods
   include Wand::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Wand)
 
   sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
@@ -273,8 +261,6 @@ end
 class Wand::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include Wand::CustomFinderMethods
   include Wand::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Wand)
 
   sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }

--- a/spec/test_data/v5.1/expected_wizard.rbi
+++ b/spec/test_data/v5.1/expected_wizard.rbi
@@ -3,8 +3,6 @@
 
 # typed: strong
 module Wizard::EnumInstanceMethods
-  extend T::Sig
-
   sig { returns(T::Boolean) }
   def broom_nimbus?; end
 
@@ -114,8 +112,6 @@ module Wizard::ActiveRelation_WhereNot
 end
 
 module Wizard::GeneratedAttributeMethods
-  extend T::Sig
-
   sig { returns(T::Boolean) }
   def broom?; end
 
@@ -293,8 +289,6 @@ class Wizard::QuidditchPosition < T::Enum
 end
 
 module Wizard::GeneratedAssociationMethods
-  extend T::Sig
-
   sig { returns(T.nilable(::School)) }
   def school; end
 
@@ -349,8 +343,6 @@ class Wizard < ApplicationRecord
   include Wizard::GeneratedAssociationMethods
   extend Wizard::CustomFinderMethods
   extend Wizard::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   RelationType = T.type_alias { T.any(Wizard::ActiveRecord_Relation, Wizard::ActiveRecord_Associations_CollectionProxy, Wizard::ActiveRecord_AssociationRelation) }
 
   sig { returns(T::Hash[T.any(String, Symbol), String]) }
@@ -466,8 +458,6 @@ class Wizard::ActiveRecord_Relation < ActiveRecord::Relation
   include Wizard::ActiveRelation_WhereNot
   include Wizard::CustomFinderMethods
   include Wizard::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Wizard)
 
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
@@ -529,8 +519,6 @@ class Wizard::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelati
   include Wizard::ActiveRelation_WhereNot
   include Wizard::CustomFinderMethods
   include Wizard::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Wizard)
 
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
@@ -591,8 +579,6 @@ end
 class Wizard::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include Wizard::CustomFinderMethods
   include Wizard::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Wizard)
 
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }

--- a/spec/test_data/v5.1/expected_wizard.rbi
+++ b/spec/test_data/v5.1/expected_wizard.rbi
@@ -348,6 +348,7 @@ class Wizard < ApplicationRecord
   include Wizard::GeneratedAttributeMethods
   include Wizard::GeneratedAssociationMethods
   extend Wizard::CustomFinderMethods
+  extend Wizard::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   RelationType = T.type_alias { T.any(Wizard::ActiveRecord_Relation, Wizard::ActiveRecord_Associations_CollectionProxy, Wizard::ActiveRecord_AssociationRelation) }
@@ -424,93 +425,6 @@ class Wizard < ApplicationRecord
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
   def self.recent(*args); end
 
-  sig { returns(Wizard::ActiveRecord_Relation) }
-  def self.all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.select(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.order(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.group(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.limit(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.offset(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.joins(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.where(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.preload(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.includes(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.from(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.lock(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.or(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.having(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.references(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.none(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.merge(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.extending(*args, &block); end
-
   sig { returns(T.nilable(Wizard::Broom)) }
   def typed_broom; end
 
@@ -551,6 +465,7 @@ end
 class Wizard::ActiveRecord_Relation < ActiveRecord::Relation
   include Wizard::ActiveRelation_WhereNot
   include Wizard::CustomFinderMethods
+  include Wizard::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: Wizard)
@@ -608,7 +523,146 @@ class Wizard::ActiveRecord_Relation < ActiveRecord::Relation
 
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
   def recent(*args); end
+end
 
+class Wizard::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
+  include Wizard::ActiveRelation_WhereNot
+  include Wizard::CustomFinderMethods
+  include Wizard::QueryMethodsReturningAssociationRelation
+  extend T::Sig
+  extend T::Generic
+  Elem = type_member(fixed: Wizard)
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def Gryffindor(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def Hagrid(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def Hufflepuff(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def Ravenclaw(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def Slytherin(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def black_hair(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def blonde_hair(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def broom_firebolt(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def broom_nimbus(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def brown_hair(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def color_blue_eyes(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def color_brown_eyes(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def color_green_eyes(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def quidditch_beater(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def quidditch_chaser(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def quidditch_keeper(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def quidditch_seeker(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def recent(*args); end
+end
+
+class Wizard::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
+  include Wizard::CustomFinderMethods
+  include Wizard::QueryMethodsReturningAssociationRelation
+  extend T::Sig
+  extend T::Generic
+  Elem = type_member(fixed: Wizard)
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def Gryffindor(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def Hagrid(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def Hufflepuff(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def Ravenclaw(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def Slytherin(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def black_hair(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def blonde_hair(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def broom_firebolt(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def broom_nimbus(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def brown_hair(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def color_blue_eyes(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def color_brown_eyes(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def color_green_eyes(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def quidditch_beater(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def quidditch_chaser(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def quidditch_keeper(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def quidditch_seeker(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def recent(*args); end
+
+  sig { params(records: T.any(Wizard, T::Array[Wizard])).returns(T.self_type) }
+  def <<(*records); end
+
+  sig { params(records: T.any(Wizard, T::Array[Wizard])).returns(T.self_type) }
+  def append(*records); end
+
+  sig { params(records: T.any(Wizard, T::Array[Wizard])).returns(T.self_type) }
+  def push(*records); end
+
+  sig { params(records: T.any(Wizard, T::Array[Wizard])).returns(T.self_type) }
+  def concat(*records); end
+end
+
+module Wizard::QueryMethodsReturningRelation
   sig { returns(Wizard::ActiveRecord_Relation) }
   def all; end
 
@@ -697,71 +751,11 @@ class Wizard::ActiveRecord_Relation < ActiveRecord::Relation
   def extending(*args, &block); end
 end
 
-class Wizard::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
-  include Wizard::ActiveRelation_WhereNot
-  include Wizard::CustomFinderMethods
-  extend T::Sig
-  extend T::Generic
-  Elem = type_member(fixed: Wizard)
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def Gryffindor(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def Hagrid(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def Hufflepuff(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def Ravenclaw(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def Slytherin(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def black_hair(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def blonde_hair(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def broom_firebolt(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def broom_nimbus(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def brown_hair(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def color_blue_eyes(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def color_brown_eyes(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def color_green_eyes(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def quidditch_beater(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def quidditch_chaser(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def quidditch_keeper(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def quidditch_seeker(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def recent(*args); end
-
+module Wizard::QueryMethodsReturningAssociationRelation
   sig { returns(Wizard::ActiveRecord_AssociationRelation) }
   def all; end
 
-  sig { params(block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
+  sig { params(block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def unscoped(&block); end
 
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
@@ -844,164 +838,4 @@ class Wizard::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelati
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
   def extending(*args, &block); end
-end
-
-class Wizard::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
-  include Wizard::CustomFinderMethods
-  extend T::Sig
-  extend T::Generic
-  Elem = type_member(fixed: Wizard)
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def Gryffindor(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def Hagrid(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def Hufflepuff(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def Ravenclaw(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def Slytherin(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def black_hair(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def blonde_hair(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def broom_firebolt(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def broom_nimbus(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def brown_hair(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def color_blue_eyes(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def color_brown_eyes(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def color_green_eyes(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def quidditch_beater(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def quidditch_chaser(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def quidditch_keeper(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def quidditch_seeker(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def recent(*args); end
-
-  sig { returns(Wizard::ActiveRecord_AssociationRelation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
-
-  sig { params(records: T.any(Wizard, T::Array[Wizard])).returns(T.self_type) }
-  def <<(*records); end
-
-  sig { params(records: T.any(Wizard, T::Array[Wizard])).returns(T.self_type) }
-  def append(*records); end
-
-  sig { params(records: T.any(Wizard, T::Array[Wizard])).returns(T.self_type) }
-  def push(*records); end
-
-  sig { params(records: T.any(Wizard, T::Array[Wizard])).returns(T.self_type) }
-  def concat(*records); end
 end

--- a/spec/test_data/v5.1/expected_wizard/habtm_subjects.rbi
+++ b/spec/test_data/v5.1/expected_wizard/habtm_subjects.rbi
@@ -8,8 +8,6 @@ module Wizard::HABTM_Subjects::ActiveRelation_WhereNot
 end
 
 module Wizard::HABTM_Subjects::GeneratedAttributeMethods
-  extend T::Sig
-
   sig { returns(T.nilable(Integer)) }
   def subject_id; end
 
@@ -30,8 +28,6 @@ module Wizard::HABTM_Subjects::GeneratedAttributeMethods
 end
 
 module Wizard::HABTM_Subjects::GeneratedAssociationMethods
-  extend T::Sig
-
   sig { returns(T.nilable(::Wizard)) }
   def left_side; end
 
@@ -67,8 +63,6 @@ class Wizard::HABTM_Subjects < ActiveRecord::Base
   include Wizard::HABTM_Subjects::GeneratedAssociationMethods
   extend Wizard::HABTM_Subjects::CustomFinderMethods
   extend Wizard::HABTM_Subjects::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   RelationType = T.type_alias { T.any(Wizard::HABTM_Subjects::ActiveRecord_Relation, Wizard::HABTM_Subjects::ActiveRecord_Associations_CollectionProxy, Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
 end
 
@@ -254,8 +248,6 @@ class Wizard::HABTM_Subjects::ActiveRecord_Relation < ActiveRecord::Relation
   include Wizard::HABTM_Subjects::ActiveRelation_WhereNot
   include Wizard::HABTM_Subjects::CustomFinderMethods
   include Wizard::HABTM_Subjects::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Wizard::HABTM_Subjects)
 end
 
@@ -263,16 +255,12 @@ class Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation < ActiveRecord::A
   include Wizard::HABTM_Subjects::ActiveRelation_WhereNot
   include Wizard::HABTM_Subjects::CustomFinderMethods
   include Wizard::HABTM_Subjects::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Wizard::HABTM_Subjects)
 end
 
 class Wizard::HABTM_Subjects::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include Wizard::HABTM_Subjects::CustomFinderMethods
   include Wizard::HABTM_Subjects::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Wizard::HABTM_Subjects)
 
   sig { params(records: T.any(Wizard::HABTM_Subjects, T::Array[Wizard::HABTM_Subjects])).returns(T.self_type) }

--- a/spec/test_data/v5.1/expected_wizard/habtm_subjects.rbi
+++ b/spec/test_data/v5.1/expected_wizard/habtm_subjects.rbi
@@ -66,380 +66,214 @@ class Wizard::HABTM_Subjects < ActiveRecord::Base
   include Wizard::HABTM_Subjects::GeneratedAttributeMethods
   include Wizard::HABTM_Subjects::GeneratedAssociationMethods
   extend Wizard::HABTM_Subjects::CustomFinderMethods
+  extend Wizard::HABTM_Subjects::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   RelationType = T.type_alias { T.any(Wizard::HABTM_Subjects::ActiveRecord_Relation, Wizard::HABTM_Subjects::ActiveRecord_Associations_CollectionProxy, Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
+end
 
+module Wizard::HABTM_Subjects::QueryMethodsReturningRelation
   sig { returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def self.all; end
+  def all; end
 
   sig { params(block: T.nilable(T.proc.void)).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def self.unscoped(&block); end
+  def unscoped(&block); end
 
   sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def self.select(*args); end
+  def select(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def self.order(*args); end
+  def order(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def self.reorder(*args); end
+  def reorder(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def self.group(*args); end
+  def group(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def self.limit(*args); end
+  def limit(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def self.offset(*args); end
+  def offset(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def self.joins(*args); end
+  def joins(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def self.left_joins(*args); end
+  def left_joins(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def self.left_outer_joins(*args); end
+  def left_outer_joins(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def self.where(*args); end
+  def where(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def self.rewhere(*args); end
+  def rewhere(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def self.preload(*args); end
+  def preload(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def self.eager_load(*args); end
+  def eager_load(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def self.includes(*args); end
+  def includes(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def self.from(*args); end
+  def from(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def self.lock(*args); end
+  def lock(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def self.readonly(*args); end
+  def readonly(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def self.or(*args); end
+  def or(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def self.having(*args); end
+  def having(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def self.create_with(*args); end
+  def create_with(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def self.distinct(*args); end
+  def distinct(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def self.references(*args); end
+  def references(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def self.none(*args); end
+  def none(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def self.unscope(*args); end
+  def unscope(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def self.merge(*args); end
+  def merge(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def self.except(*args); end
+  def except(*args); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def self.extending(*args, &block); end
+  def extending(*args, &block); end
+end
+
+module Wizard::HABTM_Subjects::QueryMethodsReturningAssociationRelation
+  sig { returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
+  def all; end
+
+  sig { params(block: T.nilable(T.proc.void)).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
+  def unscoped(&block); end
+
+  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
+  def select(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
+  def order(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
+  def reorder(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
+  def group(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
+  def limit(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
+  def offset(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
+  def joins(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
+  def left_joins(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
+  def left_outer_joins(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
+  def where(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
+  def rewhere(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
+  def preload(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
+  def eager_load(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
+  def includes(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
+  def from(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
+  def lock(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
+  def readonly(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
+  def or(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
+  def having(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
+  def create_with(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
+  def distinct(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
+  def references(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
+  def none(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
+  def unscope(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
+  def merge(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
+  def except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
+  def extending(*args, &block); end
 end
 
 class Wizard::HABTM_Subjects::ActiveRecord_Relation < ActiveRecord::Relation
   include Wizard::HABTM_Subjects::ActiveRelation_WhereNot
   include Wizard::HABTM_Subjects::CustomFinderMethods
+  include Wizard::HABTM_Subjects::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: Wizard::HABTM_Subjects)
-
-  sig { returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def extending(*args, &block); end
 end
 
 class Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
   include Wizard::HABTM_Subjects::ActiveRelation_WhereNot
   include Wizard::HABTM_Subjects::CustomFinderMethods
+  include Wizard::HABTM_Subjects::QueryMethodsReturningAssociationRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: Wizard::HABTM_Subjects)
-
-  sig { returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
 end
 
 class Wizard::HABTM_Subjects::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include Wizard::HABTM_Subjects::CustomFinderMethods
+  include Wizard::HABTM_Subjects::QueryMethodsReturningAssociationRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: Wizard::HABTM_Subjects)
-
-  sig { returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
 
   sig { params(records: T.any(Wizard::HABTM_Subjects, T::Array[Wizard::HABTM_Subjects])).returns(T.self_type) }
   def <<(*records); end

--- a/spec/test_data/v5.1/expected_wizard_wo_spellbook.rbi
+++ b/spec/test_data/v5.1/expected_wizard_wo_spellbook.rbi
@@ -3,8 +3,6 @@
 
 # typed: strong
 module Wizard::EnumInstanceMethods
-  extend T::Sig
-
   sig { returns(T::Boolean) }
   def broom_nimbus?; end
 
@@ -114,8 +112,6 @@ module Wizard::ActiveRelation_WhereNot
 end
 
 module Wizard::GeneratedAttributeMethods
-  extend T::Sig
-
   sig { returns(T::Boolean) }
   def broom?; end
 
@@ -293,8 +289,6 @@ class Wizard::QuidditchPosition < T::Enum
 end
 
 module Wizard::GeneratedAssociationMethods
-  extend T::Sig
-
   sig { returns(T.nilable(T.untyped)) }
   def school; end
 
@@ -343,8 +337,6 @@ class Wizard < ApplicationRecord
   include Wizard::GeneratedAssociationMethods
   extend Wizard::CustomFinderMethods
   extend Wizard::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   RelationType = T.type_alias { T.any(Wizard::ActiveRecord_Relation, Wizard::ActiveRecord_Associations_CollectionProxy, Wizard::ActiveRecord_AssociationRelation) }
 
   sig { returns(T::Hash[T.any(String, Symbol), String]) }
@@ -460,8 +452,6 @@ class Wizard::ActiveRecord_Relation < ActiveRecord::Relation
   include Wizard::ActiveRelation_WhereNot
   include Wizard::CustomFinderMethods
   include Wizard::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Wizard)
 
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
@@ -523,8 +513,6 @@ class Wizard::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelati
   include Wizard::ActiveRelation_WhereNot
   include Wizard::CustomFinderMethods
   include Wizard::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Wizard)
 
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
@@ -585,8 +573,6 @@ end
 class Wizard::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include Wizard::CustomFinderMethods
   include Wizard::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Wizard)
 
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }

--- a/spec/test_data/v5.1/expected_wizard_wo_spellbook.rbi
+++ b/spec/test_data/v5.1/expected_wizard_wo_spellbook.rbi
@@ -342,6 +342,7 @@ class Wizard < ApplicationRecord
   include Wizard::GeneratedAttributeMethods
   include Wizard::GeneratedAssociationMethods
   extend Wizard::CustomFinderMethods
+  extend Wizard::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   RelationType = T.type_alias { T.any(Wizard::ActiveRecord_Relation, Wizard::ActiveRecord_Associations_CollectionProxy, Wizard::ActiveRecord_AssociationRelation) }
@@ -418,93 +419,6 @@ class Wizard < ApplicationRecord
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
   def self.recent(*args); end
 
-  sig { returns(Wizard::ActiveRecord_Relation) }
-  def self.all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.select(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.order(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.group(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.limit(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.offset(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.joins(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.where(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.preload(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.includes(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.from(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.lock(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.or(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.having(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.references(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.none(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.merge(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.extending(*args, &block); end
-
   sig { returns(T.nilable(Wizard::Broom)) }
   def typed_broom; end
 
@@ -545,6 +459,7 @@ end
 class Wizard::ActiveRecord_Relation < ActiveRecord::Relation
   include Wizard::ActiveRelation_WhereNot
   include Wizard::CustomFinderMethods
+  include Wizard::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: Wizard)
@@ -602,7 +517,146 @@ class Wizard::ActiveRecord_Relation < ActiveRecord::Relation
 
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
   def recent(*args); end
+end
 
+class Wizard::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
+  include Wizard::ActiveRelation_WhereNot
+  include Wizard::CustomFinderMethods
+  include Wizard::QueryMethodsReturningAssociationRelation
+  extend T::Sig
+  extend T::Generic
+  Elem = type_member(fixed: Wizard)
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def Gryffindor(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def Hagrid(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def Hufflepuff(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def Ravenclaw(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def Slytherin(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def black_hair(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def blonde_hair(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def broom_firebolt(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def broom_nimbus(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def brown_hair(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def color_blue_eyes(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def color_brown_eyes(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def color_green_eyes(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def quidditch_beater(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def quidditch_chaser(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def quidditch_keeper(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def quidditch_seeker(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def recent(*args); end
+end
+
+class Wizard::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
+  include Wizard::CustomFinderMethods
+  include Wizard::QueryMethodsReturningAssociationRelation
+  extend T::Sig
+  extend T::Generic
+  Elem = type_member(fixed: Wizard)
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def Gryffindor(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def Hagrid(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def Hufflepuff(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def Ravenclaw(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def Slytherin(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def black_hair(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def blonde_hair(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def broom_firebolt(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def broom_nimbus(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def brown_hair(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def color_blue_eyes(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def color_brown_eyes(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def color_green_eyes(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def quidditch_beater(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def quidditch_chaser(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def quidditch_keeper(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def quidditch_seeker(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def recent(*args); end
+
+  sig { params(records: T.any(Wizard, T::Array[Wizard])).returns(T.self_type) }
+  def <<(*records); end
+
+  sig { params(records: T.any(Wizard, T::Array[Wizard])).returns(T.self_type) }
+  def append(*records); end
+
+  sig { params(records: T.any(Wizard, T::Array[Wizard])).returns(T.self_type) }
+  def push(*records); end
+
+  sig { params(records: T.any(Wizard, T::Array[Wizard])).returns(T.self_type) }
+  def concat(*records); end
+end
+
+module Wizard::QueryMethodsReturningRelation
   sig { returns(Wizard::ActiveRecord_Relation) }
   def all; end
 
@@ -691,71 +745,11 @@ class Wizard::ActiveRecord_Relation < ActiveRecord::Relation
   def extending(*args, &block); end
 end
 
-class Wizard::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
-  include Wizard::ActiveRelation_WhereNot
-  include Wizard::CustomFinderMethods
-  extend T::Sig
-  extend T::Generic
-  Elem = type_member(fixed: Wizard)
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def Gryffindor(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def Hagrid(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def Hufflepuff(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def Ravenclaw(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def Slytherin(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def black_hair(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def blonde_hair(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def broom_firebolt(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def broom_nimbus(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def brown_hair(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def color_blue_eyes(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def color_brown_eyes(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def color_green_eyes(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def quidditch_beater(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def quidditch_chaser(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def quidditch_keeper(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def quidditch_seeker(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def recent(*args); end
-
+module Wizard::QueryMethodsReturningAssociationRelation
   sig { returns(Wizard::ActiveRecord_AssociationRelation) }
   def all; end
 
-  sig { params(block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
+  sig { params(block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def unscoped(&block); end
 
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
@@ -838,164 +832,4 @@ class Wizard::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelati
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
   def extending(*args, &block); end
-end
-
-class Wizard::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
-  include Wizard::CustomFinderMethods
-  extend T::Sig
-  extend T::Generic
-  Elem = type_member(fixed: Wizard)
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def Gryffindor(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def Hagrid(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def Hufflepuff(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def Ravenclaw(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def Slytherin(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def black_hair(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def blonde_hair(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def broom_firebolt(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def broom_nimbus(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def brown_hair(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def color_blue_eyes(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def color_brown_eyes(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def color_green_eyes(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def quidditch_beater(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def quidditch_chaser(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def quidditch_keeper(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def quidditch_seeker(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def recent(*args); end
-
-  sig { returns(Wizard::ActiveRecord_AssociationRelation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
-
-  sig { params(records: T.any(Wizard, T::Array[Wizard])).returns(T.self_type) }
-  def <<(*records); end
-
-  sig { params(records: T.any(Wizard, T::Array[Wizard])).returns(T.self_type) }
-  def append(*records); end
-
-  sig { params(records: T.any(Wizard, T::Array[Wizard])).returns(T.self_type) }
-  def push(*records); end
-
-  sig { params(records: T.any(Wizard, T::Array[Wizard])).returns(T.self_type) }
-  def concat(*records); end
 end

--- a/spec/test_data/v5.2/expected_attachment.rbi
+++ b/spec/test_data/v5.2/expected_attachment.rbi
@@ -8,8 +8,6 @@ module ActiveStorage::Attachment::ActiveRelation_WhereNot
 end
 
 module ActiveStorage::Attachment::GeneratedAssociationMethods
-  extend T::Sig
-
   sig { returns(::ActiveStorage::Blob) }
   def blob; end
 
@@ -44,8 +42,6 @@ class ActiveStorage::Attachment < ActiveRecord::Base
   include ActiveStorage::Attachment::GeneratedAssociationMethods
   extend ActiveStorage::Attachment::CustomFinderMethods
   extend ActiveStorage::Attachment::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   RelationType = T.type_alias { T.any(ActiveStorage::Attachment::ActiveRecord_Relation, ActiveStorage::Attachment::ActiveRecord_Associations_CollectionProxy, ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
 end
 
@@ -231,8 +227,6 @@ class ActiveStorage::Attachment::ActiveRecord_Relation < ActiveRecord::Relation
   include ActiveStorage::Attachment::ActiveRelation_WhereNot
   include ActiveStorage::Attachment::CustomFinderMethods
   include ActiveStorage::Attachment::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: ActiveStorage::Attachment)
 end
 
@@ -240,16 +234,12 @@ class ActiveStorage::Attachment::ActiveRecord_AssociationRelation < ActiveRecord
   include ActiveStorage::Attachment::ActiveRelation_WhereNot
   include ActiveStorage::Attachment::CustomFinderMethods
   include ActiveStorage::Attachment::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: ActiveStorage::Attachment)
 end
 
 class ActiveStorage::Attachment::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include ActiveStorage::Attachment::CustomFinderMethods
   include ActiveStorage::Attachment::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: ActiveStorage::Attachment)
 
   sig { params(records: T.any(ActiveStorage::Attachment, T::Array[ActiveStorage::Attachment])).returns(T.self_type) }

--- a/spec/test_data/v5.2/expected_attachment.rbi
+++ b/spec/test_data/v5.2/expected_attachment.rbi
@@ -43,380 +43,214 @@ end
 class ActiveStorage::Attachment < ActiveRecord::Base
   include ActiveStorage::Attachment::GeneratedAssociationMethods
   extend ActiveStorage::Attachment::CustomFinderMethods
+  extend ActiveStorage::Attachment::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   RelationType = T.type_alias { T.any(ActiveStorage::Attachment::ActiveRecord_Relation, ActiveStorage::Attachment::ActiveRecord_Associations_CollectionProxy, ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+end
 
+module ActiveStorage::Attachment::QueryMethodsReturningRelation
   sig { returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def self.all; end
+  def all; end
 
   sig { params(block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def self.unscoped(&block); end
+  def unscoped(&block); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def self.select(*args); end
+  def select(*args); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def self.order(*args); end
+  def order(*args); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def self.reorder(*args); end
+  def reorder(*args); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def self.group(*args); end
+  def group(*args); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def self.limit(*args); end
+  def limit(*args); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def self.offset(*args); end
+  def offset(*args); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def self.joins(*args); end
+  def joins(*args); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def self.left_joins(*args); end
+  def left_joins(*args); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def self.left_outer_joins(*args); end
+  def left_outer_joins(*args); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def self.where(*args); end
+  def where(*args); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def self.rewhere(*args); end
+  def rewhere(*args); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def self.preload(*args); end
+  def preload(*args); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def self.eager_load(*args); end
+  def eager_load(*args); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def self.includes(*args); end
+  def includes(*args); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def self.from(*args); end
+  def from(*args); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def self.lock(*args); end
+  def lock(*args); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def self.readonly(*args); end
+  def readonly(*args); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def self.or(*args); end
+  def or(*args); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def self.having(*args); end
+  def having(*args); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def self.create_with(*args); end
+  def create_with(*args); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def self.distinct(*args); end
+  def distinct(*args); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def self.references(*args); end
+  def references(*args); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def self.none(*args); end
+  def none(*args); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def self.unscope(*args); end
+  def unscope(*args); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def self.merge(*args); end
+  def merge(*args); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def self.except(*args); end
+  def except(*args); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def self.extending(*args, &block); end
+  def extending(*args, &block); end
+end
+
+module ActiveStorage::Attachment::QueryMethodsReturningAssociationRelation
+  sig { returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def all; end
+
+  sig { params(block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
+  def unscoped(&block); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def select(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def order(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def reorder(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def group(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def limit(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def offset(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def joins(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def left_joins(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def left_outer_joins(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def where(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def rewhere(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def preload(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def eager_load(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def includes(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def from(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def lock(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def readonly(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def or(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def having(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def create_with(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def distinct(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def references(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def none(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def unscope(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def merge(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def extending(*args, &block); end
 end
 
 class ActiveStorage::Attachment::ActiveRecord_Relation < ActiveRecord::Relation
   include ActiveStorage::Attachment::ActiveRelation_WhereNot
   include ActiveStorage::Attachment::CustomFinderMethods
+  include ActiveStorage::Attachment::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: ActiveStorage::Attachment)
-
-  sig { returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def extending(*args, &block); end
 end
 
 class ActiveStorage::Attachment::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
   include ActiveStorage::Attachment::ActiveRelation_WhereNot
   include ActiveStorage::Attachment::CustomFinderMethods
+  include ActiveStorage::Attachment::QueryMethodsReturningAssociationRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: ActiveStorage::Attachment)
-
-  sig { returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
 end
 
 class ActiveStorage::Attachment::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include ActiveStorage::Attachment::CustomFinderMethods
+  include ActiveStorage::Attachment::QueryMethodsReturningAssociationRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: ActiveStorage::Attachment)
-
-  sig { returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
 
   sig { params(records: T.any(ActiveStorage::Attachment, T::Array[ActiveStorage::Attachment])).returns(T.self_type) }
   def <<(*records); end

--- a/spec/test_data/v5.2/expected_blob.rbi
+++ b/spec/test_data/v5.2/expected_blob.rbi
@@ -8,8 +8,6 @@ module ActiveStorage::Blob::ActiveRelation_WhereNot
 end
 
 module ActiveStorage::Blob::GeneratedAssociationMethods
-  extend T::Sig
-
   sig { returns(::ActiveStorage::Attachment::ActiveRecord_Associations_CollectionProxy) }
   def attachments; end
 
@@ -53,8 +51,6 @@ class ActiveStorage::Blob < ActiveRecord::Base
   include ActiveStorage::Blob::GeneratedAssociationMethods
   extend ActiveStorage::Blob::CustomFinderMethods
   extend ActiveStorage::Blob::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   RelationType = T.type_alias { T.any(ActiveStorage::Blob::ActiveRecord_Relation, ActiveStorage::Blob::ActiveRecord_Associations_CollectionProxy, ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
 
   sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
@@ -68,8 +64,6 @@ class ActiveStorage::Blob::ActiveRecord_Relation < ActiveRecord::Relation
   include ActiveStorage::Blob::ActiveRelation_WhereNot
   include ActiveStorage::Blob::CustomFinderMethods
   include ActiveStorage::Blob::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: ActiveStorage::Blob)
 
   sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
@@ -83,8 +77,6 @@ class ActiveStorage::Blob::ActiveRecord_AssociationRelation < ActiveRecord::Asso
   include ActiveStorage::Blob::ActiveRelation_WhereNot
   include ActiveStorage::Blob::CustomFinderMethods
   include ActiveStorage::Blob::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: ActiveStorage::Blob)
 
   sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
@@ -97,8 +89,6 @@ end
 class ActiveStorage::Blob::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include ActiveStorage::Blob::CustomFinderMethods
   include ActiveStorage::Blob::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: ActiveStorage::Blob)
 
   sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }

--- a/spec/test_data/v5.2/expected_blob.rbi
+++ b/spec/test_data/v5.2/expected_blob.rbi
@@ -52,6 +52,7 @@ end
 class ActiveStorage::Blob < ActiveRecord::Base
   include ActiveStorage::Blob::GeneratedAssociationMethods
   extend ActiveStorage::Blob::CustomFinderMethods
+  extend ActiveStorage::Blob::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   RelationType = T.type_alias { T.any(ActiveStorage::Blob::ActiveRecord_Relation, ActiveStorage::Blob::ActiveRecord_Associations_CollectionProxy, ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
@@ -61,98 +62,12 @@ class ActiveStorage::Blob < ActiveRecord::Base
 
   sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
   def self.with_attached_preview_image(*args); end
-
-  sig { returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def self.all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def self.unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def self.select(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def self.order(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def self.reorder(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def self.group(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def self.limit(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def self.offset(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def self.joins(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def self.left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def self.left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def self.where(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def self.rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def self.preload(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def self.eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def self.includes(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def self.from(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def self.lock(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def self.readonly(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def self.or(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def self.having(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def self.create_with(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def self.distinct(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def self.references(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def self.none(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def self.unscope(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def self.merge(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def self.except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def self.extending(*args, &block); end
 end
 
 class ActiveStorage::Blob::ActiveRecord_Relation < ActiveRecord::Relation
   include ActiveStorage::Blob::ActiveRelation_WhereNot
   include ActiveStorage::Blob::CustomFinderMethods
+  include ActiveStorage::Blob::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: ActiveStorage::Blob)
@@ -162,98 +77,12 @@ class ActiveStorage::Blob::ActiveRecord_Relation < ActiveRecord::Relation
 
   sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
   def with_attached_preview_image(*args); end
-
-  sig { returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def extending(*args, &block); end
 end
 
 class ActiveStorage::Blob::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
   include ActiveStorage::Blob::ActiveRelation_WhereNot
   include ActiveStorage::Blob::CustomFinderMethods
+  include ActiveStorage::Blob::QueryMethodsReturningAssociationRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: ActiveStorage::Blob)
@@ -263,97 +92,11 @@ class ActiveStorage::Blob::ActiveRecord_AssociationRelation < ActiveRecord::Asso
 
   sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
   def with_attached_preview_image(*args); end
-
-  sig { returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
 end
 
 class ActiveStorage::Blob::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include ActiveStorage::Blob::CustomFinderMethods
+  include ActiveStorage::Blob::QueryMethodsReturningAssociationRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: ActiveStorage::Blob)
@@ -363,93 +106,6 @@ class ActiveStorage::Blob::ActiveRecord_Associations_CollectionProxy < ActiveRec
 
   sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
   def with_attached_preview_image(*args); end
-
-  sig { returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
 
   sig { params(records: T.any(ActiveStorage::Blob, T::Array[ActiveStorage::Blob])).returns(T.self_type) }
   def <<(*records); end
@@ -462,4 +118,182 @@ class ActiveStorage::Blob::ActiveRecord_Associations_CollectionProxy < ActiveRec
 
   sig { params(records: T.any(ActiveStorage::Blob, T::Array[ActiveStorage::Blob])).returns(T.self_type) }
   def concat(*records); end
+end
+
+module ActiveStorage::Blob::QueryMethodsReturningRelation
+  sig { returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def all; end
+
+  sig { params(block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def unscoped(&block); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def select(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def order(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def reorder(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def group(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def limit(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def offset(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def joins(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def left_joins(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def left_outer_joins(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def where(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def rewhere(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def preload(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def eager_load(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def includes(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def from(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def lock(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def readonly(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def or(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def having(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def create_with(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def distinct(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def references(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def none(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def unscope(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def merge(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def extending(*args, &block); end
+end
+
+module ActiveStorage::Blob::QueryMethodsReturningAssociationRelation
+  sig { returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def all; end
+
+  sig { params(block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def unscoped(&block); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def select(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def order(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def reorder(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def group(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def limit(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def offset(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def joins(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def left_joins(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def left_outer_joins(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def where(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def rewhere(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def preload(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def eager_load(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def includes(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def from(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def lock(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def readonly(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def or(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def having(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def create_with(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def distinct(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def references(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def none(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def unscope(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def merge(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def extending(*args, &block); end
 end

--- a/spec/test_data/v5.2/expected_headmaster.rbi
+++ b/spec/test_data/v5.2/expected_headmaster.rbi
@@ -8,8 +8,6 @@ module Headmaster::ActiveRelation_WhereNot
 end
 
 module Headmaster::GeneratedAttributeMethods
-  extend T::Sig
-
   sig { returns(Integer) }
   def id; end
 
@@ -39,8 +37,6 @@ module Headmaster::GeneratedAttributeMethods
 end
 
 module Headmaster::GeneratedAssociationMethods
-  extend T::Sig
-
   sig { returns(::School) }
   def school; end
 
@@ -76,8 +72,6 @@ class Headmaster < ApplicationRecord
   include Headmaster::GeneratedAssociationMethods
   extend Headmaster::CustomFinderMethods
   extend Headmaster::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   RelationType = T.type_alias { T.any(Headmaster::ActiveRecord_Relation, Headmaster::ActiveRecord_Associations_CollectionProxy, Headmaster::ActiveRecord_AssociationRelation) }
 end
 
@@ -263,8 +257,6 @@ class Headmaster::ActiveRecord_Relation < ActiveRecord::Relation
   include Headmaster::ActiveRelation_WhereNot
   include Headmaster::CustomFinderMethods
   include Headmaster::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Headmaster)
 end
 
@@ -272,16 +264,12 @@ class Headmaster::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRe
   include Headmaster::ActiveRelation_WhereNot
   include Headmaster::CustomFinderMethods
   include Headmaster::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Headmaster)
 end
 
 class Headmaster::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include Headmaster::CustomFinderMethods
   include Headmaster::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Headmaster)
 
   sig { params(records: T.any(Headmaster, T::Array[Headmaster])).returns(T.self_type) }

--- a/spec/test_data/v5.2/expected_headmaster.rbi
+++ b/spec/test_data/v5.2/expected_headmaster.rbi
@@ -75,380 +75,214 @@ class Headmaster < ApplicationRecord
   include Headmaster::GeneratedAttributeMethods
   include Headmaster::GeneratedAssociationMethods
   extend Headmaster::CustomFinderMethods
+  extend Headmaster::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   RelationType = T.type_alias { T.any(Headmaster::ActiveRecord_Relation, Headmaster::ActiveRecord_Associations_CollectionProxy, Headmaster::ActiveRecord_AssociationRelation) }
+end
 
+module Headmaster::QueryMethodsReturningRelation
   sig { returns(Headmaster::ActiveRecord_Relation) }
-  def self.all; end
+  def all; end
 
   sig { params(block: T.nilable(T.proc.void)).returns(Headmaster::ActiveRecord_Relation) }
-  def self.unscoped(&block); end
+  def unscoped(&block); end
 
   sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def self.select(*args); end
+  def select(*args); end
 
   sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def self.order(*args); end
+  def order(*args); end
 
   sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def self.reorder(*args); end
+  def reorder(*args); end
 
   sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def self.group(*args); end
+  def group(*args); end
 
   sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def self.limit(*args); end
+  def limit(*args); end
 
   sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def self.offset(*args); end
+  def offset(*args); end
 
   sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def self.joins(*args); end
+  def joins(*args); end
 
   sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def self.left_joins(*args); end
+  def left_joins(*args); end
 
   sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def self.left_outer_joins(*args); end
+  def left_outer_joins(*args); end
 
   sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def self.where(*args); end
+  def where(*args); end
 
   sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def self.rewhere(*args); end
+  def rewhere(*args); end
 
   sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def self.preload(*args); end
+  def preload(*args); end
 
   sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def self.eager_load(*args); end
+  def eager_load(*args); end
 
   sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def self.includes(*args); end
+  def includes(*args); end
 
   sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def self.from(*args); end
+  def from(*args); end
 
   sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def self.lock(*args); end
+  def lock(*args); end
 
   sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def self.readonly(*args); end
+  def readonly(*args); end
 
   sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def self.or(*args); end
+  def or(*args); end
 
   sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def self.having(*args); end
+  def having(*args); end
 
   sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def self.create_with(*args); end
+  def create_with(*args); end
 
   sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def self.distinct(*args); end
+  def distinct(*args); end
 
   sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def self.references(*args); end
+  def references(*args); end
 
   sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def self.none(*args); end
+  def none(*args); end
 
   sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def self.unscope(*args); end
+  def unscope(*args); end
 
   sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def self.merge(*args); end
+  def merge(*args); end
 
   sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def self.except(*args); end
+  def except(*args); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Headmaster::ActiveRecord_Relation) }
-  def self.extending(*args, &block); end
+  def extending(*args, &block); end
+end
+
+module Headmaster::QueryMethodsReturningAssociationRelation
+  sig { returns(Headmaster::ActiveRecord_AssociationRelation) }
+  def all; end
+
+  sig { params(block: T.nilable(T.proc.void)).returns(Headmaster::ActiveRecord_Relation) }
+  def unscoped(&block); end
+
+  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
+  def select(*args); end
+
+  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
+  def order(*args); end
+
+  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
+  def reorder(*args); end
+
+  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
+  def group(*args); end
+
+  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
+  def limit(*args); end
+
+  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
+  def offset(*args); end
+
+  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
+  def joins(*args); end
+
+  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
+  def left_joins(*args); end
+
+  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
+  def left_outer_joins(*args); end
+
+  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
+  def where(*args); end
+
+  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
+  def rewhere(*args); end
+
+  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
+  def preload(*args); end
+
+  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
+  def eager_load(*args); end
+
+  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
+  def includes(*args); end
+
+  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
+  def from(*args); end
+
+  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
+  def lock(*args); end
+
+  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
+  def readonly(*args); end
+
+  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
+  def or(*args); end
+
+  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
+  def having(*args); end
+
+  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
+  def create_with(*args); end
+
+  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
+  def distinct(*args); end
+
+  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
+  def references(*args); end
+
+  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
+  def none(*args); end
+
+  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
+  def unscope(*args); end
+
+  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
+  def merge(*args); end
+
+  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
+  def except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Headmaster::ActiveRecord_AssociationRelation) }
+  def extending(*args, &block); end
 end
 
 class Headmaster::ActiveRecord_Relation < ActiveRecord::Relation
   include Headmaster::ActiveRelation_WhereNot
   include Headmaster::CustomFinderMethods
+  include Headmaster::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: Headmaster)
-
-  sig { returns(Headmaster::ActiveRecord_Relation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Headmaster::ActiveRecord_Relation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Headmaster::ActiveRecord_Relation) }
-  def extending(*args, &block); end
 end
 
 class Headmaster::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
   include Headmaster::ActiveRelation_WhereNot
   include Headmaster::CustomFinderMethods
+  include Headmaster::QueryMethodsReturningAssociationRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: Headmaster)
-
-  sig { returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
 end
 
 class Headmaster::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include Headmaster::CustomFinderMethods
+  include Headmaster::QueryMethodsReturningAssociationRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: Headmaster)
-
-  sig { returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
 
   sig { params(records: T.any(Headmaster, T::Array[Headmaster])).returns(T.self_type) }
   def <<(*records); end

--- a/spec/test_data/v5.2/expected_internal_metadata.rbi
+++ b/spec/test_data/v5.2/expected_internal_metadata.rbi
@@ -8,8 +8,6 @@ module ActiveRecord::InternalMetadata::ActiveRelation_WhereNot
 end
 
 module ActiveRecord::InternalMetadata::GeneratedAttributeMethods
-  extend T::Sig
-
   sig { returns(ActiveSupport::TimeWithZone) }
   def created_at; end
 
@@ -68,8 +66,6 @@ class ActiveRecord::InternalMetadata < ActiveRecord::Base
   include ActiveRecord::InternalMetadata::GeneratedAttributeMethods
   extend ActiveRecord::InternalMetadata::CustomFinderMethods
   extend ActiveRecord::InternalMetadata::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   RelationType = T.type_alias { T.any(ActiveRecord::InternalMetadata::ActiveRecord_Relation, ActiveRecord::InternalMetadata::ActiveRecord_Associations_CollectionProxy, ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
 end
 
@@ -255,8 +251,6 @@ class ActiveRecord::InternalMetadata::ActiveRecord_Relation < ActiveRecord::Rela
   include ActiveRecord::InternalMetadata::ActiveRelation_WhereNot
   include ActiveRecord::InternalMetadata::CustomFinderMethods
   include ActiveRecord::InternalMetadata::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: ActiveRecord::InternalMetadata)
 end
 
@@ -264,16 +258,12 @@ class ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation < ActiveR
   include ActiveRecord::InternalMetadata::ActiveRelation_WhereNot
   include ActiveRecord::InternalMetadata::CustomFinderMethods
   include ActiveRecord::InternalMetadata::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: ActiveRecord::InternalMetadata)
 end
 
 class ActiveRecord::InternalMetadata::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include ActiveRecord::InternalMetadata::CustomFinderMethods
   include ActiveRecord::InternalMetadata::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: ActiveRecord::InternalMetadata)
 
   sig { params(records: T.any(ActiveRecord::InternalMetadata, T::Array[ActiveRecord::InternalMetadata])).returns(T.self_type) }

--- a/spec/test_data/v5.2/expected_internal_metadata.rbi
+++ b/spec/test_data/v5.2/expected_internal_metadata.rbi
@@ -67,380 +67,214 @@ end
 class ActiveRecord::InternalMetadata < ActiveRecord::Base
   include ActiveRecord::InternalMetadata::GeneratedAttributeMethods
   extend ActiveRecord::InternalMetadata::CustomFinderMethods
+  extend ActiveRecord::InternalMetadata::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   RelationType = T.type_alias { T.any(ActiveRecord::InternalMetadata::ActiveRecord_Relation, ActiveRecord::InternalMetadata::ActiveRecord_Associations_CollectionProxy, ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+end
 
+module ActiveRecord::InternalMetadata::QueryMethodsReturningRelation
   sig { returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.all; end
+  def all; end
 
   sig { params(block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.unscoped(&block); end
+  def unscoped(&block); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.select(*args); end
+  def select(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.order(*args); end
+  def order(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.reorder(*args); end
+  def reorder(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.group(*args); end
+  def group(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.limit(*args); end
+  def limit(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.offset(*args); end
+  def offset(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.joins(*args); end
+  def joins(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.left_joins(*args); end
+  def left_joins(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.left_outer_joins(*args); end
+  def left_outer_joins(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.where(*args); end
+  def where(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.rewhere(*args); end
+  def rewhere(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.preload(*args); end
+  def preload(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.eager_load(*args); end
+  def eager_load(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.includes(*args); end
+  def includes(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.from(*args); end
+  def from(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.lock(*args); end
+  def lock(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.readonly(*args); end
+  def readonly(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.or(*args); end
+  def or(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.having(*args); end
+  def having(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.create_with(*args); end
+  def create_with(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.distinct(*args); end
+  def distinct(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.references(*args); end
+  def references(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.none(*args); end
+  def none(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.unscope(*args); end
+  def unscope(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.merge(*args); end
+  def merge(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.except(*args); end
+  def except(*args); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.extending(*args, &block); end
+  def extending(*args, &block); end
+end
+
+module ActiveRecord::InternalMetadata::QueryMethodsReturningAssociationRelation
+  sig { returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def all; end
+
+  sig { params(block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def unscoped(&block); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def select(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def order(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def reorder(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def group(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def limit(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def offset(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def joins(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def left_joins(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def left_outer_joins(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def where(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def rewhere(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def preload(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def eager_load(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def includes(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def from(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def lock(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def readonly(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def or(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def having(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def create_with(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def distinct(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def references(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def none(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def unscope(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def merge(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def extending(*args, &block); end
 end
 
 class ActiveRecord::InternalMetadata::ActiveRecord_Relation < ActiveRecord::Relation
   include ActiveRecord::InternalMetadata::ActiveRelation_WhereNot
   include ActiveRecord::InternalMetadata::CustomFinderMethods
+  include ActiveRecord::InternalMetadata::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: ActiveRecord::InternalMetadata)
-
-  sig { returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def extending(*args, &block); end
 end
 
 class ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
   include ActiveRecord::InternalMetadata::ActiveRelation_WhereNot
   include ActiveRecord::InternalMetadata::CustomFinderMethods
+  include ActiveRecord::InternalMetadata::QueryMethodsReturningAssociationRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: ActiveRecord::InternalMetadata)
-
-  sig { returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
 end
 
 class ActiveRecord::InternalMetadata::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include ActiveRecord::InternalMetadata::CustomFinderMethods
+  include ActiveRecord::InternalMetadata::QueryMethodsReturningAssociationRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: ActiveRecord::InternalMetadata)
-
-  sig { returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
 
   sig { params(records: T.any(ActiveRecord::InternalMetadata, T::Array[ActiveRecord::InternalMetadata])).returns(T.self_type) }
   def <<(*records); end

--- a/spec/test_data/v5.2/expected_potion.rbi
+++ b/spec/test_data/v5.2/expected_potion.rbi
@@ -8,8 +8,6 @@ module Potion::ActiveRelation_WhereNot
 end
 
 module Potion::GeneratedAssociationMethods
-  extend T::Sig
-
   sig { returns(T.nilable(::Wizard)) }
   def wizard; end
 
@@ -38,8 +36,6 @@ class Potion < ApplicationRecord
   include Potion::GeneratedAssociationMethods
   extend Potion::CustomFinderMethods
   extend Potion::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   RelationType = T.type_alias { T.any(Potion::ActiveRecord_Relation, Potion::ActiveRecord_Associations_CollectionProxy, Potion::ActiveRecord_AssociationRelation) }
 end
 
@@ -225,8 +221,6 @@ class Potion::ActiveRecord_Relation < ActiveRecord::Relation
   include Potion::ActiveRelation_WhereNot
   include Potion::CustomFinderMethods
   include Potion::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Potion)
 end
 
@@ -234,16 +228,12 @@ class Potion::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelati
   include Potion::ActiveRelation_WhereNot
   include Potion::CustomFinderMethods
   include Potion::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Potion)
 end
 
 class Potion::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include Potion::CustomFinderMethods
   include Potion::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Potion)
 
   sig { params(records: T.any(Potion, T::Array[Potion])).returns(T.self_type) }

--- a/spec/test_data/v5.2/expected_potion.rbi
+++ b/spec/test_data/v5.2/expected_potion.rbi
@@ -37,380 +37,214 @@ end
 class Potion < ApplicationRecord
   include Potion::GeneratedAssociationMethods
   extend Potion::CustomFinderMethods
+  extend Potion::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   RelationType = T.type_alias { T.any(Potion::ActiveRecord_Relation, Potion::ActiveRecord_Associations_CollectionProxy, Potion::ActiveRecord_AssociationRelation) }
+end
 
+module Potion::QueryMethodsReturningRelation
   sig { returns(Potion::ActiveRecord_Relation) }
-  def self.all; end
+  def all; end
 
   sig { params(block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def self.unscoped(&block); end
+  def unscoped(&block); end
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def self.select(*args); end
+  def select(*args); end
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def self.order(*args); end
+  def order(*args); end
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def self.reorder(*args); end
+  def reorder(*args); end
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def self.group(*args); end
+  def group(*args); end
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def self.limit(*args); end
+  def limit(*args); end
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def self.offset(*args); end
+  def offset(*args); end
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def self.joins(*args); end
+  def joins(*args); end
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def self.left_joins(*args); end
+  def left_joins(*args); end
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def self.left_outer_joins(*args); end
+  def left_outer_joins(*args); end
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def self.where(*args); end
+  def where(*args); end
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def self.rewhere(*args); end
+  def rewhere(*args); end
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def self.preload(*args); end
+  def preload(*args); end
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def self.eager_load(*args); end
+  def eager_load(*args); end
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def self.includes(*args); end
+  def includes(*args); end
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def self.from(*args); end
+  def from(*args); end
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def self.lock(*args); end
+  def lock(*args); end
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def self.readonly(*args); end
+  def readonly(*args); end
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def self.or(*args); end
+  def or(*args); end
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def self.having(*args); end
+  def having(*args); end
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def self.create_with(*args); end
+  def create_with(*args); end
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def self.distinct(*args); end
+  def distinct(*args); end
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def self.references(*args); end
+  def references(*args); end
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def self.none(*args); end
+  def none(*args); end
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def self.unscope(*args); end
+  def unscope(*args); end
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def self.merge(*args); end
+  def merge(*args); end
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def self.except(*args); end
+  def except(*args); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def self.extending(*args, &block); end
+  def extending(*args, &block); end
+end
+
+module Potion::QueryMethodsReturningAssociationRelation
+  sig { returns(Potion::ActiveRecord_AssociationRelation) }
+  def all; end
+
+  sig { params(block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
+  def unscoped(&block); end
+
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def select(*args); end
+
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def order(*args); end
+
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def reorder(*args); end
+
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def group(*args); end
+
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def limit(*args); end
+
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def offset(*args); end
+
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def joins(*args); end
+
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def left_joins(*args); end
+
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def left_outer_joins(*args); end
+
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def where(*args); end
+
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def rewhere(*args); end
+
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def preload(*args); end
+
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def eager_load(*args); end
+
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def includes(*args); end
+
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def from(*args); end
+
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def lock(*args); end
+
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def readonly(*args); end
+
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def or(*args); end
+
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def having(*args); end
+
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def create_with(*args); end
+
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def distinct(*args); end
+
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def references(*args); end
+
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def none(*args); end
+
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def unscope(*args); end
+
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def merge(*args); end
+
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
+  def extending(*args, &block); end
 end
 
 class Potion::ActiveRecord_Relation < ActiveRecord::Relation
   include Potion::ActiveRelation_WhereNot
   include Potion::CustomFinderMethods
+  include Potion::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: Potion)
-
-  sig { returns(Potion::ActiveRecord_Relation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def extending(*args, &block); end
 end
 
 class Potion::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
   include Potion::ActiveRelation_WhereNot
   include Potion::CustomFinderMethods
+  include Potion::QueryMethodsReturningAssociationRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: Potion)
-
-  sig { returns(Potion::ActiveRecord_AssociationRelation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
 end
 
 class Potion::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include Potion::CustomFinderMethods
+  include Potion::QueryMethodsReturningAssociationRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: Potion)
-
-  sig { returns(Potion::ActiveRecord_AssociationRelation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
 
   sig { params(records: T.any(Potion, T::Array[Potion])).returns(T.self_type) }
   def <<(*records); end

--- a/spec/test_data/v5.2/expected_robe.rbi
+++ b/spec/test_data/v5.2/expected_robe.rbi
@@ -60,380 +60,214 @@ class Robe < ApplicationRecord
   include Robe::GeneratedAttributeMethods
   include Robe::GeneratedAssociationMethods
   extend Robe::CustomFinderMethods
+  extend Robe::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   RelationType = T.type_alias { T.any(Robe::ActiveRecord_Relation, Robe::ActiveRecord_Associations_CollectionProxy, Robe::ActiveRecord_AssociationRelation) }
+end
 
+module Robe::QueryMethodsReturningRelation
   sig { returns(Robe::ActiveRecord_Relation) }
-  def self.all; end
+  def all; end
 
   sig { params(block: T.nilable(T.proc.void)).returns(Robe::ActiveRecord_Relation) }
-  def self.unscoped(&block); end
+  def unscoped(&block); end
 
   sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def self.select(*args); end
+  def select(*args); end
 
   sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def self.order(*args); end
+  def order(*args); end
 
   sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def self.reorder(*args); end
+  def reorder(*args); end
 
   sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def self.group(*args); end
+  def group(*args); end
 
   sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def self.limit(*args); end
+  def limit(*args); end
 
   sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def self.offset(*args); end
+  def offset(*args); end
 
   sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def self.joins(*args); end
+  def joins(*args); end
 
   sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def self.left_joins(*args); end
+  def left_joins(*args); end
 
   sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def self.left_outer_joins(*args); end
+  def left_outer_joins(*args); end
 
   sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def self.where(*args); end
+  def where(*args); end
 
   sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def self.rewhere(*args); end
+  def rewhere(*args); end
 
   sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def self.preload(*args); end
+  def preload(*args); end
 
   sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def self.eager_load(*args); end
+  def eager_load(*args); end
 
   sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def self.includes(*args); end
+  def includes(*args); end
 
   sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def self.from(*args); end
+  def from(*args); end
 
   sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def self.lock(*args); end
+  def lock(*args); end
 
   sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def self.readonly(*args); end
+  def readonly(*args); end
 
   sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def self.or(*args); end
+  def or(*args); end
 
   sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def self.having(*args); end
+  def having(*args); end
 
   sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def self.create_with(*args); end
+  def create_with(*args); end
 
   sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def self.distinct(*args); end
+  def distinct(*args); end
 
   sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def self.references(*args); end
+  def references(*args); end
 
   sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def self.none(*args); end
+  def none(*args); end
 
   sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def self.unscope(*args); end
+  def unscope(*args); end
 
   sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def self.merge(*args); end
+  def merge(*args); end
 
   sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def self.except(*args); end
+  def except(*args); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Robe::ActiveRecord_Relation) }
-  def self.extending(*args, &block); end
+  def extending(*args, &block); end
+end
+
+module Robe::QueryMethodsReturningAssociationRelation
+  sig { returns(Robe::ActiveRecord_AssociationRelation) }
+  def all; end
+
+  sig { params(block: T.nilable(T.proc.void)).returns(Robe::ActiveRecord_Relation) }
+  def unscoped(&block); end
+
+  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
+  def select(*args); end
+
+  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
+  def order(*args); end
+
+  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
+  def reorder(*args); end
+
+  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
+  def group(*args); end
+
+  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
+  def limit(*args); end
+
+  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
+  def offset(*args); end
+
+  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
+  def joins(*args); end
+
+  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
+  def left_joins(*args); end
+
+  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
+  def left_outer_joins(*args); end
+
+  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
+  def where(*args); end
+
+  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
+  def rewhere(*args); end
+
+  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
+  def preload(*args); end
+
+  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
+  def eager_load(*args); end
+
+  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
+  def includes(*args); end
+
+  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
+  def from(*args); end
+
+  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
+  def lock(*args); end
+
+  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
+  def readonly(*args); end
+
+  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
+  def or(*args); end
+
+  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
+  def having(*args); end
+
+  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
+  def create_with(*args); end
+
+  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
+  def distinct(*args); end
+
+  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
+  def references(*args); end
+
+  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
+  def none(*args); end
+
+  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
+  def unscope(*args); end
+
+  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
+  def merge(*args); end
+
+  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
+  def except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Robe::ActiveRecord_AssociationRelation) }
+  def extending(*args, &block); end
 end
 
 class Robe::ActiveRecord_Relation < ActiveRecord::Relation
   include Robe::ActiveRelation_WhereNot
   include Robe::CustomFinderMethods
+  include Robe::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: Robe)
-
-  sig { returns(Robe::ActiveRecord_Relation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Robe::ActiveRecord_Relation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Robe::ActiveRecord_Relation) }
-  def extending(*args, &block); end
 end
 
 class Robe::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
   include Robe::ActiveRelation_WhereNot
   include Robe::CustomFinderMethods
+  include Robe::QueryMethodsReturningAssociationRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: Robe)
-
-  sig { returns(Robe::ActiveRecord_AssociationRelation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Robe::ActiveRecord_AssociationRelation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Robe::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
 end
 
 class Robe::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include Robe::CustomFinderMethods
+  include Robe::QueryMethodsReturningAssociationRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: Robe)
-
-  sig { returns(Robe::ActiveRecord_AssociationRelation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Robe::ActiveRecord_AssociationRelation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Robe::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
 
   sig { params(records: T.any(Robe, T::Array[Robe])).returns(T.self_type) }
   def <<(*records); end

--- a/spec/test_data/v5.2/expected_robe.rbi
+++ b/spec/test_data/v5.2/expected_robe.rbi
@@ -8,8 +8,6 @@ module Robe::ActiveRelation_WhereNot
 end
 
 module Robe::GeneratedAttributeMethods
-  extend T::Sig
-
   sig { returns(Integer) }
   def id; end
 
@@ -30,8 +28,6 @@ module Robe::GeneratedAttributeMethods
 end
 
 module Robe::GeneratedAssociationMethods
-  extend T::Sig
-
   sig { returns(T.nilable(::Wizard)) }
   def wizard; end
 
@@ -61,8 +57,6 @@ class Robe < ApplicationRecord
   include Robe::GeneratedAssociationMethods
   extend Robe::CustomFinderMethods
   extend Robe::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   RelationType = T.type_alias { T.any(Robe::ActiveRecord_Relation, Robe::ActiveRecord_Associations_CollectionProxy, Robe::ActiveRecord_AssociationRelation) }
 end
 
@@ -248,8 +242,6 @@ class Robe::ActiveRecord_Relation < ActiveRecord::Relation
   include Robe::ActiveRelation_WhereNot
   include Robe::CustomFinderMethods
   include Robe::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Robe)
 end
 
@@ -257,16 +249,12 @@ class Robe::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
   include Robe::ActiveRelation_WhereNot
   include Robe::CustomFinderMethods
   include Robe::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Robe)
 end
 
 class Robe::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include Robe::CustomFinderMethods
   include Robe::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Robe)
 
   sig { params(records: T.any(Robe, T::Array[Robe])).returns(T.self_type) }

--- a/spec/test_data/v5.2/expected_schema_migration.rbi
+++ b/spec/test_data/v5.2/expected_schema_migration.rbi
@@ -40,380 +40,214 @@ end
 class ActiveRecord::SchemaMigration < ActiveRecord::Base
   include ActiveRecord::SchemaMigration::GeneratedAttributeMethods
   extend ActiveRecord::SchemaMigration::CustomFinderMethods
+  extend ActiveRecord::SchemaMigration::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   RelationType = T.type_alias { T.any(ActiveRecord::SchemaMigration::ActiveRecord_Relation, ActiveRecord::SchemaMigration::ActiveRecord_Associations_CollectionProxy, ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+end
 
+module ActiveRecord::SchemaMigration::QueryMethodsReturningRelation
   sig { returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.all; end
+  def all; end
 
   sig { params(block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.unscoped(&block); end
+  def unscoped(&block); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.select(*args); end
+  def select(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.order(*args); end
+  def order(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.reorder(*args); end
+  def reorder(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.group(*args); end
+  def group(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.limit(*args); end
+  def limit(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.offset(*args); end
+  def offset(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.joins(*args); end
+  def joins(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.left_joins(*args); end
+  def left_joins(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.left_outer_joins(*args); end
+  def left_outer_joins(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.where(*args); end
+  def where(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.rewhere(*args); end
+  def rewhere(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.preload(*args); end
+  def preload(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.eager_load(*args); end
+  def eager_load(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.includes(*args); end
+  def includes(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.from(*args); end
+  def from(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.lock(*args); end
+  def lock(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.readonly(*args); end
+  def readonly(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.or(*args); end
+  def or(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.having(*args); end
+  def having(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.create_with(*args); end
+  def create_with(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.distinct(*args); end
+  def distinct(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.references(*args); end
+  def references(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.none(*args); end
+  def none(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.unscope(*args); end
+  def unscope(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.merge(*args); end
+  def merge(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.except(*args); end
+  def except(*args); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.extending(*args, &block); end
+  def extending(*args, &block); end
+end
+
+module ActiveRecord::SchemaMigration::QueryMethodsReturningAssociationRelation
+  sig { returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def all; end
+
+  sig { params(block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def unscoped(&block); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def select(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def order(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def reorder(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def group(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def limit(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def offset(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def joins(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def left_joins(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def left_outer_joins(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def where(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def rewhere(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def preload(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def eager_load(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def includes(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def from(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def lock(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def readonly(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def or(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def having(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def create_with(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def distinct(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def references(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def none(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def unscope(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def merge(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def extending(*args, &block); end
 end
 
 class ActiveRecord::SchemaMigration::ActiveRecord_Relation < ActiveRecord::Relation
   include ActiveRecord::SchemaMigration::ActiveRelation_WhereNot
   include ActiveRecord::SchemaMigration::CustomFinderMethods
+  include ActiveRecord::SchemaMigration::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: ActiveRecord::SchemaMigration)
-
-  sig { returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def extending(*args, &block); end
 end
 
 class ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
   include ActiveRecord::SchemaMigration::ActiveRelation_WhereNot
   include ActiveRecord::SchemaMigration::CustomFinderMethods
+  include ActiveRecord::SchemaMigration::QueryMethodsReturningAssociationRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: ActiveRecord::SchemaMigration)
-
-  sig { returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
 end
 
 class ActiveRecord::SchemaMigration::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include ActiveRecord::SchemaMigration::CustomFinderMethods
+  include ActiveRecord::SchemaMigration::QueryMethodsReturningAssociationRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: ActiveRecord::SchemaMigration)
-
-  sig { returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
 
   sig { params(records: T.any(ActiveRecord::SchemaMigration, T::Array[ActiveRecord::SchemaMigration])).returns(T.self_type) }
   def <<(*records); end

--- a/spec/test_data/v5.2/expected_schema_migration.rbi
+++ b/spec/test_data/v5.2/expected_schema_migration.rbi
@@ -8,8 +8,6 @@ module ActiveRecord::SchemaMigration::ActiveRelation_WhereNot
 end
 
 module ActiveRecord::SchemaMigration::GeneratedAttributeMethods
-  extend T::Sig
-
   sig { returns(String) }
   def version; end
 
@@ -41,8 +39,6 @@ class ActiveRecord::SchemaMigration < ActiveRecord::Base
   include ActiveRecord::SchemaMigration::GeneratedAttributeMethods
   extend ActiveRecord::SchemaMigration::CustomFinderMethods
   extend ActiveRecord::SchemaMigration::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   RelationType = T.type_alias { T.any(ActiveRecord::SchemaMigration::ActiveRecord_Relation, ActiveRecord::SchemaMigration::ActiveRecord_Associations_CollectionProxy, ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
 end
 
@@ -228,8 +224,6 @@ class ActiveRecord::SchemaMigration::ActiveRecord_Relation < ActiveRecord::Relat
   include ActiveRecord::SchemaMigration::ActiveRelation_WhereNot
   include ActiveRecord::SchemaMigration::CustomFinderMethods
   include ActiveRecord::SchemaMigration::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: ActiveRecord::SchemaMigration)
 end
 
@@ -237,16 +231,12 @@ class ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation < ActiveRe
   include ActiveRecord::SchemaMigration::ActiveRelation_WhereNot
   include ActiveRecord::SchemaMigration::CustomFinderMethods
   include ActiveRecord::SchemaMigration::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: ActiveRecord::SchemaMigration)
 end
 
 class ActiveRecord::SchemaMigration::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include ActiveRecord::SchemaMigration::CustomFinderMethods
   include ActiveRecord::SchemaMigration::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: ActiveRecord::SchemaMigration)
 
   sig { params(records: T.any(ActiveRecord::SchemaMigration, T::Array[ActiveRecord::SchemaMigration])).returns(T.self_type) }

--- a/spec/test_data/v5.2/expected_school.rbi
+++ b/spec/test_data/v5.2/expected_school.rbi
@@ -8,8 +8,6 @@ module School::ActiveRelation_WhereNot
 end
 
 module School::GeneratedAttributeMethods
-  extend T::Sig
-
   sig { returns(Integer) }
   def id; end
 
@@ -30,8 +28,6 @@ module School::GeneratedAttributeMethods
 end
 
 module School::GeneratedAssociationMethods
-  extend T::Sig
-
   sig { returns(::Headmaster) }
   def headmaster; end
 
@@ -61,8 +57,6 @@ class School < ApplicationRecord
   include School::GeneratedAssociationMethods
   extend School::CustomFinderMethods
   extend School::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   RelationType = T.type_alias { T.any(School::ActiveRecord_Relation, School::ActiveRecord_Associations_CollectionProxy, School::ActiveRecord_AssociationRelation) }
 end
 
@@ -248,8 +242,6 @@ class School::ActiveRecord_Relation < ActiveRecord::Relation
   include School::ActiveRelation_WhereNot
   include School::CustomFinderMethods
   include School::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: School)
 end
 
@@ -257,16 +249,12 @@ class School::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelati
   include School::ActiveRelation_WhereNot
   include School::CustomFinderMethods
   include School::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: School)
 end
 
 class School::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include School::CustomFinderMethods
   include School::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: School)
 
   sig { params(records: T.any(School, T::Array[School])).returns(T.self_type) }

--- a/spec/test_data/v5.2/expected_school.rbi
+++ b/spec/test_data/v5.2/expected_school.rbi
@@ -60,380 +60,214 @@ class School < ApplicationRecord
   include School::GeneratedAttributeMethods
   include School::GeneratedAssociationMethods
   extend School::CustomFinderMethods
+  extend School::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   RelationType = T.type_alias { T.any(School::ActiveRecord_Relation, School::ActiveRecord_Associations_CollectionProxy, School::ActiveRecord_AssociationRelation) }
+end
 
+module School::QueryMethodsReturningRelation
   sig { returns(School::ActiveRecord_Relation) }
-  def self.all; end
+  def all; end
 
   sig { params(block: T.nilable(T.proc.void)).returns(School::ActiveRecord_Relation) }
-  def self.unscoped(&block); end
+  def unscoped(&block); end
 
   sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def self.select(*args); end
+  def select(*args); end
 
   sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def self.order(*args); end
+  def order(*args); end
 
   sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def self.reorder(*args); end
+  def reorder(*args); end
 
   sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def self.group(*args); end
+  def group(*args); end
 
   sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def self.limit(*args); end
+  def limit(*args); end
 
   sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def self.offset(*args); end
+  def offset(*args); end
 
   sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def self.joins(*args); end
+  def joins(*args); end
 
   sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def self.left_joins(*args); end
+  def left_joins(*args); end
 
   sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def self.left_outer_joins(*args); end
+  def left_outer_joins(*args); end
 
   sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def self.where(*args); end
+  def where(*args); end
 
   sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def self.rewhere(*args); end
+  def rewhere(*args); end
 
   sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def self.preload(*args); end
+  def preload(*args); end
 
   sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def self.eager_load(*args); end
+  def eager_load(*args); end
 
   sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def self.includes(*args); end
+  def includes(*args); end
 
   sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def self.from(*args); end
+  def from(*args); end
 
   sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def self.lock(*args); end
+  def lock(*args); end
 
   sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def self.readonly(*args); end
+  def readonly(*args); end
 
   sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def self.or(*args); end
+  def or(*args); end
 
   sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def self.having(*args); end
+  def having(*args); end
 
   sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def self.create_with(*args); end
+  def create_with(*args); end
 
   sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def self.distinct(*args); end
+  def distinct(*args); end
 
   sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def self.references(*args); end
+  def references(*args); end
 
   sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def self.none(*args); end
+  def none(*args); end
 
   sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def self.unscope(*args); end
+  def unscope(*args); end
 
   sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def self.merge(*args); end
+  def merge(*args); end
 
   sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def self.except(*args); end
+  def except(*args); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(School::ActiveRecord_Relation) }
-  def self.extending(*args, &block); end
+  def extending(*args, &block); end
+end
+
+module School::QueryMethodsReturningAssociationRelation
+  sig { returns(School::ActiveRecord_AssociationRelation) }
+  def all; end
+
+  sig { params(block: T.nilable(T.proc.void)).returns(School::ActiveRecord_Relation) }
+  def unscoped(&block); end
+
+  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
+  def select(*args); end
+
+  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
+  def order(*args); end
+
+  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
+  def reorder(*args); end
+
+  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
+  def group(*args); end
+
+  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
+  def limit(*args); end
+
+  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
+  def offset(*args); end
+
+  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
+  def joins(*args); end
+
+  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
+  def left_joins(*args); end
+
+  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
+  def left_outer_joins(*args); end
+
+  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
+  def where(*args); end
+
+  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
+  def rewhere(*args); end
+
+  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
+  def preload(*args); end
+
+  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
+  def eager_load(*args); end
+
+  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
+  def includes(*args); end
+
+  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
+  def from(*args); end
+
+  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
+  def lock(*args); end
+
+  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
+  def readonly(*args); end
+
+  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
+  def or(*args); end
+
+  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
+  def having(*args); end
+
+  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
+  def create_with(*args); end
+
+  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
+  def distinct(*args); end
+
+  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
+  def references(*args); end
+
+  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
+  def none(*args); end
+
+  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
+  def unscope(*args); end
+
+  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
+  def merge(*args); end
+
+  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
+  def except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(School::ActiveRecord_AssociationRelation) }
+  def extending(*args, &block); end
 end
 
 class School::ActiveRecord_Relation < ActiveRecord::Relation
   include School::ActiveRelation_WhereNot
   include School::CustomFinderMethods
+  include School::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: School)
-
-  sig { returns(School::ActiveRecord_Relation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(School::ActiveRecord_Relation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(School::ActiveRecord_Relation) }
-  def extending(*args, &block); end
 end
 
 class School::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
   include School::ActiveRelation_WhereNot
   include School::CustomFinderMethods
+  include School::QueryMethodsReturningAssociationRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: School)
-
-  sig { returns(School::ActiveRecord_AssociationRelation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(School::ActiveRecord_AssociationRelation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(School::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
 end
 
 class School::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include School::CustomFinderMethods
+  include School::QueryMethodsReturningAssociationRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: School)
-
-  sig { returns(School::ActiveRecord_AssociationRelation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(School::ActiveRecord_AssociationRelation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(School::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
 
   sig { params(records: T.any(School, T::Array[School])).returns(T.self_type) }
   def <<(*records); end

--- a/spec/test_data/v5.2/expected_spell.rbi
+++ b/spec/test_data/v5.2/expected_spell.rbi
@@ -63,380 +63,214 @@ class Spell < ApplicationRecord
   include Spell::GeneratedAttributeMethods
   include Spell::GeneratedAssociationMethods
   extend Spell::CustomFinderMethods
+  extend Spell::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   RelationType = T.type_alias { T.any(Spell::ActiveRecord_Relation, Spell::ActiveRecord_Associations_CollectionProxy, Spell::ActiveRecord_AssociationRelation) }
+end
 
+module Spell::QueryMethodsReturningRelation
   sig { returns(Spell::ActiveRecord_Relation) }
-  def self.all; end
+  def all; end
 
   sig { params(block: T.nilable(T.proc.void)).returns(Spell::ActiveRecord_Relation) }
-  def self.unscoped(&block); end
+  def unscoped(&block); end
 
   sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def self.select(*args); end
+  def select(*args); end
 
   sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def self.order(*args); end
+  def order(*args); end
 
   sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def self.reorder(*args); end
+  def reorder(*args); end
 
   sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def self.group(*args); end
+  def group(*args); end
 
   sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def self.limit(*args); end
+  def limit(*args); end
 
   sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def self.offset(*args); end
+  def offset(*args); end
 
   sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def self.joins(*args); end
+  def joins(*args); end
 
   sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def self.left_joins(*args); end
+  def left_joins(*args); end
 
   sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def self.left_outer_joins(*args); end
+  def left_outer_joins(*args); end
 
   sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def self.where(*args); end
+  def where(*args); end
 
   sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def self.rewhere(*args); end
+  def rewhere(*args); end
 
   sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def self.preload(*args); end
+  def preload(*args); end
 
   sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def self.eager_load(*args); end
+  def eager_load(*args); end
 
   sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def self.includes(*args); end
+  def includes(*args); end
 
   sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def self.from(*args); end
+  def from(*args); end
 
   sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def self.lock(*args); end
+  def lock(*args); end
 
   sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def self.readonly(*args); end
+  def readonly(*args); end
 
   sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def self.or(*args); end
+  def or(*args); end
 
   sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def self.having(*args); end
+  def having(*args); end
 
   sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def self.create_with(*args); end
+  def create_with(*args); end
 
   sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def self.distinct(*args); end
+  def distinct(*args); end
 
   sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def self.references(*args); end
+  def references(*args); end
 
   sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def self.none(*args); end
+  def none(*args); end
 
   sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def self.unscope(*args); end
+  def unscope(*args); end
 
   sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def self.merge(*args); end
+  def merge(*args); end
 
   sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def self.except(*args); end
+  def except(*args); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Spell::ActiveRecord_Relation) }
-  def self.extending(*args, &block); end
+  def extending(*args, &block); end
+end
+
+module Spell::QueryMethodsReturningAssociationRelation
+  sig { returns(Spell::ActiveRecord_AssociationRelation) }
+  def all; end
+
+  sig { params(block: T.nilable(T.proc.void)).returns(Spell::ActiveRecord_Relation) }
+  def unscoped(&block); end
+
+  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
+  def select(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
+  def order(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
+  def reorder(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
+  def group(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
+  def limit(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
+  def offset(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
+  def joins(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
+  def left_joins(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
+  def left_outer_joins(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
+  def where(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
+  def rewhere(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
+  def preload(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
+  def eager_load(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
+  def includes(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
+  def from(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
+  def lock(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
+  def readonly(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
+  def or(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
+  def having(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
+  def create_with(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
+  def distinct(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
+  def references(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
+  def none(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
+  def unscope(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
+  def merge(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
+  def except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Spell::ActiveRecord_AssociationRelation) }
+  def extending(*args, &block); end
 end
 
 class Spell::ActiveRecord_Relation < ActiveRecord::Relation
   include Spell::ActiveRelation_WhereNot
   include Spell::CustomFinderMethods
+  include Spell::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: Spell)
-
-  sig { returns(Spell::ActiveRecord_Relation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Spell::ActiveRecord_Relation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Spell::ActiveRecord_Relation) }
-  def extending(*args, &block); end
 end
 
 class Spell::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
   include Spell::ActiveRelation_WhereNot
   include Spell::CustomFinderMethods
+  include Spell::QueryMethodsReturningAssociationRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: Spell)
-
-  sig { returns(Spell::ActiveRecord_AssociationRelation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Spell::ActiveRecord_AssociationRelation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Spell::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
 end
 
 class Spell::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include Spell::CustomFinderMethods
+  include Spell::QueryMethodsReturningAssociationRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: Spell)
-
-  sig { returns(Spell::ActiveRecord_AssociationRelation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Spell::ActiveRecord_AssociationRelation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Spell::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
 
   sig { params(records: T.any(Spell, T::Array[Spell])).returns(T.self_type) }
   def <<(*records); end

--- a/spec/test_data/v5.2/expected_spell.rbi
+++ b/spec/test_data/v5.2/expected_spell.rbi
@@ -8,8 +8,6 @@ module Spell::ActiveRelation_WhereNot
 end
 
 module Spell::GeneratedAttributeMethods
-  extend T::Sig
-
   sig { returns(Integer) }
   def id; end
 
@@ -30,8 +28,6 @@ module Spell::GeneratedAttributeMethods
 end
 
 module Spell::GeneratedAssociationMethods
-  extend T::Sig
-
   sig { returns(::SpellBook::ActiveRecord_Associations_CollectionProxy) }
   def spell_books; end
 
@@ -64,8 +60,6 @@ class Spell < ApplicationRecord
   include Spell::GeneratedAssociationMethods
   extend Spell::CustomFinderMethods
   extend Spell::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   RelationType = T.type_alias { T.any(Spell::ActiveRecord_Relation, Spell::ActiveRecord_Associations_CollectionProxy, Spell::ActiveRecord_AssociationRelation) }
 end
 
@@ -251,8 +245,6 @@ class Spell::ActiveRecord_Relation < ActiveRecord::Relation
   include Spell::ActiveRelation_WhereNot
   include Spell::CustomFinderMethods
   include Spell::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Spell)
 end
 
@@ -260,16 +252,12 @@ class Spell::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelatio
   include Spell::ActiveRelation_WhereNot
   include Spell::CustomFinderMethods
   include Spell::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Spell)
 end
 
 class Spell::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include Spell::CustomFinderMethods
   include Spell::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Spell)
 
   sig { params(records: T.any(Spell, T::Array[Spell])).returns(T.self_type) }

--- a/spec/test_data/v5.2/expected_spell/habtm_spell_books.rbi
+++ b/spec/test_data/v5.2/expected_spell/habtm_spell_books.rbi
@@ -8,8 +8,6 @@ module Spell::HABTM_SpellBooks::ActiveRelation_WhereNot
 end
 
 module Spell::HABTM_SpellBooks::GeneratedAttributeMethods
-  extend T::Sig
-
   sig { returns(Integer) }
   def spell_book_id; end
 
@@ -30,8 +28,6 @@ module Spell::HABTM_SpellBooks::GeneratedAttributeMethods
 end
 
 module Spell::HABTM_SpellBooks::GeneratedAssociationMethods
-  extend T::Sig
-
   sig { returns(T.nilable(::Spell)) }
   def left_side; end
 
@@ -67,8 +63,6 @@ class Spell::HABTM_SpellBooks < ActiveRecord::Base
   include Spell::HABTM_SpellBooks::GeneratedAssociationMethods
   extend Spell::HABTM_SpellBooks::CustomFinderMethods
   extend Spell::HABTM_SpellBooks::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   RelationType = T.type_alias { T.any(Spell::HABTM_SpellBooks::ActiveRecord_Relation, Spell::HABTM_SpellBooks::ActiveRecord_Associations_CollectionProxy, Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
 end
 
@@ -254,8 +248,6 @@ class Spell::HABTM_SpellBooks::ActiveRecord_Relation < ActiveRecord::Relation
   include Spell::HABTM_SpellBooks::ActiveRelation_WhereNot
   include Spell::HABTM_SpellBooks::CustomFinderMethods
   include Spell::HABTM_SpellBooks::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Spell::HABTM_SpellBooks)
 end
 
@@ -263,16 +255,12 @@ class Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation < ActiveRecord::
   include Spell::HABTM_SpellBooks::ActiveRelation_WhereNot
   include Spell::HABTM_SpellBooks::CustomFinderMethods
   include Spell::HABTM_SpellBooks::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Spell::HABTM_SpellBooks)
 end
 
 class Spell::HABTM_SpellBooks::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include Spell::HABTM_SpellBooks::CustomFinderMethods
   include Spell::HABTM_SpellBooks::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Spell::HABTM_SpellBooks)
 
   sig { params(records: T.any(Spell::HABTM_SpellBooks, T::Array[Spell::HABTM_SpellBooks])).returns(T.self_type) }

--- a/spec/test_data/v5.2/expected_spell/habtm_spell_books.rbi
+++ b/spec/test_data/v5.2/expected_spell/habtm_spell_books.rbi
@@ -66,380 +66,214 @@ class Spell::HABTM_SpellBooks < ActiveRecord::Base
   include Spell::HABTM_SpellBooks::GeneratedAttributeMethods
   include Spell::HABTM_SpellBooks::GeneratedAssociationMethods
   extend Spell::HABTM_SpellBooks::CustomFinderMethods
+  extend Spell::HABTM_SpellBooks::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   RelationType = T.type_alias { T.any(Spell::HABTM_SpellBooks::ActiveRecord_Relation, Spell::HABTM_SpellBooks::ActiveRecord_Associations_CollectionProxy, Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
+end
 
+module Spell::HABTM_SpellBooks::QueryMethodsReturningRelation
   sig { returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def self.all; end
+  def all; end
 
   sig { params(block: T.nilable(T.proc.void)).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def self.unscoped(&block); end
+  def unscoped(&block); end
 
   sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def self.select(*args); end
+  def select(*args); end
 
   sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def self.order(*args); end
+  def order(*args); end
 
   sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def self.reorder(*args); end
+  def reorder(*args); end
 
   sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def self.group(*args); end
+  def group(*args); end
 
   sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def self.limit(*args); end
+  def limit(*args); end
 
   sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def self.offset(*args); end
+  def offset(*args); end
 
   sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def self.joins(*args); end
+  def joins(*args); end
 
   sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def self.left_joins(*args); end
+  def left_joins(*args); end
 
   sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def self.left_outer_joins(*args); end
+  def left_outer_joins(*args); end
 
   sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def self.where(*args); end
+  def where(*args); end
 
   sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def self.rewhere(*args); end
+  def rewhere(*args); end
 
   sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def self.preload(*args); end
+  def preload(*args); end
 
   sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def self.eager_load(*args); end
+  def eager_load(*args); end
 
   sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def self.includes(*args); end
+  def includes(*args); end
 
   sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def self.from(*args); end
+  def from(*args); end
 
   sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def self.lock(*args); end
+  def lock(*args); end
 
   sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def self.readonly(*args); end
+  def readonly(*args); end
 
   sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def self.or(*args); end
+  def or(*args); end
 
   sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def self.having(*args); end
+  def having(*args); end
 
   sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def self.create_with(*args); end
+  def create_with(*args); end
 
   sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def self.distinct(*args); end
+  def distinct(*args); end
 
   sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def self.references(*args); end
+  def references(*args); end
 
   sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def self.none(*args); end
+  def none(*args); end
 
   sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def self.unscope(*args); end
+  def unscope(*args); end
 
   sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def self.merge(*args); end
+  def merge(*args); end
 
   sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def self.except(*args); end
+  def except(*args); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def self.extending(*args, &block); end
+  def extending(*args, &block); end
+end
+
+module Spell::HABTM_SpellBooks::QueryMethodsReturningAssociationRelation
+  sig { returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
+  def all; end
+
+  sig { params(block: T.nilable(T.proc.void)).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
+  def unscoped(&block); end
+
+  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
+  def select(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
+  def order(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
+  def reorder(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
+  def group(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
+  def limit(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
+  def offset(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
+  def joins(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
+  def left_joins(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
+  def left_outer_joins(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
+  def where(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
+  def rewhere(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
+  def preload(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
+  def eager_load(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
+  def includes(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
+  def from(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
+  def lock(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
+  def readonly(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
+  def or(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
+  def having(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
+  def create_with(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
+  def distinct(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
+  def references(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
+  def none(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
+  def unscope(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
+  def merge(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
+  def except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
+  def extending(*args, &block); end
 end
 
 class Spell::HABTM_SpellBooks::ActiveRecord_Relation < ActiveRecord::Relation
   include Spell::HABTM_SpellBooks::ActiveRelation_WhereNot
   include Spell::HABTM_SpellBooks::CustomFinderMethods
+  include Spell::HABTM_SpellBooks::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: Spell::HABTM_SpellBooks)
-
-  sig { returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def extending(*args, &block); end
 end
 
 class Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
   include Spell::HABTM_SpellBooks::ActiveRelation_WhereNot
   include Spell::HABTM_SpellBooks::CustomFinderMethods
+  include Spell::HABTM_SpellBooks::QueryMethodsReturningAssociationRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: Spell::HABTM_SpellBooks)
-
-  sig { returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
 end
 
 class Spell::HABTM_SpellBooks::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include Spell::HABTM_SpellBooks::CustomFinderMethods
+  include Spell::HABTM_SpellBooks::QueryMethodsReturningAssociationRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: Spell::HABTM_SpellBooks)
-
-  sig { returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
 
   sig { params(records: T.any(Spell::HABTM_SpellBooks, T::Array[Spell::HABTM_SpellBooks])).returns(T.self_type) }
   def <<(*records); end

--- a/spec/test_data/v5.2/expected_spell_book.rbi
+++ b/spec/test_data/v5.2/expected_spell_book.rbi
@@ -119,6 +119,7 @@ class SpellBook < ApplicationRecord
   include SpellBook::GeneratedAttributeMethods
   include SpellBook::GeneratedAssociationMethods
   extend SpellBook::CustomFinderMethods
+  extend SpellBook::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   RelationType = T.type_alias { T.any(SpellBook::ActiveRecord_Relation, SpellBook::ActiveRecord_Associations_CollectionProxy, SpellBook::ActiveRecord_AssociationRelation) }
@@ -133,94 +134,10 @@ class SpellBook < ApplicationRecord
   def self.dark_art(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def self.recent(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
   def self.unclassified(*args); end
-
-  sig { returns(SpellBook::ActiveRecord_Relation) }
-  def self.all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def self.unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def self.select(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def self.order(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def self.reorder(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def self.group(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def self.limit(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def self.offset(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def self.joins(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def self.left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def self.left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def self.where(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def self.rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def self.preload(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def self.eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def self.includes(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def self.from(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def self.lock(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def self.readonly(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def self.or(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def self.having(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def self.create_with(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def self.distinct(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def self.references(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def self.none(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def self.unscope(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def self.merge(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def self.except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def self.extending(*args, &block); end
 
   sig { returns(SpellBook::BookType) }
   def typed_book_type; end
@@ -232,6 +149,7 @@ end
 class SpellBook::ActiveRecord_Relation < ActiveRecord::Relation
   include SpellBook::ActiveRelation_WhereNot
   include SpellBook::CustomFinderMethods
+  include SpellBook::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: SpellBook)
@@ -243,99 +161,16 @@ class SpellBook::ActiveRecord_Relation < ActiveRecord::Relation
   def dark_art(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def recent(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
   def unclassified(*args); end
-
-  sig { returns(SpellBook::ActiveRecord_Relation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def extending(*args, &block); end
 end
 
 class SpellBook::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
   include SpellBook::ActiveRelation_WhereNot
   include SpellBook::CustomFinderMethods
+  include SpellBook::QueryMethodsReturningAssociationRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: SpellBook)
@@ -347,98 +182,15 @@ class SpellBook::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRel
   def dark_art(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def recent(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
   def unclassified(*args); end
-
-  sig { returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
 end
 
 class SpellBook::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include SpellBook::CustomFinderMethods
+  include SpellBook::QueryMethodsReturningAssociationRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: SpellBook)
@@ -450,94 +202,10 @@ class SpellBook::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Assoc
   def dark_art(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def recent(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
   def unclassified(*args); end
-
-  sig { returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
 
   sig { params(records: T.any(SpellBook, T::Array[SpellBook])).returns(T.self_type) }
   def <<(*records); end
@@ -550,4 +218,182 @@ class SpellBook::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Assoc
 
   sig { params(records: T.any(SpellBook, T::Array[SpellBook])).returns(T.self_type) }
   def concat(*records); end
+end
+
+module SpellBook::QueryMethodsReturningRelation
+  sig { returns(SpellBook::ActiveRecord_Relation) }
+  def all; end
+
+  sig { params(block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
+  def unscoped(&block); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def select(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def order(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def reorder(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def group(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def limit(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def offset(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def joins(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def left_joins(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def left_outer_joins(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def where(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def rewhere(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def preload(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def eager_load(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def includes(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def from(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def lock(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def readonly(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def or(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def having(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def create_with(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def distinct(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def references(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def none(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def unscope(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def merge(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
+  def extending(*args, &block); end
+end
+
+module SpellBook::QueryMethodsReturningAssociationRelation
+  sig { returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def all; end
+
+  sig { params(block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
+  def unscoped(&block); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def select(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def order(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def reorder(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def group(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def limit(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def offset(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def joins(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def left_joins(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def left_outer_joins(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def where(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def rewhere(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def preload(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def eager_load(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def includes(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def from(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def lock(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def readonly(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def or(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def having(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def create_with(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def distinct(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def references(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def none(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def unscope(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def merge(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def extending(*args, &block); end
 end

--- a/spec/test_data/v5.2/expected_spell_book.rbi
+++ b/spec/test_data/v5.2/expected_spell_book.rbi
@@ -3,8 +3,6 @@
 
 # typed: strong
 module SpellBook::EnumInstanceMethods
-  extend T::Sig
-
   sig { returns(T::Boolean) }
   def unclassified?; end
 
@@ -30,8 +28,6 @@ module SpellBook::ActiveRelation_WhereNot
 end
 
 module SpellBook::GeneratedAttributeMethods
-  extend T::Sig
-
   sig { returns(String) }
   def book_type; end
 
@@ -79,8 +75,6 @@ class SpellBook::BookType < T::Enum
 end
 
 module SpellBook::GeneratedAssociationMethods
-  extend T::Sig
-
   sig { returns(::Spell::ActiveRecord_Associations_CollectionProxy) }
   def spells; end
 
@@ -120,8 +114,6 @@ class SpellBook < ApplicationRecord
   include SpellBook::GeneratedAssociationMethods
   extend SpellBook::CustomFinderMethods
   extend SpellBook::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   RelationType = T.type_alias { T.any(SpellBook::ActiveRecord_Relation, SpellBook::ActiveRecord_Associations_CollectionProxy, SpellBook::ActiveRecord_AssociationRelation) }
 
   sig { returns(T::Hash[T.any(String, Symbol), Integer]) }
@@ -150,8 +142,6 @@ class SpellBook::ActiveRecord_Relation < ActiveRecord::Relation
   include SpellBook::ActiveRelation_WhereNot
   include SpellBook::CustomFinderMethods
   include SpellBook::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: SpellBook)
 
   sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
@@ -171,8 +161,6 @@ class SpellBook::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRel
   include SpellBook::ActiveRelation_WhereNot
   include SpellBook::CustomFinderMethods
   include SpellBook::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: SpellBook)
 
   sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
@@ -191,8 +179,6 @@ end
 class SpellBook::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include SpellBook::CustomFinderMethods
   include SpellBook::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: SpellBook)
 
   sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }

--- a/spec/test_data/v5.2/expected_spell_book/habtm_spells.rbi
+++ b/spec/test_data/v5.2/expected_spell_book/habtm_spells.rbi
@@ -8,8 +8,6 @@ module SpellBook::HABTM_Spells::ActiveRelation_WhereNot
 end
 
 module SpellBook::HABTM_Spells::GeneratedAttributeMethods
-  extend T::Sig
-
   sig { returns(Integer) }
   def spell_book_id; end
 
@@ -30,8 +28,6 @@ module SpellBook::HABTM_Spells::GeneratedAttributeMethods
 end
 
 module SpellBook::HABTM_Spells::GeneratedAssociationMethods
-  extend T::Sig
-
   sig { returns(T.nilable(::SpellBook)) }
   def left_side; end
 
@@ -67,8 +63,6 @@ class SpellBook::HABTM_Spells < ActiveRecord::Base
   include SpellBook::HABTM_Spells::GeneratedAssociationMethods
   extend SpellBook::HABTM_Spells::CustomFinderMethods
   extend SpellBook::HABTM_Spells::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   RelationType = T.type_alias { T.any(SpellBook::HABTM_Spells::ActiveRecord_Relation, SpellBook::HABTM_Spells::ActiveRecord_Associations_CollectionProxy, SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
 end
 
@@ -254,8 +248,6 @@ class SpellBook::HABTM_Spells::ActiveRecord_Relation < ActiveRecord::Relation
   include SpellBook::HABTM_Spells::ActiveRelation_WhereNot
   include SpellBook::HABTM_Spells::CustomFinderMethods
   include SpellBook::HABTM_Spells::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: SpellBook::HABTM_Spells)
 end
 
@@ -263,16 +255,12 @@ class SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation < ActiveRecord::
   include SpellBook::HABTM_Spells::ActiveRelation_WhereNot
   include SpellBook::HABTM_Spells::CustomFinderMethods
   include SpellBook::HABTM_Spells::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: SpellBook::HABTM_Spells)
 end
 
 class SpellBook::HABTM_Spells::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include SpellBook::HABTM_Spells::CustomFinderMethods
   include SpellBook::HABTM_Spells::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: SpellBook::HABTM_Spells)
 
   sig { params(records: T.any(SpellBook::HABTM_Spells, T::Array[SpellBook::HABTM_Spells])).returns(T.self_type) }

--- a/spec/test_data/v5.2/expected_spell_book/habtm_spells.rbi
+++ b/spec/test_data/v5.2/expected_spell_book/habtm_spells.rbi
@@ -66,380 +66,214 @@ class SpellBook::HABTM_Spells < ActiveRecord::Base
   include SpellBook::HABTM_Spells::GeneratedAttributeMethods
   include SpellBook::HABTM_Spells::GeneratedAssociationMethods
   extend SpellBook::HABTM_Spells::CustomFinderMethods
+  extend SpellBook::HABTM_Spells::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   RelationType = T.type_alias { T.any(SpellBook::HABTM_Spells::ActiveRecord_Relation, SpellBook::HABTM_Spells::ActiveRecord_Associations_CollectionProxy, SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
+end
 
+module SpellBook::HABTM_Spells::QueryMethodsReturningRelation
   sig { returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def self.all; end
+  def all; end
 
   sig { params(block: T.nilable(T.proc.void)).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def self.unscoped(&block); end
+  def unscoped(&block); end
 
   sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def self.select(*args); end
+  def select(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def self.order(*args); end
+  def order(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def self.reorder(*args); end
+  def reorder(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def self.group(*args); end
+  def group(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def self.limit(*args); end
+  def limit(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def self.offset(*args); end
+  def offset(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def self.joins(*args); end
+  def joins(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def self.left_joins(*args); end
+  def left_joins(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def self.left_outer_joins(*args); end
+  def left_outer_joins(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def self.where(*args); end
+  def where(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def self.rewhere(*args); end
+  def rewhere(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def self.preload(*args); end
+  def preload(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def self.eager_load(*args); end
+  def eager_load(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def self.includes(*args); end
+  def includes(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def self.from(*args); end
+  def from(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def self.lock(*args); end
+  def lock(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def self.readonly(*args); end
+  def readonly(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def self.or(*args); end
+  def or(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def self.having(*args); end
+  def having(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def self.create_with(*args); end
+  def create_with(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def self.distinct(*args); end
+  def distinct(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def self.references(*args); end
+  def references(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def self.none(*args); end
+  def none(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def self.unscope(*args); end
+  def unscope(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def self.merge(*args); end
+  def merge(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def self.except(*args); end
+  def except(*args); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def self.extending(*args, &block); end
+  def extending(*args, &block); end
+end
+
+module SpellBook::HABTM_Spells::QueryMethodsReturningAssociationRelation
+  sig { returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
+  def all; end
+
+  sig { params(block: T.nilable(T.proc.void)).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
+  def unscoped(&block); end
+
+  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
+  def select(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
+  def order(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
+  def reorder(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
+  def group(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
+  def limit(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
+  def offset(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
+  def joins(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
+  def left_joins(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
+  def left_outer_joins(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
+  def where(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
+  def rewhere(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
+  def preload(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
+  def eager_load(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
+  def includes(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
+  def from(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
+  def lock(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
+  def readonly(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
+  def or(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
+  def having(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
+  def create_with(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
+  def distinct(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
+  def references(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
+  def none(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
+  def unscope(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
+  def merge(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
+  def except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
+  def extending(*args, &block); end
 end
 
 class SpellBook::HABTM_Spells::ActiveRecord_Relation < ActiveRecord::Relation
   include SpellBook::HABTM_Spells::ActiveRelation_WhereNot
   include SpellBook::HABTM_Spells::CustomFinderMethods
+  include SpellBook::HABTM_Spells::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: SpellBook::HABTM_Spells)
-
-  sig { returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def extending(*args, &block); end
 end
 
 class SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
   include SpellBook::HABTM_Spells::ActiveRelation_WhereNot
   include SpellBook::HABTM_Spells::CustomFinderMethods
+  include SpellBook::HABTM_Spells::QueryMethodsReturningAssociationRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: SpellBook::HABTM_Spells)
-
-  sig { returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
 end
 
 class SpellBook::HABTM_Spells::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include SpellBook::HABTM_Spells::CustomFinderMethods
+  include SpellBook::HABTM_Spells::QueryMethodsReturningAssociationRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: SpellBook::HABTM_Spells)
-
-  sig { returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
 
   sig { params(records: T.any(SpellBook::HABTM_Spells, T::Array[SpellBook::HABTM_Spells])).returns(T.self_type) }
   def <<(*records); end

--- a/spec/test_data/v5.2/expected_squib.rbi
+++ b/spec/test_data/v5.2/expected_squib.rbi
@@ -338,6 +338,7 @@ class Squib < Wizard
   include Squib::GeneratedAttributeMethods
   include Squib::GeneratedAssociationMethods
   extend Squib::CustomFinderMethods
+  extend Squib::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   RelationType = T.type_alias { T.any(Squib::ActiveRecord_Relation, Squib::ActiveRecord_Associations_CollectionProxy, Squib::ActiveRecord_AssociationRelation) }
@@ -419,98 +420,12 @@ class Squib < Wizard
 
   sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
   def self.with_attached_school_photo(*args); end
-
-  sig { returns(Squib::ActiveRecord_Relation) }
-  def self.all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def self.unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.select(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.order(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.group(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.limit(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.offset(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.joins(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.where(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.preload(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.includes(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.from(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.lock(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.or(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.having(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.references(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.none(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.merge(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def self.extending(*args, &block); end
 end
 
 class Squib::ActiveRecord_Relation < ActiveRecord::Relation
   include Squib::ActiveRelation_WhereNot
   include Squib::CustomFinderMethods
+  include Squib::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: Squib)
@@ -574,98 +489,12 @@ class Squib::ActiveRecord_Relation < ActiveRecord::Relation
 
   sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
   def with_attached_school_photo(*args); end
-
-  sig { returns(Squib::ActiveRecord_Relation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def extending(*args, &block); end
 end
 
 class Squib::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
   include Squib::ActiveRelation_WhereNot
   include Squib::CustomFinderMethods
+  include Squib::QueryMethodsReturningAssociationRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: Squib)
@@ -729,97 +558,11 @@ class Squib::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelatio
 
   sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
   def with_attached_school_photo(*args); end
-
-  sig { returns(Squib::ActiveRecord_AssociationRelation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
 end
 
 class Squib::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include Squib::CustomFinderMethods
+  include Squib::QueryMethodsReturningAssociationRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: Squib)
@@ -883,93 +626,6 @@ class Squib::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associati
 
   sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
   def with_attached_school_photo(*args); end
-
-  sig { returns(Squib::ActiveRecord_AssociationRelation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
 
   sig { params(records: T.any(Squib, T::Array[Squib])).returns(T.self_type) }
   def <<(*records); end
@@ -982,4 +638,182 @@ class Squib::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associati
 
   sig { params(records: T.any(Squib, T::Array[Squib])).returns(T.self_type) }
   def concat(*records); end
+end
+
+module Squib::QueryMethodsReturningRelation
+  sig { returns(Squib::ActiveRecord_Relation) }
+  def all; end
+
+  sig { params(block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
+  def unscoped(&block); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def select(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def order(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def reorder(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def group(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def limit(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def offset(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def joins(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def left_joins(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def left_outer_joins(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def where(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def rewhere(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def preload(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def eager_load(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def includes(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def from(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def lock(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def readonly(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def or(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def having(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def create_with(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def distinct(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def references(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def none(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def unscope(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def merge(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
+  def extending(*args, &block); end
+end
+
+module Squib::QueryMethodsReturningAssociationRelation
+  sig { returns(Squib::ActiveRecord_AssociationRelation) }
+  def all; end
+
+  sig { params(block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
+  def unscoped(&block); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def select(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def order(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def reorder(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def group(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def limit(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def offset(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def joins(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def left_joins(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def left_outer_joins(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def where(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def rewhere(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def preload(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def eager_load(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def includes(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def from(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def lock(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def readonly(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def or(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def having(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def create_with(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def distinct(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def references(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def none(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def unscope(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def merge(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
+  def extending(*args, &block); end
 end

--- a/spec/test_data/v5.2/expected_squib.rbi
+++ b/spec/test_data/v5.2/expected_squib.rbi
@@ -3,8 +3,6 @@
 
 # typed: strong
 module Squib::EnumInstanceMethods
-  extend T::Sig
-
   sig { returns(T::Boolean) }
   def broom_nimbus?; end
 
@@ -114,8 +112,6 @@ module Squib::ActiveRelation_WhereNot
 end
 
 module Squib::GeneratedAttributeMethods
-  extend T::Sig
-
   sig { returns(T.nilable(String)) }
   def broom; end
 
@@ -253,8 +249,6 @@ module Squib::GeneratedAttributeMethods
 end
 
 module Squib::GeneratedAssociationMethods
-  extend T::Sig
-
   sig { returns(::ActiveStorage::Attachment::ActiveRecord_Associations_CollectionProxy) }
   def hats_attachments; end
 
@@ -339,8 +333,6 @@ class Squib < Wizard
   include Squib::GeneratedAssociationMethods
   extend Squib::CustomFinderMethods
   extend Squib::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   RelationType = T.type_alias { T.any(Squib::ActiveRecord_Relation, Squib::ActiveRecord_Associations_CollectionProxy, Squib::ActiveRecord_AssociationRelation) }
 
   sig { returns(T::Hash[T.any(String, Symbol), String]) }
@@ -426,8 +418,6 @@ class Squib::ActiveRecord_Relation < ActiveRecord::Relation
   include Squib::ActiveRelation_WhereNot
   include Squib::CustomFinderMethods
   include Squib::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Squib)
 
   sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
@@ -495,8 +485,6 @@ class Squib::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelatio
   include Squib::ActiveRelation_WhereNot
   include Squib::CustomFinderMethods
   include Squib::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Squib)
 
   sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
@@ -563,8 +551,6 @@ end
 class Squib::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include Squib::CustomFinderMethods
   include Squib::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Squib)
 
   sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }

--- a/spec/test_data/v5.2/expected_subject.rbi
+++ b/spec/test_data/v5.2/expected_subject.rbi
@@ -63,380 +63,214 @@ class Subject < ApplicationRecord
   include Subject::GeneratedAttributeMethods
   include Subject::GeneratedAssociationMethods
   extend Subject::CustomFinderMethods
+  extend Subject::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   RelationType = T.type_alias { T.any(Subject::ActiveRecord_Relation, Subject::ActiveRecord_Associations_CollectionProxy, Subject::ActiveRecord_AssociationRelation) }
+end
 
+module Subject::QueryMethodsReturningRelation
   sig { returns(Subject::ActiveRecord_Relation) }
-  def self.all; end
+  def all; end
 
   sig { params(block: T.nilable(T.proc.void)).returns(Subject::ActiveRecord_Relation) }
-  def self.unscoped(&block); end
+  def unscoped(&block); end
 
   sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def self.select(*args); end
+  def select(*args); end
 
   sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def self.order(*args); end
+  def order(*args); end
 
   sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def self.reorder(*args); end
+  def reorder(*args); end
 
   sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def self.group(*args); end
+  def group(*args); end
 
   sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def self.limit(*args); end
+  def limit(*args); end
 
   sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def self.offset(*args); end
+  def offset(*args); end
 
   sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def self.joins(*args); end
+  def joins(*args); end
 
   sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def self.left_joins(*args); end
+  def left_joins(*args); end
 
   sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def self.left_outer_joins(*args); end
+  def left_outer_joins(*args); end
 
   sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def self.where(*args); end
+  def where(*args); end
 
   sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def self.rewhere(*args); end
+  def rewhere(*args); end
 
   sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def self.preload(*args); end
+  def preload(*args); end
 
   sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def self.eager_load(*args); end
+  def eager_load(*args); end
 
   sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def self.includes(*args); end
+  def includes(*args); end
 
   sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def self.from(*args); end
+  def from(*args); end
 
   sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def self.lock(*args); end
+  def lock(*args); end
 
   sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def self.readonly(*args); end
+  def readonly(*args); end
 
   sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def self.or(*args); end
+  def or(*args); end
 
   sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def self.having(*args); end
+  def having(*args); end
 
   sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def self.create_with(*args); end
+  def create_with(*args); end
 
   sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def self.distinct(*args); end
+  def distinct(*args); end
 
   sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def self.references(*args); end
+  def references(*args); end
 
   sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def self.none(*args); end
+  def none(*args); end
 
   sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def self.unscope(*args); end
+  def unscope(*args); end
 
   sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def self.merge(*args); end
+  def merge(*args); end
 
   sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def self.except(*args); end
+  def except(*args); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Subject::ActiveRecord_Relation) }
-  def self.extending(*args, &block); end
+  def extending(*args, &block); end
+end
+
+module Subject::QueryMethodsReturningAssociationRelation
+  sig { returns(Subject::ActiveRecord_AssociationRelation) }
+  def all; end
+
+  sig { params(block: T.nilable(T.proc.void)).returns(Subject::ActiveRecord_Relation) }
+  def unscoped(&block); end
+
+  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
+  def select(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
+  def order(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
+  def reorder(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
+  def group(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
+  def limit(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
+  def offset(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
+  def joins(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
+  def left_joins(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
+  def left_outer_joins(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
+  def where(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
+  def rewhere(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
+  def preload(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
+  def eager_load(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
+  def includes(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
+  def from(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
+  def lock(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
+  def readonly(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
+  def or(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
+  def having(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
+  def create_with(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
+  def distinct(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
+  def references(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
+  def none(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
+  def unscope(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
+  def merge(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
+  def except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Subject::ActiveRecord_AssociationRelation) }
+  def extending(*args, &block); end
 end
 
 class Subject::ActiveRecord_Relation < ActiveRecord::Relation
   include Subject::ActiveRelation_WhereNot
   include Subject::CustomFinderMethods
+  include Subject::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: Subject)
-
-  sig { returns(Subject::ActiveRecord_Relation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Subject::ActiveRecord_Relation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Subject::ActiveRecord_Relation) }
-  def extending(*args, &block); end
 end
 
 class Subject::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
   include Subject::ActiveRelation_WhereNot
   include Subject::CustomFinderMethods
+  include Subject::QueryMethodsReturningAssociationRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: Subject)
-
-  sig { returns(Subject::ActiveRecord_AssociationRelation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Subject::ActiveRecord_AssociationRelation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Subject::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
 end
 
 class Subject::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include Subject::CustomFinderMethods
+  include Subject::QueryMethodsReturningAssociationRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: Subject)
-
-  sig { returns(Subject::ActiveRecord_AssociationRelation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Subject::ActiveRecord_AssociationRelation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Subject::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
 
   sig { params(records: T.any(Subject, T::Array[Subject])).returns(T.self_type) }
   def <<(*records); end

--- a/spec/test_data/v5.2/expected_subject.rbi
+++ b/spec/test_data/v5.2/expected_subject.rbi
@@ -8,8 +8,6 @@ module Subject::ActiveRelation_WhereNot
 end
 
 module Subject::GeneratedAttributeMethods
-  extend T::Sig
-
   sig { returns(Integer) }
   def id; end
 
@@ -30,8 +28,6 @@ module Subject::GeneratedAttributeMethods
 end
 
 module Subject::GeneratedAssociationMethods
-  extend T::Sig
-
   sig { returns(::Wizard::ActiveRecord_Associations_CollectionProxy) }
   def wizards; end
 
@@ -64,8 +60,6 @@ class Subject < ApplicationRecord
   include Subject::GeneratedAssociationMethods
   extend Subject::CustomFinderMethods
   extend Subject::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   RelationType = T.type_alias { T.any(Subject::ActiveRecord_Relation, Subject::ActiveRecord_Associations_CollectionProxy, Subject::ActiveRecord_AssociationRelation) }
 end
 
@@ -251,8 +245,6 @@ class Subject::ActiveRecord_Relation < ActiveRecord::Relation
   include Subject::ActiveRelation_WhereNot
   include Subject::CustomFinderMethods
   include Subject::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Subject)
 end
 
@@ -260,16 +252,12 @@ class Subject::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelat
   include Subject::ActiveRelation_WhereNot
   include Subject::CustomFinderMethods
   include Subject::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Subject)
 end
 
 class Subject::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include Subject::CustomFinderMethods
   include Subject::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Subject)
 
   sig { params(records: T.any(Subject, T::Array[Subject])).returns(T.self_type) }

--- a/spec/test_data/v5.2/expected_subject/habtm_wizards.rbi
+++ b/spec/test_data/v5.2/expected_subject/habtm_wizards.rbi
@@ -8,8 +8,6 @@ module Subject::HABTM_Wizards::ActiveRelation_WhereNot
 end
 
 module Subject::HABTM_Wizards::GeneratedAttributeMethods
-  extend T::Sig
-
   sig { returns(T.nilable(Integer)) }
   def subject_id; end
 
@@ -30,8 +28,6 @@ module Subject::HABTM_Wizards::GeneratedAttributeMethods
 end
 
 module Subject::HABTM_Wizards::GeneratedAssociationMethods
-  extend T::Sig
-
   sig { returns(T.nilable(::Subject)) }
   def left_side; end
 
@@ -67,8 +63,6 @@ class Subject::HABTM_Wizards < ActiveRecord::Base
   include Subject::HABTM_Wizards::GeneratedAssociationMethods
   extend Subject::HABTM_Wizards::CustomFinderMethods
   extend Subject::HABTM_Wizards::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   RelationType = T.type_alias { T.any(Subject::HABTM_Wizards::ActiveRecord_Relation, Subject::HABTM_Wizards::ActiveRecord_Associations_CollectionProxy, Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
 end
 
@@ -254,8 +248,6 @@ class Subject::HABTM_Wizards::ActiveRecord_Relation < ActiveRecord::Relation
   include Subject::HABTM_Wizards::ActiveRelation_WhereNot
   include Subject::HABTM_Wizards::CustomFinderMethods
   include Subject::HABTM_Wizards::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Subject::HABTM_Wizards)
 end
 
@@ -263,16 +255,12 @@ class Subject::HABTM_Wizards::ActiveRecord_AssociationRelation < ActiveRecord::A
   include Subject::HABTM_Wizards::ActiveRelation_WhereNot
   include Subject::HABTM_Wizards::CustomFinderMethods
   include Subject::HABTM_Wizards::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Subject::HABTM_Wizards)
 end
 
 class Subject::HABTM_Wizards::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include Subject::HABTM_Wizards::CustomFinderMethods
   include Subject::HABTM_Wizards::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Subject::HABTM_Wizards)
 
   sig { params(records: T.any(Subject::HABTM_Wizards, T::Array[Subject::HABTM_Wizards])).returns(T.self_type) }

--- a/spec/test_data/v5.2/expected_subject/habtm_wizards.rbi
+++ b/spec/test_data/v5.2/expected_subject/habtm_wizards.rbi
@@ -66,380 +66,214 @@ class Subject::HABTM_Wizards < ActiveRecord::Base
   include Subject::HABTM_Wizards::GeneratedAttributeMethods
   include Subject::HABTM_Wizards::GeneratedAssociationMethods
   extend Subject::HABTM_Wizards::CustomFinderMethods
+  extend Subject::HABTM_Wizards::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   RelationType = T.type_alias { T.any(Subject::HABTM_Wizards::ActiveRecord_Relation, Subject::HABTM_Wizards::ActiveRecord_Associations_CollectionProxy, Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
+end
 
+module Subject::HABTM_Wizards::QueryMethodsReturningRelation
   sig { returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def self.all; end
+  def all; end
 
   sig { params(block: T.nilable(T.proc.void)).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def self.unscoped(&block); end
+  def unscoped(&block); end
 
   sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def self.select(*args); end
+  def select(*args); end
 
   sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def self.order(*args); end
+  def order(*args); end
 
   sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def self.reorder(*args); end
+  def reorder(*args); end
 
   sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def self.group(*args); end
+  def group(*args); end
 
   sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def self.limit(*args); end
+  def limit(*args); end
 
   sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def self.offset(*args); end
+  def offset(*args); end
 
   sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def self.joins(*args); end
+  def joins(*args); end
 
   sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def self.left_joins(*args); end
+  def left_joins(*args); end
 
   sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def self.left_outer_joins(*args); end
+  def left_outer_joins(*args); end
 
   sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def self.where(*args); end
+  def where(*args); end
 
   sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def self.rewhere(*args); end
+  def rewhere(*args); end
 
   sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def self.preload(*args); end
+  def preload(*args); end
 
   sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def self.eager_load(*args); end
+  def eager_load(*args); end
 
   sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def self.includes(*args); end
+  def includes(*args); end
 
   sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def self.from(*args); end
+  def from(*args); end
 
   sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def self.lock(*args); end
+  def lock(*args); end
 
   sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def self.readonly(*args); end
+  def readonly(*args); end
 
   sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def self.or(*args); end
+  def or(*args); end
 
   sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def self.having(*args); end
+  def having(*args); end
 
   sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def self.create_with(*args); end
+  def create_with(*args); end
 
   sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def self.distinct(*args); end
+  def distinct(*args); end
 
   sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def self.references(*args); end
+  def references(*args); end
 
   sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def self.none(*args); end
+  def none(*args); end
 
   sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def self.unscope(*args); end
+  def unscope(*args); end
 
   sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def self.merge(*args); end
+  def merge(*args); end
 
   sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def self.except(*args); end
+  def except(*args); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def self.extending(*args, &block); end
+  def extending(*args, &block); end
+end
+
+module Subject::HABTM_Wizards::QueryMethodsReturningAssociationRelation
+  sig { returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
+  def all; end
+
+  sig { params(block: T.nilable(T.proc.void)).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
+  def unscoped(&block); end
+
+  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
+  def select(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
+  def order(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
+  def reorder(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
+  def group(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
+  def limit(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
+  def offset(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
+  def joins(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
+  def left_joins(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
+  def left_outer_joins(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
+  def where(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
+  def rewhere(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
+  def preload(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
+  def eager_load(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
+  def includes(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
+  def from(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
+  def lock(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
+  def readonly(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
+  def or(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
+  def having(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
+  def create_with(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
+  def distinct(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
+  def references(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
+  def none(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
+  def unscope(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
+  def merge(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
+  def except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
+  def extending(*args, &block); end
 end
 
 class Subject::HABTM_Wizards::ActiveRecord_Relation < ActiveRecord::Relation
   include Subject::HABTM_Wizards::ActiveRelation_WhereNot
   include Subject::HABTM_Wizards::CustomFinderMethods
+  include Subject::HABTM_Wizards::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: Subject::HABTM_Wizards)
-
-  sig { returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def extending(*args, &block); end
 end
 
 class Subject::HABTM_Wizards::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
   include Subject::HABTM_Wizards::ActiveRelation_WhereNot
   include Subject::HABTM_Wizards::CustomFinderMethods
+  include Subject::HABTM_Wizards::QueryMethodsReturningAssociationRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: Subject::HABTM_Wizards)
-
-  sig { returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
 end
 
 class Subject::HABTM_Wizards::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include Subject::HABTM_Wizards::CustomFinderMethods
+  include Subject::HABTM_Wizards::QueryMethodsReturningAssociationRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: Subject::HABTM_Wizards)
-
-  sig { returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
 
   sig { params(records: T.any(Subject::HABTM_Wizards, T::Array[Subject::HABTM_Wizards])).returns(T.self_type) }
   def <<(*records); end

--- a/spec/test_data/v5.2/expected_wand.rbi
+++ b/spec/test_data/v5.2/expected_wand.rbi
@@ -216,6 +216,7 @@ class Wand < ApplicationRecord
   include Wand::GeneratedAttributeMethods
   include Wand::GeneratedAssociationMethods
   extend Wand::CustomFinderMethods
+  extend Wand::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   RelationType = T.type_alias { T.any(Wand::ActiveRecord_Relation, Wand::ActiveRecord_Associations_CollectionProxy, Wand::ActiveRecord_AssociationRelation) }
@@ -235,93 +236,6 @@ class Wand < ApplicationRecord
   sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
   def self.unicorn_tail_hair(*args); end
 
-  sig { returns(Wand::ActiveRecord_Relation) }
-  def self.all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def self.unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
-  def self.select(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
-  def self.order(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
-  def self.reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
-  def self.group(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
-  def self.limit(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
-  def self.offset(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
-  def self.joins(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
-  def self.left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
-  def self.left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
-  def self.where(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
-  def self.rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
-  def self.preload(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
-  def self.eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
-  def self.includes(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
-  def self.from(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
-  def self.lock(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
-  def self.readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
-  def self.or(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
-  def self.having(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
-  def self.create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
-  def self.distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
-  def self.references(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
-  def self.none(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
-  def self.unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
-  def self.merge(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
-  def self.except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def self.extending(*args, &block); end
-
   sig { returns(T.nilable(Wand::CoreType)) }
   def typed_core_type; end
 
@@ -335,6 +249,7 @@ end
 class Wand::ActiveRecord_Relation < ActiveRecord::Relation
   include Wand::ActiveRelation_WhereNot
   include Wand::CustomFinderMethods
+  include Wand::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: Wand)
@@ -350,7 +265,62 @@ class Wand::ActiveRecord_Relation < ActiveRecord::Relation
 
   sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
   def unicorn_tail_hair(*args); end
+end
 
+class Wand::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
+  include Wand::ActiveRelation_WhereNot
+  include Wand::CustomFinderMethods
+  include Wand::QueryMethodsReturningAssociationRelation
+  extend T::Sig
+  extend T::Generic
+  Elem = type_member(fixed: Wand)
+
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def basilisk_horn(*args); end
+
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def dragon_heartstring(*args); end
+
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def phoenix_feather(*args); end
+
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def unicorn_tail_hair(*args); end
+end
+
+class Wand::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
+  include Wand::CustomFinderMethods
+  include Wand::QueryMethodsReturningAssociationRelation
+  extend T::Sig
+  extend T::Generic
+  Elem = type_member(fixed: Wand)
+
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def basilisk_horn(*args); end
+
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def dragon_heartstring(*args); end
+
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def phoenix_feather(*args); end
+
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def unicorn_tail_hair(*args); end
+
+  sig { params(records: T.any(Wand, T::Array[Wand])).returns(T.self_type) }
+  def <<(*records); end
+
+  sig { params(records: T.any(Wand, T::Array[Wand])).returns(T.self_type) }
+  def append(*records); end
+
+  sig { params(records: T.any(Wand, T::Array[Wand])).returns(T.self_type) }
+  def push(*records); end
+
+  sig { params(records: T.any(Wand, T::Array[Wand])).returns(T.self_type) }
+  def concat(*records); end
+end
+
+module Wand::QueryMethodsReturningRelation
   sig { returns(Wand::ActiveRecord_Relation) }
   def all; end
 
@@ -439,29 +409,11 @@ class Wand::ActiveRecord_Relation < ActiveRecord::Relation
   def extending(*args, &block); end
 end
 
-class Wand::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
-  include Wand::ActiveRelation_WhereNot
-  include Wand::CustomFinderMethods
-  extend T::Sig
-  extend T::Generic
-  Elem = type_member(fixed: Wand)
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def basilisk_horn(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def dragon_heartstring(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def phoenix_feather(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def unicorn_tail_hair(*args); end
-
+module Wand::QueryMethodsReturningAssociationRelation
   sig { returns(Wand::ActiveRecord_AssociationRelation) }
   def all; end
 
-  sig { params(block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
+  sig { params(block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def unscoped(&block); end
 
   sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
@@ -544,122 +496,4 @@ class Wand::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
   def extending(*args, &block); end
-end
-
-class Wand::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
-  include Wand::CustomFinderMethods
-  extend T::Sig
-  extend T::Generic
-  Elem = type_member(fixed: Wand)
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def basilisk_horn(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def dragon_heartstring(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def phoenix_feather(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def unicorn_tail_hair(*args); end
-
-  sig { returns(Wand::ActiveRecord_AssociationRelation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
-
-  sig { params(records: T.any(Wand, T::Array[Wand])).returns(T.self_type) }
-  def <<(*records); end
-
-  sig { params(records: T.any(Wand, T::Array[Wand])).returns(T.self_type) }
-  def append(*records); end
-
-  sig { params(records: T.any(Wand, T::Array[Wand])).returns(T.self_type) }
-  def push(*records); end
-
-  sig { params(records: T.any(Wand, T::Array[Wand])).returns(T.self_type) }
-  def concat(*records); end
 end

--- a/spec/test_data/v5.2/expected_wand.rbi
+++ b/spec/test_data/v5.2/expected_wand.rbi
@@ -3,8 +3,6 @@
 
 # typed: strong
 module Wand::EnumInstanceMethods
-  extend T::Sig
-
   sig { returns(T::Boolean) }
   def phoenix_feather?; end
 
@@ -36,8 +34,6 @@ module Wand::ActiveRelation_WhereNot
 end
 
 module Wand::GeneratedAttributeMethods
-  extend T::Sig
-
   sig { returns(T::Boolean) }
   def broken; end
 
@@ -185,8 +181,6 @@ class Wand::CoreType < T::Enum
 end
 
 module Wand::GeneratedAssociationMethods
-  extend T::Sig
-
   sig { returns(::Wizard) }
   def wizard; end
 
@@ -217,8 +211,6 @@ class Wand < ApplicationRecord
   include Wand::GeneratedAssociationMethods
   extend Wand::CustomFinderMethods
   extend Wand::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   RelationType = T.type_alias { T.any(Wand::ActiveRecord_Relation, Wand::ActiveRecord_Associations_CollectionProxy, Wand::ActiveRecord_AssociationRelation) }
 
   sig { returns(T::Hash[T.any(String, Symbol), Integer]) }
@@ -250,8 +242,6 @@ class Wand::ActiveRecord_Relation < ActiveRecord::Relation
   include Wand::ActiveRelation_WhereNot
   include Wand::CustomFinderMethods
   include Wand::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Wand)
 
   sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
@@ -271,8 +261,6 @@ class Wand::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
   include Wand::ActiveRelation_WhereNot
   include Wand::CustomFinderMethods
   include Wand::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Wand)
 
   sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
@@ -291,8 +279,6 @@ end
 class Wand::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include Wand::CustomFinderMethods
   include Wand::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Wand)
 
   sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }

--- a/spec/test_data/v5.2/expected_wizard.rbi
+++ b/spec/test_data/v5.2/expected_wizard.rbi
@@ -378,6 +378,7 @@ class Wizard < ApplicationRecord
   include Wizard::GeneratedAttributeMethods
   include Wizard::GeneratedAssociationMethods
   extend Wizard::CustomFinderMethods
+  extend Wizard::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   RelationType = T.type_alias { T.any(Wizard::ActiveRecord_Relation, Wizard::ActiveRecord_Associations_CollectionProxy, Wizard::ActiveRecord_AssociationRelation) }
@@ -460,93 +461,6 @@ class Wizard < ApplicationRecord
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
   def self.with_attached_school_photo(*args); end
 
-  sig { returns(Wizard::ActiveRecord_Relation) }
-  def self.all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.select(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.order(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.group(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.limit(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.offset(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.joins(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.where(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.preload(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.includes(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.from(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.lock(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.or(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.having(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.references(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.none(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.merge(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.extending(*args, &block); end
-
   sig { returns(T.nilable(Wizard::Broom)) }
   def typed_broom; end
 
@@ -587,6 +501,7 @@ end
 class Wizard::ActiveRecord_Relation < ActiveRecord::Relation
   include Wizard::ActiveRelation_WhereNot
   include Wizard::CustomFinderMethods
+  include Wizard::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: Wizard)
@@ -650,7 +565,158 @@ class Wizard::ActiveRecord_Relation < ActiveRecord::Relation
 
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
   def with_attached_school_photo(*args); end
+end
 
+class Wizard::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
+  include Wizard::ActiveRelation_WhereNot
+  include Wizard::CustomFinderMethods
+  include Wizard::QueryMethodsReturningAssociationRelation
+  extend T::Sig
+  extend T::Generic
+  Elem = type_member(fixed: Wizard)
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def Gryffindor(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def Hagrid(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def Hufflepuff(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def Ravenclaw(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def Slytherin(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def black_hair(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def blonde_hair(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def broom_firebolt(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def broom_nimbus(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def brown_hair(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def color_blue_eyes(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def color_brown_eyes(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def color_green_eyes(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def quidditch_beater(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def quidditch_chaser(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def quidditch_keeper(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def quidditch_seeker(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def recent(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def with_attached_hats(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def with_attached_school_photo(*args); end
+end
+
+class Wizard::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
+  include Wizard::CustomFinderMethods
+  include Wizard::QueryMethodsReturningAssociationRelation
+  extend T::Sig
+  extend T::Generic
+  Elem = type_member(fixed: Wizard)
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def Gryffindor(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def Hagrid(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def Hufflepuff(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def Ravenclaw(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def Slytherin(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def black_hair(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def blonde_hair(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def broom_firebolt(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def broom_nimbus(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def brown_hair(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def color_blue_eyes(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def color_brown_eyes(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def color_green_eyes(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def quidditch_beater(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def quidditch_chaser(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def quidditch_keeper(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def quidditch_seeker(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def recent(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def with_attached_hats(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def with_attached_school_photo(*args); end
+
+  sig { params(records: T.any(Wizard, T::Array[Wizard])).returns(T.self_type) }
+  def <<(*records); end
+
+  sig { params(records: T.any(Wizard, T::Array[Wizard])).returns(T.self_type) }
+  def append(*records); end
+
+  sig { params(records: T.any(Wizard, T::Array[Wizard])).returns(T.self_type) }
+  def push(*records); end
+
+  sig { params(records: T.any(Wizard, T::Array[Wizard])).returns(T.self_type) }
+  def concat(*records); end
+end
+
+module Wizard::QueryMethodsReturningRelation
   sig { returns(Wizard::ActiveRecord_Relation) }
   def all; end
 
@@ -739,77 +805,11 @@ class Wizard::ActiveRecord_Relation < ActiveRecord::Relation
   def extending(*args, &block); end
 end
 
-class Wizard::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
-  include Wizard::ActiveRelation_WhereNot
-  include Wizard::CustomFinderMethods
-  extend T::Sig
-  extend T::Generic
-  Elem = type_member(fixed: Wizard)
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def Gryffindor(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def Hagrid(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def Hufflepuff(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def Ravenclaw(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def Slytherin(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def black_hair(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def blonde_hair(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def broom_firebolt(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def broom_nimbus(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def brown_hair(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def color_blue_eyes(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def color_brown_eyes(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def color_green_eyes(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def quidditch_beater(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def quidditch_chaser(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def quidditch_keeper(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def quidditch_seeker(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def recent(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def with_attached_hats(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def with_attached_school_photo(*args); end
-
+module Wizard::QueryMethodsReturningAssociationRelation
   sig { returns(Wizard::ActiveRecord_AssociationRelation) }
   def all; end
 
-  sig { params(block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
+  sig { params(block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def unscoped(&block); end
 
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
@@ -892,170 +892,4 @@ class Wizard::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelati
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
   def extending(*args, &block); end
-end
-
-class Wizard::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
-  include Wizard::CustomFinderMethods
-  extend T::Sig
-  extend T::Generic
-  Elem = type_member(fixed: Wizard)
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def Gryffindor(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def Hagrid(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def Hufflepuff(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def Ravenclaw(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def Slytherin(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def black_hair(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def blonde_hair(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def broom_firebolt(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def broom_nimbus(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def brown_hair(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def color_blue_eyes(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def color_brown_eyes(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def color_green_eyes(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def quidditch_beater(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def quidditch_chaser(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def quidditch_keeper(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def quidditch_seeker(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def recent(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def with_attached_hats(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def with_attached_school_photo(*args); end
-
-  sig { returns(Wizard::ActiveRecord_AssociationRelation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
-
-  sig { params(records: T.any(Wizard, T::Array[Wizard])).returns(T.self_type) }
-  def <<(*records); end
-
-  sig { params(records: T.any(Wizard, T::Array[Wizard])).returns(T.self_type) }
-  def append(*records); end
-
-  sig { params(records: T.any(Wizard, T::Array[Wizard])).returns(T.self_type) }
-  def push(*records); end
-
-  sig { params(records: T.any(Wizard, T::Array[Wizard])).returns(T.self_type) }
-  def concat(*records); end
 end

--- a/spec/test_data/v5.2/expected_wizard.rbi
+++ b/spec/test_data/v5.2/expected_wizard.rbi
@@ -3,8 +3,6 @@
 
 # typed: strong
 module Wizard::EnumInstanceMethods
-  extend T::Sig
-
   sig { returns(T::Boolean) }
   def broom_nimbus?; end
 
@@ -114,8 +112,6 @@ module Wizard::ActiveRelation_WhereNot
 end
 
 module Wizard::GeneratedAttributeMethods
-  extend T::Sig
-
   sig { returns(T::Boolean) }
   def broom?; end
 
@@ -293,8 +289,6 @@ class Wizard::QuidditchPosition < T::Enum
 end
 
 module Wizard::GeneratedAssociationMethods
-  extend T::Sig
-
   sig { returns(::ActiveStorage::Attachment::ActiveRecord_Associations_CollectionProxy) }
   def hats_attachments; end
 
@@ -379,8 +373,6 @@ class Wizard < ApplicationRecord
   include Wizard::GeneratedAssociationMethods
   extend Wizard::CustomFinderMethods
   extend Wizard::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   RelationType = T.type_alias { T.any(Wizard::ActiveRecord_Relation, Wizard::ActiveRecord_Associations_CollectionProxy, Wizard::ActiveRecord_AssociationRelation) }
 
   sig { returns(T::Hash[T.any(String, Symbol), String]) }
@@ -502,8 +494,6 @@ class Wizard::ActiveRecord_Relation < ActiveRecord::Relation
   include Wizard::ActiveRelation_WhereNot
   include Wizard::CustomFinderMethods
   include Wizard::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Wizard)
 
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
@@ -571,8 +561,6 @@ class Wizard::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelati
   include Wizard::ActiveRelation_WhereNot
   include Wizard::CustomFinderMethods
   include Wizard::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Wizard)
 
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
@@ -639,8 +627,6 @@ end
 class Wizard::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include Wizard::CustomFinderMethods
   include Wizard::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Wizard)
 
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }

--- a/spec/test_data/v5.2/expected_wizard/habtm_subjects.rbi
+++ b/spec/test_data/v5.2/expected_wizard/habtm_subjects.rbi
@@ -8,8 +8,6 @@ module Wizard::HABTM_Subjects::ActiveRelation_WhereNot
 end
 
 module Wizard::HABTM_Subjects::GeneratedAttributeMethods
-  extend T::Sig
-
   sig { returns(T.nilable(Integer)) }
   def subject_id; end
 
@@ -30,8 +28,6 @@ module Wizard::HABTM_Subjects::GeneratedAttributeMethods
 end
 
 module Wizard::HABTM_Subjects::GeneratedAssociationMethods
-  extend T::Sig
-
   sig { returns(T.nilable(::Wizard)) }
   def left_side; end
 
@@ -67,8 +63,6 @@ class Wizard::HABTM_Subjects < ActiveRecord::Base
   include Wizard::HABTM_Subjects::GeneratedAssociationMethods
   extend Wizard::HABTM_Subjects::CustomFinderMethods
   extend Wizard::HABTM_Subjects::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   RelationType = T.type_alias { T.any(Wizard::HABTM_Subjects::ActiveRecord_Relation, Wizard::HABTM_Subjects::ActiveRecord_Associations_CollectionProxy, Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
 end
 
@@ -254,8 +248,6 @@ class Wizard::HABTM_Subjects::ActiveRecord_Relation < ActiveRecord::Relation
   include Wizard::HABTM_Subjects::ActiveRelation_WhereNot
   include Wizard::HABTM_Subjects::CustomFinderMethods
   include Wizard::HABTM_Subjects::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Wizard::HABTM_Subjects)
 end
 
@@ -263,16 +255,12 @@ class Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation < ActiveRecord::A
   include Wizard::HABTM_Subjects::ActiveRelation_WhereNot
   include Wizard::HABTM_Subjects::CustomFinderMethods
   include Wizard::HABTM_Subjects::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Wizard::HABTM_Subjects)
 end
 
 class Wizard::HABTM_Subjects::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include Wizard::HABTM_Subjects::CustomFinderMethods
   include Wizard::HABTM_Subjects::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Wizard::HABTM_Subjects)
 
   sig { params(records: T.any(Wizard::HABTM_Subjects, T::Array[Wizard::HABTM_Subjects])).returns(T.self_type) }

--- a/spec/test_data/v5.2/expected_wizard/habtm_subjects.rbi
+++ b/spec/test_data/v5.2/expected_wizard/habtm_subjects.rbi
@@ -66,380 +66,214 @@ class Wizard::HABTM_Subjects < ActiveRecord::Base
   include Wizard::HABTM_Subjects::GeneratedAttributeMethods
   include Wizard::HABTM_Subjects::GeneratedAssociationMethods
   extend Wizard::HABTM_Subjects::CustomFinderMethods
+  extend Wizard::HABTM_Subjects::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   RelationType = T.type_alias { T.any(Wizard::HABTM_Subjects::ActiveRecord_Relation, Wizard::HABTM_Subjects::ActiveRecord_Associations_CollectionProxy, Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
+end
 
+module Wizard::HABTM_Subjects::QueryMethodsReturningRelation
   sig { returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def self.all; end
+  def all; end
 
   sig { params(block: T.nilable(T.proc.void)).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def self.unscoped(&block); end
+  def unscoped(&block); end
 
   sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def self.select(*args); end
+  def select(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def self.order(*args); end
+  def order(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def self.reorder(*args); end
+  def reorder(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def self.group(*args); end
+  def group(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def self.limit(*args); end
+  def limit(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def self.offset(*args); end
+  def offset(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def self.joins(*args); end
+  def joins(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def self.left_joins(*args); end
+  def left_joins(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def self.left_outer_joins(*args); end
+  def left_outer_joins(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def self.where(*args); end
+  def where(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def self.rewhere(*args); end
+  def rewhere(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def self.preload(*args); end
+  def preload(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def self.eager_load(*args); end
+  def eager_load(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def self.includes(*args); end
+  def includes(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def self.from(*args); end
+  def from(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def self.lock(*args); end
+  def lock(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def self.readonly(*args); end
+  def readonly(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def self.or(*args); end
+  def or(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def self.having(*args); end
+  def having(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def self.create_with(*args); end
+  def create_with(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def self.distinct(*args); end
+  def distinct(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def self.references(*args); end
+  def references(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def self.none(*args); end
+  def none(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def self.unscope(*args); end
+  def unscope(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def self.merge(*args); end
+  def merge(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def self.except(*args); end
+  def except(*args); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def self.extending(*args, &block); end
+  def extending(*args, &block); end
+end
+
+module Wizard::HABTM_Subjects::QueryMethodsReturningAssociationRelation
+  sig { returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
+  def all; end
+
+  sig { params(block: T.nilable(T.proc.void)).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
+  def unscoped(&block); end
+
+  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
+  def select(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
+  def order(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
+  def reorder(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
+  def group(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
+  def limit(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
+  def offset(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
+  def joins(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
+  def left_joins(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
+  def left_outer_joins(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
+  def where(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
+  def rewhere(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
+  def preload(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
+  def eager_load(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
+  def includes(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
+  def from(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
+  def lock(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
+  def readonly(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
+  def or(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
+  def having(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
+  def create_with(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
+  def distinct(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
+  def references(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
+  def none(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
+  def unscope(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
+  def merge(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
+  def except(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
+  def extending(*args, &block); end
 end
 
 class Wizard::HABTM_Subjects::ActiveRecord_Relation < ActiveRecord::Relation
   include Wizard::HABTM_Subjects::ActiveRelation_WhereNot
   include Wizard::HABTM_Subjects::CustomFinderMethods
+  include Wizard::HABTM_Subjects::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: Wizard::HABTM_Subjects)
-
-  sig { returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def extending(*args, &block); end
 end
 
 class Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
   include Wizard::HABTM_Subjects::ActiveRelation_WhereNot
   include Wizard::HABTM_Subjects::CustomFinderMethods
+  include Wizard::HABTM_Subjects::QueryMethodsReturningAssociationRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: Wizard::HABTM_Subjects)
-
-  sig { returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
 end
 
 class Wizard::HABTM_Subjects::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include Wizard::HABTM_Subjects::CustomFinderMethods
+  include Wizard::HABTM_Subjects::QueryMethodsReturningAssociationRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: Wizard::HABTM_Subjects)
-
-  sig { returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
 
   sig { params(records: T.any(Wizard::HABTM_Subjects, T::Array[Wizard::HABTM_Subjects])).returns(T.self_type) }
   def <<(*records); end

--- a/spec/test_data/v5.2/expected_wizard_wo_spellbook.rbi
+++ b/spec/test_data/v5.2/expected_wizard_wo_spellbook.rbi
@@ -372,6 +372,7 @@ class Wizard < ApplicationRecord
   include Wizard::GeneratedAttributeMethods
   include Wizard::GeneratedAssociationMethods
   extend Wizard::CustomFinderMethods
+  extend Wizard::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   RelationType = T.type_alias { T.any(Wizard::ActiveRecord_Relation, Wizard::ActiveRecord_Associations_CollectionProxy, Wizard::ActiveRecord_AssociationRelation) }
@@ -454,93 +455,6 @@ class Wizard < ApplicationRecord
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
   def self.with_attached_school_photo(*args); end
 
-  sig { returns(Wizard::ActiveRecord_Relation) }
-  def self.all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.select(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.order(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.group(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.limit(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.offset(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.joins(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.where(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.preload(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.includes(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.from(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.lock(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.or(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.having(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.references(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.none(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.merge(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.extending(*args, &block); end
-
   sig { returns(T.nilable(Wizard::Broom)) }
   def typed_broom; end
 
@@ -581,6 +495,7 @@ end
 class Wizard::ActiveRecord_Relation < ActiveRecord::Relation
   include Wizard::ActiveRelation_WhereNot
   include Wizard::CustomFinderMethods
+  include Wizard::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: Wizard)
@@ -644,7 +559,158 @@ class Wizard::ActiveRecord_Relation < ActiveRecord::Relation
 
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
   def with_attached_school_photo(*args); end
+end
 
+class Wizard::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
+  include Wizard::ActiveRelation_WhereNot
+  include Wizard::CustomFinderMethods
+  include Wizard::QueryMethodsReturningAssociationRelation
+  extend T::Sig
+  extend T::Generic
+  Elem = type_member(fixed: Wizard)
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def Gryffindor(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def Hagrid(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def Hufflepuff(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def Ravenclaw(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def Slytherin(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def black_hair(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def blonde_hair(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def broom_firebolt(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def broom_nimbus(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def brown_hair(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def color_blue_eyes(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def color_brown_eyes(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def color_green_eyes(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def quidditch_beater(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def quidditch_chaser(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def quidditch_keeper(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def quidditch_seeker(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def recent(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def with_attached_hats(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def with_attached_school_photo(*args); end
+end
+
+class Wizard::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
+  include Wizard::CustomFinderMethods
+  include Wizard::QueryMethodsReturningAssociationRelation
+  extend T::Sig
+  extend T::Generic
+  Elem = type_member(fixed: Wizard)
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def Gryffindor(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def Hagrid(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def Hufflepuff(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def Ravenclaw(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def Slytherin(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def black_hair(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def blonde_hair(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def broom_firebolt(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def broom_nimbus(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def brown_hair(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def color_blue_eyes(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def color_brown_eyes(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def color_green_eyes(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def quidditch_beater(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def quidditch_chaser(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def quidditch_keeper(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def quidditch_seeker(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def recent(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def with_attached_hats(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def with_attached_school_photo(*args); end
+
+  sig { params(records: T.any(Wizard, T::Array[Wizard])).returns(T.self_type) }
+  def <<(*records); end
+
+  sig { params(records: T.any(Wizard, T::Array[Wizard])).returns(T.self_type) }
+  def append(*records); end
+
+  sig { params(records: T.any(Wizard, T::Array[Wizard])).returns(T.self_type) }
+  def push(*records); end
+
+  sig { params(records: T.any(Wizard, T::Array[Wizard])).returns(T.self_type) }
+  def concat(*records); end
+end
+
+module Wizard::QueryMethodsReturningRelation
   sig { returns(Wizard::ActiveRecord_Relation) }
   def all; end
 
@@ -733,77 +799,11 @@ class Wizard::ActiveRecord_Relation < ActiveRecord::Relation
   def extending(*args, &block); end
 end
 
-class Wizard::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
-  include Wizard::ActiveRelation_WhereNot
-  include Wizard::CustomFinderMethods
-  extend T::Sig
-  extend T::Generic
-  Elem = type_member(fixed: Wizard)
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def Gryffindor(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def Hagrid(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def Hufflepuff(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def Ravenclaw(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def Slytherin(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def black_hair(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def blonde_hair(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def broom_firebolt(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def broom_nimbus(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def brown_hair(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def color_blue_eyes(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def color_brown_eyes(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def color_green_eyes(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def quidditch_beater(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def quidditch_chaser(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def quidditch_keeper(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def quidditch_seeker(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def recent(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def with_attached_hats(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def with_attached_school_photo(*args); end
-
+module Wizard::QueryMethodsReturningAssociationRelation
   sig { returns(Wizard::ActiveRecord_AssociationRelation) }
   def all; end
 
-  sig { params(block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
+  sig { params(block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def unscoped(&block); end
 
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
@@ -886,170 +886,4 @@ class Wizard::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelati
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
   def extending(*args, &block); end
-end
-
-class Wizard::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
-  include Wizard::CustomFinderMethods
-  extend T::Sig
-  extend T::Generic
-  Elem = type_member(fixed: Wizard)
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def Gryffindor(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def Hagrid(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def Hufflepuff(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def Ravenclaw(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def Slytherin(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def black_hair(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def blonde_hair(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def broom_firebolt(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def broom_nimbus(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def brown_hair(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def color_blue_eyes(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def color_brown_eyes(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def color_green_eyes(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def quidditch_beater(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def quidditch_chaser(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def quidditch_keeper(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def quidditch_seeker(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def recent(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def with_attached_hats(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def with_attached_school_photo(*args); end
-
-  sig { returns(Wizard::ActiveRecord_AssociationRelation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
-
-  sig { params(records: T.any(Wizard, T::Array[Wizard])).returns(T.self_type) }
-  def <<(*records); end
-
-  sig { params(records: T.any(Wizard, T::Array[Wizard])).returns(T.self_type) }
-  def append(*records); end
-
-  sig { params(records: T.any(Wizard, T::Array[Wizard])).returns(T.self_type) }
-  def push(*records); end
-
-  sig { params(records: T.any(Wizard, T::Array[Wizard])).returns(T.self_type) }
-  def concat(*records); end
 end

--- a/spec/test_data/v5.2/expected_wizard_wo_spellbook.rbi
+++ b/spec/test_data/v5.2/expected_wizard_wo_spellbook.rbi
@@ -3,8 +3,6 @@
 
 # typed: strong
 module Wizard::EnumInstanceMethods
-  extend T::Sig
-
   sig { returns(T::Boolean) }
   def broom_nimbus?; end
 
@@ -114,8 +112,6 @@ module Wizard::ActiveRelation_WhereNot
 end
 
 module Wizard::GeneratedAttributeMethods
-  extend T::Sig
-
   sig { returns(T::Boolean) }
   def broom?; end
 
@@ -293,8 +289,6 @@ class Wizard::QuidditchPosition < T::Enum
 end
 
 module Wizard::GeneratedAssociationMethods
-  extend T::Sig
-
   sig { returns(::ActiveStorage::Attachment::ActiveRecord_Associations_CollectionProxy) }
   def hats_attachments; end
 
@@ -373,8 +367,6 @@ class Wizard < ApplicationRecord
   include Wizard::GeneratedAssociationMethods
   extend Wizard::CustomFinderMethods
   extend Wizard::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   RelationType = T.type_alias { T.any(Wizard::ActiveRecord_Relation, Wizard::ActiveRecord_Associations_CollectionProxy, Wizard::ActiveRecord_AssociationRelation) }
 
   sig { returns(T::Hash[T.any(String, Symbol), String]) }
@@ -496,8 +488,6 @@ class Wizard::ActiveRecord_Relation < ActiveRecord::Relation
   include Wizard::ActiveRelation_WhereNot
   include Wizard::CustomFinderMethods
   include Wizard::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Wizard)
 
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
@@ -565,8 +555,6 @@ class Wizard::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelati
   include Wizard::ActiveRelation_WhereNot
   include Wizard::CustomFinderMethods
   include Wizard::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Wizard)
 
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
@@ -633,8 +621,6 @@ end
 class Wizard::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include Wizard::CustomFinderMethods
   include Wizard::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Wizard)
 
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }

--- a/spec/test_data/v6.0/expected_attachment.rbi
+++ b/spec/test_data/v6.0/expected_attachment.rbi
@@ -8,8 +8,6 @@ module ActiveStorage::Attachment::ActiveRelation_WhereNot
 end
 
 module ActiveStorage::Attachment::GeneratedAssociationMethods
-  extend T::Sig
-
   sig { returns(::ActiveStorage::Blob) }
   def blob; end
 
@@ -44,8 +42,6 @@ class ActiveStorage::Attachment < ActiveRecord::Base
   include ActiveStorage::Attachment::GeneratedAssociationMethods
   extend ActiveStorage::Attachment::CustomFinderMethods
   extend ActiveStorage::Attachment::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   RelationType = T.type_alias { T.any(ActiveStorage::Attachment::ActiveRecord_Relation, ActiveStorage::Attachment::ActiveRecord_Associations_CollectionProxy, ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
 end
 
@@ -255,8 +251,6 @@ class ActiveStorage::Attachment::ActiveRecord_Relation < ActiveRecord::Relation
   include ActiveStorage::Attachment::ActiveRelation_WhereNot
   include ActiveStorage::Attachment::CustomFinderMethods
   include ActiveStorage::Attachment::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: ActiveStorage::Attachment)
 end
 
@@ -264,16 +258,12 @@ class ActiveStorage::Attachment::ActiveRecord_AssociationRelation < ActiveRecord
   include ActiveStorage::Attachment::ActiveRelation_WhereNot
   include ActiveStorage::Attachment::CustomFinderMethods
   include ActiveStorage::Attachment::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: ActiveStorage::Attachment)
 end
 
 class ActiveStorage::Attachment::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include ActiveStorage::Attachment::CustomFinderMethods
   include ActiveStorage::Attachment::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: ActiveStorage::Attachment)
 
   sig { params(records: T.any(ActiveStorage::Attachment, T::Array[ActiveStorage::Attachment])).returns(T.self_type) }

--- a/spec/test_data/v6.0/expected_attachment.rbi
+++ b/spec/test_data/v6.0/expected_attachment.rbi
@@ -43,428 +43,238 @@ end
 class ActiveStorage::Attachment < ActiveRecord::Base
   include ActiveStorage::Attachment::GeneratedAssociationMethods
   extend ActiveStorage::Attachment::CustomFinderMethods
+  extend ActiveStorage::Attachment::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   RelationType = T.type_alias { T.any(ActiveStorage::Attachment::ActiveRecord_Relation, ActiveStorage::Attachment::ActiveRecord_Associations_CollectionProxy, ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+end
 
+module ActiveStorage::Attachment::QueryMethodsReturningRelation
   sig { returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def self.all; end
+  def all; end
 
   sig { params(block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def self.unscoped(&block); end
+  def unscoped(&block); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def self.select(*args); end
+  def select(*args); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def self.reselect(*args); end
+  def reselect(*args); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def self.order(*args); end
+  def order(*args); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def self.reorder(*args); end
+  def reorder(*args); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def self.group(*args); end
+  def group(*args); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def self.limit(*args); end
+  def limit(*args); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def self.offset(*args); end
+  def offset(*args); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def self.joins(*args); end
+  def joins(*args); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def self.left_joins(*args); end
+  def left_joins(*args); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def self.left_outer_joins(*args); end
+  def left_outer_joins(*args); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def self.where(*args); end
+  def where(*args); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def self.rewhere(*args); end
+  def rewhere(*args); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def self.preload(*args); end
+  def preload(*args); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def self.extract_associated(*args); end
+  def extract_associated(*args); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def self.eager_load(*args); end
+  def eager_load(*args); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def self.includes(*args); end
+  def includes(*args); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def self.from(*args); end
+  def from(*args); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def self.lock(*args); end
+  def lock(*args); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def self.readonly(*args); end
+  def readonly(*args); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def self.or(*args); end
+  def or(*args); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def self.having(*args); end
+  def having(*args); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def self.create_with(*args); end
+  def create_with(*args); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def self.distinct(*args); end
+  def distinct(*args); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def self.references(*args); end
+  def references(*args); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def self.none(*args); end
+  def none(*args); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def self.unscope(*args); end
+  def unscope(*args); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def self.optimizer_hints(*args); end
+  def optimizer_hints(*args); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def self.merge(*args); end
+  def merge(*args); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def self.except(*args); end
+  def except(*args); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def self.only(*args); end
+  def only(*args); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def self.extending(*args, &block); end
+  def extending(*args, &block); end
+end
+
+module ActiveStorage::Attachment::QueryMethodsReturningAssociationRelation
+  sig { returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def all; end
+
+  sig { params(block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
+  def unscoped(&block); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def select(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def reselect(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def order(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def reorder(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def group(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def limit(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def offset(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def joins(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def left_joins(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def left_outer_joins(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def where(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def rewhere(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def preload(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def extract_associated(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def eager_load(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def includes(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def from(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def lock(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def readonly(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def or(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def having(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def create_with(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def distinct(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def references(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def none(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def unscope(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def optimizer_hints(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def merge(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def except(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def only(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def extending(*args, &block); end
 end
 
 class ActiveStorage::Attachment::ActiveRecord_Relation < ActiveRecord::Relation
   include ActiveStorage::Attachment::ActiveRelation_WhereNot
   include ActiveStorage::Attachment::CustomFinderMethods
+  include ActiveStorage::Attachment::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: ActiveStorage::Attachment)
-
-  sig { returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def reselect(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def extract_associated(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def optimizer_hints(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def only(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
-  def extending(*args, &block); end
 end
 
 class ActiveStorage::Attachment::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
   include ActiveStorage::Attachment::ActiveRelation_WhereNot
   include ActiveStorage::Attachment::CustomFinderMethods
+  include ActiveStorage::Attachment::QueryMethodsReturningAssociationRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: ActiveStorage::Attachment)
-
-  sig { returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def reselect(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def extract_associated(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def optimizer_hints(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def only(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
 end
 
 class ActiveStorage::Attachment::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include ActiveStorage::Attachment::CustomFinderMethods
+  include ActiveStorage::Attachment::QueryMethodsReturningAssociationRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: ActiveStorage::Attachment)
-
-  sig { returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def reselect(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def extract_associated(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def optimizer_hints(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def only(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
 
   sig { params(records: T.any(ActiveStorage::Attachment, T::Array[ActiveStorage::Attachment])).returns(T.self_type) }
   def <<(*records); end

--- a/spec/test_data/v6.0/expected_blob.rbi
+++ b/spec/test_data/v6.0/expected_blob.rbi
@@ -28,8 +28,6 @@ class ActiveStorage::Blob < ActiveRecord::Base
   include ActiveStorage::Blob::GeneratedAssociationMethods
   extend ActiveStorage::Blob::CustomFinderMethods
   extend ActiveStorage::Blob::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   RelationType = T.type_alias { T.any(ActiveStorage::Blob::ActiveRecord_Relation, ActiveStorage::Blob::ActiveRecord_Associations_CollectionProxy, ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
 end
 
@@ -251,8 +249,6 @@ class ActiveStorage::Blob::ActiveRecord_Relation < ActiveRecord::Relation
   include ActiveStorage::Blob::ActiveRelation_WhereNot
   include ActiveStorage::Blob::CustomFinderMethods
   include ActiveStorage::Blob::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: ActiveStorage::Blob)
 end
 
@@ -260,14 +256,10 @@ class ActiveStorage::Blob::ActiveRecord_AssociationRelation < ActiveRecord::Asso
   include ActiveStorage::Blob::ActiveRelation_WhereNot
   include ActiveStorage::Blob::CustomFinderMethods
   include ActiveStorage::Blob::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: ActiveStorage::Blob)
 end
 
 module ActiveStorage::Blob::GeneratedAssociationMethods
-  extend T::Sig
-
   sig { returns(::ActiveStorage::Attachment::ActiveRecord_Associations_CollectionProxy) }
   def attachments; end
 
@@ -299,8 +291,6 @@ end
 class ActiveStorage::Blob::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include ActiveStorage::Blob::CustomFinderMethods
   include ActiveStorage::Blob::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: ActiveStorage::Blob)
 
   sig { params(records: T.any(ActiveStorage::Blob, T::Array[ActiveStorage::Blob])).returns(T.self_type) }

--- a/spec/test_data/v6.0/expected_blob.rbi
+++ b/spec/test_data/v6.0/expected_blob.rbi
@@ -27,464 +27,242 @@ end
 class ActiveStorage::Blob < ActiveRecord::Base
   include ActiveStorage::Blob::GeneratedAssociationMethods
   extend ActiveStorage::Blob::CustomFinderMethods
+  extend ActiveStorage::Blob::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   RelationType = T.type_alias { T.any(ActiveStorage::Blob::ActiveRecord_Relation, ActiveStorage::Blob::ActiveRecord_Associations_CollectionProxy, ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+end
+
+module ActiveStorage::Blob::QueryMethodsReturningRelation
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def unattached(*args); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def self.unattached(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def self.with_attached_preview_image(*args); end
+  def with_attached_preview_image(*args); end
 
   sig { returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def self.all; end
+  def all; end
 
   sig { params(block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def self.unscoped(&block); end
+  def unscoped(&block); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def self.select(*args); end
+  def select(*args); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def self.reselect(*args); end
+  def reselect(*args); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def self.order(*args); end
+  def order(*args); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def self.reorder(*args); end
+  def reorder(*args); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def self.group(*args); end
+  def group(*args); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def self.limit(*args); end
+  def limit(*args); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def self.offset(*args); end
+  def offset(*args); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def self.joins(*args); end
+  def joins(*args); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def self.left_joins(*args); end
+  def left_joins(*args); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def self.left_outer_joins(*args); end
+  def left_outer_joins(*args); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def self.where(*args); end
+  def where(*args); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def self.rewhere(*args); end
+  def rewhere(*args); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def self.preload(*args); end
+  def preload(*args); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def self.extract_associated(*args); end
+  def extract_associated(*args); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def self.eager_load(*args); end
+  def eager_load(*args); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def self.includes(*args); end
+  def includes(*args); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def self.from(*args); end
+  def from(*args); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def self.lock(*args); end
+  def lock(*args); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def self.readonly(*args); end
+  def readonly(*args); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def self.or(*args); end
+  def or(*args); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def self.having(*args); end
+  def having(*args); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def self.create_with(*args); end
+  def create_with(*args); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def self.distinct(*args); end
+  def distinct(*args); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def self.references(*args); end
+  def references(*args); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def self.none(*args); end
+  def none(*args); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def self.unscope(*args); end
+  def unscope(*args); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def self.optimizer_hints(*args); end
+  def optimizer_hints(*args); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def self.merge(*args); end
+  def merge(*args); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def self.except(*args); end
+  def except(*args); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def self.only(*args); end
+  def only(*args); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def self.extending(*args, &block); end
+  def extending(*args, &block); end
+end
+
+module ActiveStorage::Blob::QueryMethodsReturningAssociationRelation
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def unattached(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def with_attached_preview_image(*args); end
+
+  sig { returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def all; end
+
+  sig { params(block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def unscoped(&block); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def select(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def reselect(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def order(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def reorder(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def group(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def limit(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def offset(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def joins(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def left_joins(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def left_outer_joins(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def where(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def rewhere(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def preload(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def extract_associated(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def eager_load(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def includes(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def from(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def lock(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def readonly(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def or(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def having(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def create_with(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def distinct(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def references(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def none(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def unscope(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def optimizer_hints(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def merge(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def except(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def only(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def extending(*args, &block); end
 end
 
 class ActiveStorage::Blob::ActiveRecord_Relation < ActiveRecord::Relation
   include ActiveStorage::Blob::ActiveRelation_WhereNot
   include ActiveStorage::Blob::CustomFinderMethods
+  include ActiveStorage::Blob::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: ActiveStorage::Blob)
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def unattached(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def with_attached_preview_image(*args); end
-
-  sig { returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def reselect(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def extract_associated(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def optimizer_hints(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def only(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
-  def extending(*args, &block); end
 end
 
 class ActiveStorage::Blob::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
   include ActiveStorage::Blob::ActiveRelation_WhereNot
   include ActiveStorage::Blob::CustomFinderMethods
+  include ActiveStorage::Blob::QueryMethodsReturningAssociationRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: ActiveStorage::Blob)
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def unattached(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def with_attached_preview_image(*args); end
-
-  sig { returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def reselect(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def extract_associated(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def optimizer_hints(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def only(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
-end
-
-class ActiveStorage::Blob::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
-  include ActiveStorage::Blob::CustomFinderMethods
-  extend T::Sig
-  extend T::Generic
-  Elem = type_member(fixed: ActiveStorage::Blob)
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def unattached(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def with_attached_preview_image(*args); end
-
-  sig { returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def reselect(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def extract_associated(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def optimizer_hints(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def only(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
-
-  sig { params(records: T.any(ActiveStorage::Blob, T::Array[ActiveStorage::Blob])).returns(T.self_type) }
-  def <<(*records); end
-
-  sig { params(records: T.any(ActiveStorage::Blob, T::Array[ActiveStorage::Blob])).returns(T.self_type) }
-  def append(*records); end
-
-  sig { params(records: T.any(ActiveStorage::Blob, T::Array[ActiveStorage::Blob])).returns(T.self_type) }
-  def push(*records); end
-
-  sig { params(records: T.any(ActiveStorage::Blob, T::Array[ActiveStorage::Blob])).returns(T.self_type) }
-  def concat(*records); end
 end
 
 module ActiveStorage::Blob::GeneratedAssociationMethods
@@ -516,4 +294,24 @@ module ActiveStorage::Blob::GeneratedAssociationMethods
 
   sig { params(attachable: T.untyped).returns(T.untyped) }
   def preview_image=(attachable); end
+end
+
+class ActiveStorage::Blob::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
+  include ActiveStorage::Blob::CustomFinderMethods
+  include ActiveStorage::Blob::QueryMethodsReturningAssociationRelation
+  extend T::Sig
+  extend T::Generic
+  Elem = type_member(fixed: ActiveStorage::Blob)
+
+  sig { params(records: T.any(ActiveStorage::Blob, T::Array[ActiveStorage::Blob])).returns(T.self_type) }
+  def <<(*records); end
+
+  sig { params(records: T.any(ActiveStorage::Blob, T::Array[ActiveStorage::Blob])).returns(T.self_type) }
+  def append(*records); end
+
+  sig { params(records: T.any(ActiveStorage::Blob, T::Array[ActiveStorage::Blob])).returns(T.self_type) }
+  def push(*records); end
+
+  sig { params(records: T.any(ActiveStorage::Blob, T::Array[ActiveStorage::Blob])).returns(T.self_type) }
+  def concat(*records); end
 end

--- a/spec/test_data/v6.0/expected_headmaster.rbi
+++ b/spec/test_data/v6.0/expected_headmaster.rbi
@@ -8,8 +8,6 @@ module Headmaster::ActiveRelation_WhereNot
 end
 
 module Headmaster::GeneratedAttributeMethods
-  extend T::Sig
-
   sig { returns(Integer) }
   def id; end
 
@@ -39,8 +37,6 @@ module Headmaster::GeneratedAttributeMethods
 end
 
 module Headmaster::GeneratedAssociationMethods
-  extend T::Sig
-
   sig { returns(::School) }
   def school; end
 
@@ -76,8 +72,6 @@ class Headmaster < ApplicationRecord
   include Headmaster::GeneratedAssociationMethods
   extend Headmaster::CustomFinderMethods
   extend Headmaster::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   RelationType = T.type_alias { T.any(Headmaster::ActiveRecord_Relation, Headmaster::ActiveRecord_Associations_CollectionProxy, Headmaster::ActiveRecord_AssociationRelation) }
 end
 
@@ -287,8 +281,6 @@ class Headmaster::ActiveRecord_Relation < ActiveRecord::Relation
   include Headmaster::ActiveRelation_WhereNot
   include Headmaster::CustomFinderMethods
   include Headmaster::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Headmaster)
 end
 
@@ -296,16 +288,12 @@ class Headmaster::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRe
   include Headmaster::ActiveRelation_WhereNot
   include Headmaster::CustomFinderMethods
   include Headmaster::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Headmaster)
 end
 
 class Headmaster::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include Headmaster::CustomFinderMethods
   include Headmaster::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Headmaster)
 
   sig { params(records: T.any(Headmaster, T::Array[Headmaster])).returns(T.self_type) }

--- a/spec/test_data/v6.0/expected_headmaster.rbi
+++ b/spec/test_data/v6.0/expected_headmaster.rbi
@@ -75,428 +75,238 @@ class Headmaster < ApplicationRecord
   include Headmaster::GeneratedAttributeMethods
   include Headmaster::GeneratedAssociationMethods
   extend Headmaster::CustomFinderMethods
+  extend Headmaster::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   RelationType = T.type_alias { T.any(Headmaster::ActiveRecord_Relation, Headmaster::ActiveRecord_Associations_CollectionProxy, Headmaster::ActiveRecord_AssociationRelation) }
+end
 
+module Headmaster::QueryMethodsReturningRelation
   sig { returns(Headmaster::ActiveRecord_Relation) }
-  def self.all; end
+  def all; end
 
   sig { params(block: T.nilable(T.proc.void)).returns(Headmaster::ActiveRecord_Relation) }
-  def self.unscoped(&block); end
+  def unscoped(&block); end
 
   sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def self.select(*args); end
+  def select(*args); end
 
   sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def self.reselect(*args); end
+  def reselect(*args); end
 
   sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def self.order(*args); end
+  def order(*args); end
 
   sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def self.reorder(*args); end
+  def reorder(*args); end
 
   sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def self.group(*args); end
+  def group(*args); end
 
   sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def self.limit(*args); end
+  def limit(*args); end
 
   sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def self.offset(*args); end
+  def offset(*args); end
 
   sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def self.joins(*args); end
+  def joins(*args); end
 
   sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def self.left_joins(*args); end
+  def left_joins(*args); end
 
   sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def self.left_outer_joins(*args); end
+  def left_outer_joins(*args); end
 
   sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def self.where(*args); end
+  def where(*args); end
 
   sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def self.rewhere(*args); end
+  def rewhere(*args); end
 
   sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def self.preload(*args); end
+  def preload(*args); end
 
   sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def self.extract_associated(*args); end
+  def extract_associated(*args); end
 
   sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def self.eager_load(*args); end
+  def eager_load(*args); end
 
   sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def self.includes(*args); end
+  def includes(*args); end
 
   sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def self.from(*args); end
+  def from(*args); end
 
   sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def self.lock(*args); end
+  def lock(*args); end
 
   sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def self.readonly(*args); end
+  def readonly(*args); end
 
   sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def self.or(*args); end
+  def or(*args); end
 
   sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def self.having(*args); end
+  def having(*args); end
 
   sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def self.create_with(*args); end
+  def create_with(*args); end
 
   sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def self.distinct(*args); end
+  def distinct(*args); end
 
   sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def self.references(*args); end
+  def references(*args); end
 
   sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def self.none(*args); end
+  def none(*args); end
 
   sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def self.unscope(*args); end
+  def unscope(*args); end
 
   sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def self.optimizer_hints(*args); end
+  def optimizer_hints(*args); end
 
   sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def self.merge(*args); end
+  def merge(*args); end
 
   sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def self.except(*args); end
+  def except(*args); end
 
   sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def self.only(*args); end
+  def only(*args); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Headmaster::ActiveRecord_Relation) }
-  def self.extending(*args, &block); end
+  def extending(*args, &block); end
+end
+
+module Headmaster::QueryMethodsReturningAssociationRelation
+  sig { returns(Headmaster::ActiveRecord_AssociationRelation) }
+  def all; end
+
+  sig { params(block: T.nilable(T.proc.void)).returns(Headmaster::ActiveRecord_Relation) }
+  def unscoped(&block); end
+
+  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
+  def select(*args); end
+
+  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
+  def reselect(*args); end
+
+  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
+  def order(*args); end
+
+  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
+  def reorder(*args); end
+
+  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
+  def group(*args); end
+
+  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
+  def limit(*args); end
+
+  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
+  def offset(*args); end
+
+  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
+  def joins(*args); end
+
+  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
+  def left_joins(*args); end
+
+  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
+  def left_outer_joins(*args); end
+
+  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
+  def where(*args); end
+
+  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
+  def rewhere(*args); end
+
+  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
+  def preload(*args); end
+
+  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
+  def extract_associated(*args); end
+
+  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
+  def eager_load(*args); end
+
+  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
+  def includes(*args); end
+
+  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
+  def from(*args); end
+
+  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
+  def lock(*args); end
+
+  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
+  def readonly(*args); end
+
+  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
+  def or(*args); end
+
+  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
+  def having(*args); end
+
+  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
+  def create_with(*args); end
+
+  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
+  def distinct(*args); end
+
+  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
+  def references(*args); end
+
+  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
+  def none(*args); end
+
+  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
+  def unscope(*args); end
+
+  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
+  def optimizer_hints(*args); end
+
+  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
+  def merge(*args); end
+
+  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
+  def except(*args); end
+
+  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
+  def only(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Headmaster::ActiveRecord_AssociationRelation) }
+  def extending(*args, &block); end
 end
 
 class Headmaster::ActiveRecord_Relation < ActiveRecord::Relation
   include Headmaster::ActiveRelation_WhereNot
   include Headmaster::CustomFinderMethods
+  include Headmaster::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: Headmaster)
-
-  sig { returns(Headmaster::ActiveRecord_Relation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Headmaster::ActiveRecord_Relation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def reselect(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def extract_associated(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def optimizer_hints(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_Relation) }
-  def only(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Headmaster::ActiveRecord_Relation) }
-  def extending(*args, &block); end
 end
 
 class Headmaster::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
   include Headmaster::ActiveRelation_WhereNot
   include Headmaster::CustomFinderMethods
+  include Headmaster::QueryMethodsReturningAssociationRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: Headmaster)
-
-  sig { returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def reselect(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def extract_associated(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def optimizer_hints(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def only(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
 end
 
 class Headmaster::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include Headmaster::CustomFinderMethods
+  include Headmaster::QueryMethodsReturningAssociationRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: Headmaster)
-
-  sig { returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def reselect(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def extract_associated(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def optimizer_hints(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def only(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Headmaster::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
 
   sig { params(records: T.any(Headmaster, T::Array[Headmaster])).returns(T.self_type) }
   def <<(*records); end

--- a/spec/test_data/v6.0/expected_internal_metadata.rbi
+++ b/spec/test_data/v6.0/expected_internal_metadata.rbi
@@ -8,8 +8,6 @@ module ActiveRecord::InternalMetadata::ActiveRelation_WhereNot
 end
 
 module ActiveRecord::InternalMetadata::GeneratedAttributeMethods
-  extend T::Sig
-
   sig { returns(ActiveSupport::TimeWithZone) }
   def created_at; end
 
@@ -68,8 +66,6 @@ class ActiveRecord::InternalMetadata < ActiveRecord::Base
   include ActiveRecord::InternalMetadata::GeneratedAttributeMethods
   extend ActiveRecord::InternalMetadata::CustomFinderMethods
   extend ActiveRecord::InternalMetadata::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   RelationType = T.type_alias { T.any(ActiveRecord::InternalMetadata::ActiveRecord_Relation, ActiveRecord::InternalMetadata::ActiveRecord_Associations_CollectionProxy, ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
 end
 
@@ -279,8 +275,6 @@ class ActiveRecord::InternalMetadata::ActiveRecord_Relation < ActiveRecord::Rela
   include ActiveRecord::InternalMetadata::ActiveRelation_WhereNot
   include ActiveRecord::InternalMetadata::CustomFinderMethods
   include ActiveRecord::InternalMetadata::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: ActiveRecord::InternalMetadata)
 end
 
@@ -288,16 +282,12 @@ class ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation < ActiveR
   include ActiveRecord::InternalMetadata::ActiveRelation_WhereNot
   include ActiveRecord::InternalMetadata::CustomFinderMethods
   include ActiveRecord::InternalMetadata::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: ActiveRecord::InternalMetadata)
 end
 
 class ActiveRecord::InternalMetadata::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include ActiveRecord::InternalMetadata::CustomFinderMethods
   include ActiveRecord::InternalMetadata::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: ActiveRecord::InternalMetadata)
 
   sig { params(records: T.any(ActiveRecord::InternalMetadata, T::Array[ActiveRecord::InternalMetadata])).returns(T.self_type) }

--- a/spec/test_data/v6.0/expected_internal_metadata.rbi
+++ b/spec/test_data/v6.0/expected_internal_metadata.rbi
@@ -67,428 +67,238 @@ end
 class ActiveRecord::InternalMetadata < ActiveRecord::Base
   include ActiveRecord::InternalMetadata::GeneratedAttributeMethods
   extend ActiveRecord::InternalMetadata::CustomFinderMethods
+  extend ActiveRecord::InternalMetadata::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   RelationType = T.type_alias { T.any(ActiveRecord::InternalMetadata::ActiveRecord_Relation, ActiveRecord::InternalMetadata::ActiveRecord_Associations_CollectionProxy, ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+end
 
+module ActiveRecord::InternalMetadata::QueryMethodsReturningRelation
   sig { returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.all; end
+  def all; end
 
   sig { params(block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.unscoped(&block); end
+  def unscoped(&block); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.select(*args); end
+  def select(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.reselect(*args); end
+  def reselect(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.order(*args); end
+  def order(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.reorder(*args); end
+  def reorder(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.group(*args); end
+  def group(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.limit(*args); end
+  def limit(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.offset(*args); end
+  def offset(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.joins(*args); end
+  def joins(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.left_joins(*args); end
+  def left_joins(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.left_outer_joins(*args); end
+  def left_outer_joins(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.where(*args); end
+  def where(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.rewhere(*args); end
+  def rewhere(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.preload(*args); end
+  def preload(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.extract_associated(*args); end
+  def extract_associated(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.eager_load(*args); end
+  def eager_load(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.includes(*args); end
+  def includes(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.from(*args); end
+  def from(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.lock(*args); end
+  def lock(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.readonly(*args); end
+  def readonly(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.or(*args); end
+  def or(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.having(*args); end
+  def having(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.create_with(*args); end
+  def create_with(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.distinct(*args); end
+  def distinct(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.references(*args); end
+  def references(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.none(*args); end
+  def none(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.unscope(*args); end
+  def unscope(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.optimizer_hints(*args); end
+  def optimizer_hints(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.merge(*args); end
+  def merge(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.except(*args); end
+  def except(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.only(*args); end
+  def only(*args); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def self.extending(*args, &block); end
+  def extending(*args, &block); end
+end
+
+module ActiveRecord::InternalMetadata::QueryMethodsReturningAssociationRelation
+  sig { returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def all; end
+
+  sig { params(block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def unscoped(&block); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def select(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def reselect(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def order(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def reorder(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def group(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def limit(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def offset(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def joins(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def left_joins(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def left_outer_joins(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def where(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def rewhere(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def preload(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def extract_associated(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def eager_load(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def includes(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def from(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def lock(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def readonly(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def or(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def having(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def create_with(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def distinct(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def references(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def none(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def unscope(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def optimizer_hints(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def merge(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def except(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def only(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def extending(*args, &block); end
 end
 
 class ActiveRecord::InternalMetadata::ActiveRecord_Relation < ActiveRecord::Relation
   include ActiveRecord::InternalMetadata::ActiveRelation_WhereNot
   include ActiveRecord::InternalMetadata::CustomFinderMethods
+  include ActiveRecord::InternalMetadata::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: ActiveRecord::InternalMetadata)
-
-  sig { returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def reselect(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def extract_associated(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def optimizer_hints(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def only(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
-  def extending(*args, &block); end
 end
 
 class ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
   include ActiveRecord::InternalMetadata::ActiveRelation_WhereNot
   include ActiveRecord::InternalMetadata::CustomFinderMethods
+  include ActiveRecord::InternalMetadata::QueryMethodsReturningAssociationRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: ActiveRecord::InternalMetadata)
-
-  sig { returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def reselect(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def extract_associated(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def optimizer_hints(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def only(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
 end
 
 class ActiveRecord::InternalMetadata::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include ActiveRecord::InternalMetadata::CustomFinderMethods
+  include ActiveRecord::InternalMetadata::QueryMethodsReturningAssociationRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: ActiveRecord::InternalMetadata)
-
-  sig { returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def reselect(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def extract_associated(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def optimizer_hints(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def only(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
 
   sig { params(records: T.any(ActiveRecord::InternalMetadata, T::Array[ActiveRecord::InternalMetadata])).returns(T.self_type) }
   def <<(*records); end

--- a/spec/test_data/v6.0/expected_potion.rbi
+++ b/spec/test_data/v6.0/expected_potion.rbi
@@ -37,428 +37,238 @@ end
 class Potion < ApplicationRecord
   include Potion::GeneratedAssociationMethods
   extend Potion::CustomFinderMethods
+  extend Potion::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   RelationType = T.type_alias { T.any(Potion::ActiveRecord_Relation, Potion::ActiveRecord_Associations_CollectionProxy, Potion::ActiveRecord_AssociationRelation) }
+end
 
+module Potion::QueryMethodsReturningRelation
   sig { returns(Potion::ActiveRecord_Relation) }
-  def self.all; end
+  def all; end
 
   sig { params(block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def self.unscoped(&block); end
+  def unscoped(&block); end
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def self.select(*args); end
+  def select(*args); end
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def self.reselect(*args); end
+  def reselect(*args); end
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def self.order(*args); end
+  def order(*args); end
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def self.reorder(*args); end
+  def reorder(*args); end
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def self.group(*args); end
+  def group(*args); end
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def self.limit(*args); end
+  def limit(*args); end
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def self.offset(*args); end
+  def offset(*args); end
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def self.joins(*args); end
+  def joins(*args); end
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def self.left_joins(*args); end
+  def left_joins(*args); end
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def self.left_outer_joins(*args); end
+  def left_outer_joins(*args); end
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def self.where(*args); end
+  def where(*args); end
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def self.rewhere(*args); end
+  def rewhere(*args); end
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def self.preload(*args); end
+  def preload(*args); end
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def self.extract_associated(*args); end
+  def extract_associated(*args); end
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def self.eager_load(*args); end
+  def eager_load(*args); end
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def self.includes(*args); end
+  def includes(*args); end
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def self.from(*args); end
+  def from(*args); end
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def self.lock(*args); end
+  def lock(*args); end
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def self.readonly(*args); end
+  def readonly(*args); end
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def self.or(*args); end
+  def or(*args); end
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def self.having(*args); end
+  def having(*args); end
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def self.create_with(*args); end
+  def create_with(*args); end
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def self.distinct(*args); end
+  def distinct(*args); end
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def self.references(*args); end
+  def references(*args); end
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def self.none(*args); end
+  def none(*args); end
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def self.unscope(*args); end
+  def unscope(*args); end
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def self.optimizer_hints(*args); end
+  def optimizer_hints(*args); end
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def self.merge(*args); end
+  def merge(*args); end
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def self.except(*args); end
+  def except(*args); end
 
   sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def self.only(*args); end
+  def only(*args); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def self.extending(*args, &block); end
+  def extending(*args, &block); end
+end
+
+module Potion::QueryMethodsReturningAssociationRelation
+  sig { returns(Potion::ActiveRecord_AssociationRelation) }
+  def all; end
+
+  sig { params(block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
+  def unscoped(&block); end
+
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def select(*args); end
+
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def reselect(*args); end
+
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def order(*args); end
+
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def reorder(*args); end
+
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def group(*args); end
+
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def limit(*args); end
+
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def offset(*args); end
+
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def joins(*args); end
+
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def left_joins(*args); end
+
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def left_outer_joins(*args); end
+
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def where(*args); end
+
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def rewhere(*args); end
+
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def preload(*args); end
+
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def extract_associated(*args); end
+
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def eager_load(*args); end
+
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def includes(*args); end
+
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def from(*args); end
+
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def lock(*args); end
+
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def readonly(*args); end
+
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def or(*args); end
+
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def having(*args); end
+
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def create_with(*args); end
+
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def distinct(*args); end
+
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def references(*args); end
+
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def none(*args); end
+
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def unscope(*args); end
+
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def optimizer_hints(*args); end
+
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def merge(*args); end
+
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def except(*args); end
+
+  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
+  def only(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
+  def extending(*args, &block); end
 end
 
 class Potion::ActiveRecord_Relation < ActiveRecord::Relation
   include Potion::ActiveRelation_WhereNot
   include Potion::CustomFinderMethods
+  include Potion::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: Potion)
-
-  sig { returns(Potion::ActiveRecord_Relation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def reselect(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def extract_associated(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def optimizer_hints(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_Relation) }
-  def only(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
-  def extending(*args, &block); end
 end
 
 class Potion::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
   include Potion::ActiveRelation_WhereNot
   include Potion::CustomFinderMethods
+  include Potion::QueryMethodsReturningAssociationRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: Potion)
-
-  sig { returns(Potion::ActiveRecord_AssociationRelation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def reselect(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def extract_associated(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def optimizer_hints(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def only(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
 end
 
 class Potion::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include Potion::CustomFinderMethods
+  include Potion::QueryMethodsReturningAssociationRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: Potion)
-
-  sig { returns(Potion::ActiveRecord_AssociationRelation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def reselect(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def extract_associated(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def optimizer_hints(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped).returns(Potion::ActiveRecord_AssociationRelation) }
-  def only(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
 
   sig { params(records: T.any(Potion, T::Array[Potion])).returns(T.self_type) }
   def <<(*records); end

--- a/spec/test_data/v6.0/expected_potion.rbi
+++ b/spec/test_data/v6.0/expected_potion.rbi
@@ -8,8 +8,6 @@ module Potion::ActiveRelation_WhereNot
 end
 
 module Potion::GeneratedAssociationMethods
-  extend T::Sig
-
   sig { returns(T.nilable(::Wizard)) }
   def wizard; end
 
@@ -38,8 +36,6 @@ class Potion < ApplicationRecord
   include Potion::GeneratedAssociationMethods
   extend Potion::CustomFinderMethods
   extend Potion::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   RelationType = T.type_alias { T.any(Potion::ActiveRecord_Relation, Potion::ActiveRecord_Associations_CollectionProxy, Potion::ActiveRecord_AssociationRelation) }
 end
 
@@ -249,8 +245,6 @@ class Potion::ActiveRecord_Relation < ActiveRecord::Relation
   include Potion::ActiveRelation_WhereNot
   include Potion::CustomFinderMethods
   include Potion::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Potion)
 end
 
@@ -258,16 +252,12 @@ class Potion::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelati
   include Potion::ActiveRelation_WhereNot
   include Potion::CustomFinderMethods
   include Potion::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Potion)
 end
 
 class Potion::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include Potion::CustomFinderMethods
   include Potion::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Potion)
 
   sig { params(records: T.any(Potion, T::Array[Potion])).returns(T.self_type) }

--- a/spec/test_data/v6.0/expected_robe.rbi
+++ b/spec/test_data/v6.0/expected_robe.rbi
@@ -8,8 +8,6 @@ module Robe::ActiveRelation_WhereNot
 end
 
 module Robe::GeneratedAttributeMethods
-  extend T::Sig
-
   sig { returns(Integer) }
   def id; end
 
@@ -30,8 +28,6 @@ module Robe::GeneratedAttributeMethods
 end
 
 module Robe::GeneratedAssociationMethods
-  extend T::Sig
-
   sig { returns(T.nilable(::Wizard)) }
   def wizard; end
 
@@ -61,8 +57,6 @@ class Robe < ApplicationRecord
   include Robe::GeneratedAssociationMethods
   extend Robe::CustomFinderMethods
   extend Robe::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   RelationType = T.type_alias { T.any(Robe::ActiveRecord_Relation, Robe::ActiveRecord_Associations_CollectionProxy, Robe::ActiveRecord_AssociationRelation) }
 end
 
@@ -272,8 +266,6 @@ class Robe::ActiveRecord_Relation < ActiveRecord::Relation
   include Robe::ActiveRelation_WhereNot
   include Robe::CustomFinderMethods
   include Robe::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Robe)
 end
 
@@ -281,16 +273,12 @@ class Robe::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
   include Robe::ActiveRelation_WhereNot
   include Robe::CustomFinderMethods
   include Robe::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Robe)
 end
 
 class Robe::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include Robe::CustomFinderMethods
   include Robe::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Robe)
 
   sig { params(records: T.any(Robe, T::Array[Robe])).returns(T.self_type) }

--- a/spec/test_data/v6.0/expected_robe.rbi
+++ b/spec/test_data/v6.0/expected_robe.rbi
@@ -60,428 +60,238 @@ class Robe < ApplicationRecord
   include Robe::GeneratedAttributeMethods
   include Robe::GeneratedAssociationMethods
   extend Robe::CustomFinderMethods
+  extend Robe::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   RelationType = T.type_alias { T.any(Robe::ActiveRecord_Relation, Robe::ActiveRecord_Associations_CollectionProxy, Robe::ActiveRecord_AssociationRelation) }
+end
 
+module Robe::QueryMethodsReturningRelation
   sig { returns(Robe::ActiveRecord_Relation) }
-  def self.all; end
+  def all; end
 
   sig { params(block: T.nilable(T.proc.void)).returns(Robe::ActiveRecord_Relation) }
-  def self.unscoped(&block); end
+  def unscoped(&block); end
 
   sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def self.select(*args); end
+  def select(*args); end
 
   sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def self.reselect(*args); end
+  def reselect(*args); end
 
   sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def self.order(*args); end
+  def order(*args); end
 
   sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def self.reorder(*args); end
+  def reorder(*args); end
 
   sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def self.group(*args); end
+  def group(*args); end
 
   sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def self.limit(*args); end
+  def limit(*args); end
 
   sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def self.offset(*args); end
+  def offset(*args); end
 
   sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def self.joins(*args); end
+  def joins(*args); end
 
   sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def self.left_joins(*args); end
+  def left_joins(*args); end
 
   sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def self.left_outer_joins(*args); end
+  def left_outer_joins(*args); end
 
   sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def self.where(*args); end
+  def where(*args); end
 
   sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def self.rewhere(*args); end
+  def rewhere(*args); end
 
   sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def self.preload(*args); end
+  def preload(*args); end
 
   sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def self.extract_associated(*args); end
+  def extract_associated(*args); end
 
   sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def self.eager_load(*args); end
+  def eager_load(*args); end
 
   sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def self.includes(*args); end
+  def includes(*args); end
 
   sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def self.from(*args); end
+  def from(*args); end
 
   sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def self.lock(*args); end
+  def lock(*args); end
 
   sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def self.readonly(*args); end
+  def readonly(*args); end
 
   sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def self.or(*args); end
+  def or(*args); end
 
   sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def self.having(*args); end
+  def having(*args); end
 
   sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def self.create_with(*args); end
+  def create_with(*args); end
 
   sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def self.distinct(*args); end
+  def distinct(*args); end
 
   sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def self.references(*args); end
+  def references(*args); end
 
   sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def self.none(*args); end
+  def none(*args); end
 
   sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def self.unscope(*args); end
+  def unscope(*args); end
 
   sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def self.optimizer_hints(*args); end
+  def optimizer_hints(*args); end
 
   sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def self.merge(*args); end
+  def merge(*args); end
 
   sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def self.except(*args); end
+  def except(*args); end
 
   sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def self.only(*args); end
+  def only(*args); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Robe::ActiveRecord_Relation) }
-  def self.extending(*args, &block); end
+  def extending(*args, &block); end
+end
+
+module Robe::QueryMethodsReturningAssociationRelation
+  sig { returns(Robe::ActiveRecord_AssociationRelation) }
+  def all; end
+
+  sig { params(block: T.nilable(T.proc.void)).returns(Robe::ActiveRecord_Relation) }
+  def unscoped(&block); end
+
+  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
+  def select(*args); end
+
+  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
+  def reselect(*args); end
+
+  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
+  def order(*args); end
+
+  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
+  def reorder(*args); end
+
+  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
+  def group(*args); end
+
+  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
+  def limit(*args); end
+
+  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
+  def offset(*args); end
+
+  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
+  def joins(*args); end
+
+  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
+  def left_joins(*args); end
+
+  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
+  def left_outer_joins(*args); end
+
+  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
+  def where(*args); end
+
+  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
+  def rewhere(*args); end
+
+  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
+  def preload(*args); end
+
+  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
+  def extract_associated(*args); end
+
+  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
+  def eager_load(*args); end
+
+  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
+  def includes(*args); end
+
+  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
+  def from(*args); end
+
+  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
+  def lock(*args); end
+
+  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
+  def readonly(*args); end
+
+  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
+  def or(*args); end
+
+  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
+  def having(*args); end
+
+  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
+  def create_with(*args); end
+
+  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
+  def distinct(*args); end
+
+  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
+  def references(*args); end
+
+  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
+  def none(*args); end
+
+  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
+  def unscope(*args); end
+
+  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
+  def optimizer_hints(*args); end
+
+  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
+  def merge(*args); end
+
+  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
+  def except(*args); end
+
+  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
+  def only(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Robe::ActiveRecord_AssociationRelation) }
+  def extending(*args, &block); end
 end
 
 class Robe::ActiveRecord_Relation < ActiveRecord::Relation
   include Robe::ActiveRelation_WhereNot
   include Robe::CustomFinderMethods
+  include Robe::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: Robe)
-
-  sig { returns(Robe::ActiveRecord_Relation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Robe::ActiveRecord_Relation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def reselect(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def extract_associated(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def optimizer_hints(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_Relation) }
-  def only(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Robe::ActiveRecord_Relation) }
-  def extending(*args, &block); end
 end
 
 class Robe::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
   include Robe::ActiveRelation_WhereNot
   include Robe::CustomFinderMethods
+  include Robe::QueryMethodsReturningAssociationRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: Robe)
-
-  sig { returns(Robe::ActiveRecord_AssociationRelation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Robe::ActiveRecord_AssociationRelation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def reselect(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def extract_associated(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def optimizer_hints(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def only(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Robe::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
 end
 
 class Robe::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include Robe::CustomFinderMethods
+  include Robe::QueryMethodsReturningAssociationRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: Robe)
-
-  sig { returns(Robe::ActiveRecord_AssociationRelation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Robe::ActiveRecord_AssociationRelation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def reselect(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def extract_associated(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def optimizer_hints(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped).returns(Robe::ActiveRecord_AssociationRelation) }
-  def only(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Robe::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
 
   sig { params(records: T.any(Robe, T::Array[Robe])).returns(T.self_type) }
   def <<(*records); end

--- a/spec/test_data/v6.0/expected_schema_migration.rbi
+++ b/spec/test_data/v6.0/expected_schema_migration.rbi
@@ -40,428 +40,238 @@ end
 class ActiveRecord::SchemaMigration < ActiveRecord::Base
   include ActiveRecord::SchemaMigration::GeneratedAttributeMethods
   extend ActiveRecord::SchemaMigration::CustomFinderMethods
+  extend ActiveRecord::SchemaMigration::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   RelationType = T.type_alias { T.any(ActiveRecord::SchemaMigration::ActiveRecord_Relation, ActiveRecord::SchemaMigration::ActiveRecord_Associations_CollectionProxy, ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+end
 
+module ActiveRecord::SchemaMigration::QueryMethodsReturningRelation
   sig { returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.all; end
+  def all; end
 
   sig { params(block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.unscoped(&block); end
+  def unscoped(&block); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.select(*args); end
+  def select(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.reselect(*args); end
+  def reselect(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.order(*args); end
+  def order(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.reorder(*args); end
+  def reorder(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.group(*args); end
+  def group(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.limit(*args); end
+  def limit(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.offset(*args); end
+  def offset(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.joins(*args); end
+  def joins(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.left_joins(*args); end
+  def left_joins(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.left_outer_joins(*args); end
+  def left_outer_joins(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.where(*args); end
+  def where(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.rewhere(*args); end
+  def rewhere(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.preload(*args); end
+  def preload(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.extract_associated(*args); end
+  def extract_associated(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.eager_load(*args); end
+  def eager_load(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.includes(*args); end
+  def includes(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.from(*args); end
+  def from(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.lock(*args); end
+  def lock(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.readonly(*args); end
+  def readonly(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.or(*args); end
+  def or(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.having(*args); end
+  def having(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.create_with(*args); end
+  def create_with(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.distinct(*args); end
+  def distinct(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.references(*args); end
+  def references(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.none(*args); end
+  def none(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.unscope(*args); end
+  def unscope(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.optimizer_hints(*args); end
+  def optimizer_hints(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.merge(*args); end
+  def merge(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.except(*args); end
+  def except(*args); end
 
   sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.only(*args); end
+  def only(*args); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def self.extending(*args, &block); end
+  def extending(*args, &block); end
+end
+
+module ActiveRecord::SchemaMigration::QueryMethodsReturningAssociationRelation
+  sig { returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def all; end
+
+  sig { params(block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def unscoped(&block); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def select(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def reselect(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def order(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def reorder(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def group(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def limit(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def offset(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def joins(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def left_joins(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def left_outer_joins(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def where(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def rewhere(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def preload(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def extract_associated(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def eager_load(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def includes(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def from(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def lock(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def readonly(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def or(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def having(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def create_with(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def distinct(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def references(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def none(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def unscope(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def optimizer_hints(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def merge(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def except(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def only(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def extending(*args, &block); end
 end
 
 class ActiveRecord::SchemaMigration::ActiveRecord_Relation < ActiveRecord::Relation
   include ActiveRecord::SchemaMigration::ActiveRelation_WhereNot
   include ActiveRecord::SchemaMigration::CustomFinderMethods
+  include ActiveRecord::SchemaMigration::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: ActiveRecord::SchemaMigration)
-
-  sig { returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def reselect(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def extract_associated(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def optimizer_hints(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def only(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
-  def extending(*args, &block); end
 end
 
 class ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
   include ActiveRecord::SchemaMigration::ActiveRelation_WhereNot
   include ActiveRecord::SchemaMigration::CustomFinderMethods
+  include ActiveRecord::SchemaMigration::QueryMethodsReturningAssociationRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: ActiveRecord::SchemaMigration)
-
-  sig { returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def reselect(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def extract_associated(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def optimizer_hints(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def only(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
 end
 
 class ActiveRecord::SchemaMigration::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include ActiveRecord::SchemaMigration::CustomFinderMethods
+  include ActiveRecord::SchemaMigration::QueryMethodsReturningAssociationRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: ActiveRecord::SchemaMigration)
-
-  sig { returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def reselect(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def extract_associated(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def optimizer_hints(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def only(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
 
   sig { params(records: T.any(ActiveRecord::SchemaMigration, T::Array[ActiveRecord::SchemaMigration])).returns(T.self_type) }
   def <<(*records); end

--- a/spec/test_data/v6.0/expected_schema_migration.rbi
+++ b/spec/test_data/v6.0/expected_schema_migration.rbi
@@ -8,8 +8,6 @@ module ActiveRecord::SchemaMigration::ActiveRelation_WhereNot
 end
 
 module ActiveRecord::SchemaMigration::GeneratedAttributeMethods
-  extend T::Sig
-
   sig { returns(String) }
   def version; end
 
@@ -41,8 +39,6 @@ class ActiveRecord::SchemaMigration < ActiveRecord::Base
   include ActiveRecord::SchemaMigration::GeneratedAttributeMethods
   extend ActiveRecord::SchemaMigration::CustomFinderMethods
   extend ActiveRecord::SchemaMigration::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   RelationType = T.type_alias { T.any(ActiveRecord::SchemaMigration::ActiveRecord_Relation, ActiveRecord::SchemaMigration::ActiveRecord_Associations_CollectionProxy, ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
 end
 
@@ -252,8 +248,6 @@ class ActiveRecord::SchemaMigration::ActiveRecord_Relation < ActiveRecord::Relat
   include ActiveRecord::SchemaMigration::ActiveRelation_WhereNot
   include ActiveRecord::SchemaMigration::CustomFinderMethods
   include ActiveRecord::SchemaMigration::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: ActiveRecord::SchemaMigration)
 end
 
@@ -261,16 +255,12 @@ class ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation < ActiveRe
   include ActiveRecord::SchemaMigration::ActiveRelation_WhereNot
   include ActiveRecord::SchemaMigration::CustomFinderMethods
   include ActiveRecord::SchemaMigration::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: ActiveRecord::SchemaMigration)
 end
 
 class ActiveRecord::SchemaMigration::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include ActiveRecord::SchemaMigration::CustomFinderMethods
   include ActiveRecord::SchemaMigration::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: ActiveRecord::SchemaMigration)
 
   sig { params(records: T.any(ActiveRecord::SchemaMigration, T::Array[ActiveRecord::SchemaMigration])).returns(T.self_type) }

--- a/spec/test_data/v6.0/expected_school.rbi
+++ b/spec/test_data/v6.0/expected_school.rbi
@@ -60,428 +60,238 @@ class School < ApplicationRecord
   include School::GeneratedAttributeMethods
   include School::GeneratedAssociationMethods
   extend School::CustomFinderMethods
+  extend School::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   RelationType = T.type_alias { T.any(School::ActiveRecord_Relation, School::ActiveRecord_Associations_CollectionProxy, School::ActiveRecord_AssociationRelation) }
+end
 
+module School::QueryMethodsReturningRelation
   sig { returns(School::ActiveRecord_Relation) }
-  def self.all; end
+  def all; end
 
   sig { params(block: T.nilable(T.proc.void)).returns(School::ActiveRecord_Relation) }
-  def self.unscoped(&block); end
+  def unscoped(&block); end
 
   sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def self.select(*args); end
+  def select(*args); end
 
   sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def self.reselect(*args); end
+  def reselect(*args); end
 
   sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def self.order(*args); end
+  def order(*args); end
 
   sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def self.reorder(*args); end
+  def reorder(*args); end
 
   sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def self.group(*args); end
+  def group(*args); end
 
   sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def self.limit(*args); end
+  def limit(*args); end
 
   sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def self.offset(*args); end
+  def offset(*args); end
 
   sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def self.joins(*args); end
+  def joins(*args); end
 
   sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def self.left_joins(*args); end
+  def left_joins(*args); end
 
   sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def self.left_outer_joins(*args); end
+  def left_outer_joins(*args); end
 
   sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def self.where(*args); end
+  def where(*args); end
 
   sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def self.rewhere(*args); end
+  def rewhere(*args); end
 
   sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def self.preload(*args); end
+  def preload(*args); end
 
   sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def self.extract_associated(*args); end
+  def extract_associated(*args); end
 
   sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def self.eager_load(*args); end
+  def eager_load(*args); end
 
   sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def self.includes(*args); end
+  def includes(*args); end
 
   sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def self.from(*args); end
+  def from(*args); end
 
   sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def self.lock(*args); end
+  def lock(*args); end
 
   sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def self.readonly(*args); end
+  def readonly(*args); end
 
   sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def self.or(*args); end
+  def or(*args); end
 
   sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def self.having(*args); end
+  def having(*args); end
 
   sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def self.create_with(*args); end
+  def create_with(*args); end
 
   sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def self.distinct(*args); end
+  def distinct(*args); end
 
   sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def self.references(*args); end
+  def references(*args); end
 
   sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def self.none(*args); end
+  def none(*args); end
 
   sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def self.unscope(*args); end
+  def unscope(*args); end
 
   sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def self.optimizer_hints(*args); end
+  def optimizer_hints(*args); end
 
   sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def self.merge(*args); end
+  def merge(*args); end
 
   sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def self.except(*args); end
+  def except(*args); end
 
   sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def self.only(*args); end
+  def only(*args); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(School::ActiveRecord_Relation) }
-  def self.extending(*args, &block); end
+  def extending(*args, &block); end
+end
+
+module School::QueryMethodsReturningAssociationRelation
+  sig { returns(School::ActiveRecord_AssociationRelation) }
+  def all; end
+
+  sig { params(block: T.nilable(T.proc.void)).returns(School::ActiveRecord_Relation) }
+  def unscoped(&block); end
+
+  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
+  def select(*args); end
+
+  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
+  def reselect(*args); end
+
+  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
+  def order(*args); end
+
+  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
+  def reorder(*args); end
+
+  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
+  def group(*args); end
+
+  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
+  def limit(*args); end
+
+  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
+  def offset(*args); end
+
+  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
+  def joins(*args); end
+
+  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
+  def left_joins(*args); end
+
+  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
+  def left_outer_joins(*args); end
+
+  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
+  def where(*args); end
+
+  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
+  def rewhere(*args); end
+
+  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
+  def preload(*args); end
+
+  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
+  def extract_associated(*args); end
+
+  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
+  def eager_load(*args); end
+
+  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
+  def includes(*args); end
+
+  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
+  def from(*args); end
+
+  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
+  def lock(*args); end
+
+  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
+  def readonly(*args); end
+
+  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
+  def or(*args); end
+
+  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
+  def having(*args); end
+
+  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
+  def create_with(*args); end
+
+  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
+  def distinct(*args); end
+
+  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
+  def references(*args); end
+
+  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
+  def none(*args); end
+
+  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
+  def unscope(*args); end
+
+  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
+  def optimizer_hints(*args); end
+
+  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
+  def merge(*args); end
+
+  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
+  def except(*args); end
+
+  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
+  def only(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(School::ActiveRecord_AssociationRelation) }
+  def extending(*args, &block); end
 end
 
 class School::ActiveRecord_Relation < ActiveRecord::Relation
   include School::ActiveRelation_WhereNot
   include School::CustomFinderMethods
+  include School::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: School)
-
-  sig { returns(School::ActiveRecord_Relation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(School::ActiveRecord_Relation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def reselect(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def extract_associated(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def optimizer_hints(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_Relation) }
-  def only(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(School::ActiveRecord_Relation) }
-  def extending(*args, &block); end
 end
 
 class School::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
   include School::ActiveRelation_WhereNot
   include School::CustomFinderMethods
+  include School::QueryMethodsReturningAssociationRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: School)
-
-  sig { returns(School::ActiveRecord_AssociationRelation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(School::ActiveRecord_AssociationRelation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def reselect(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def extract_associated(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def optimizer_hints(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def only(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(School::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
 end
 
 class School::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include School::CustomFinderMethods
+  include School::QueryMethodsReturningAssociationRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: School)
-
-  sig { returns(School::ActiveRecord_AssociationRelation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(School::ActiveRecord_AssociationRelation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def reselect(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def extract_associated(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def optimizer_hints(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped).returns(School::ActiveRecord_AssociationRelation) }
-  def only(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(School::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
 
   sig { params(records: T.any(School, T::Array[School])).returns(T.self_type) }
   def <<(*records); end

--- a/spec/test_data/v6.0/expected_school.rbi
+++ b/spec/test_data/v6.0/expected_school.rbi
@@ -8,8 +8,6 @@ module School::ActiveRelation_WhereNot
 end
 
 module School::GeneratedAttributeMethods
-  extend T::Sig
-
   sig { returns(Integer) }
   def id; end
 
@@ -30,8 +28,6 @@ module School::GeneratedAttributeMethods
 end
 
 module School::GeneratedAssociationMethods
-  extend T::Sig
-
   sig { returns(::Headmaster) }
   def headmaster; end
 
@@ -61,8 +57,6 @@ class School < ApplicationRecord
   include School::GeneratedAssociationMethods
   extend School::CustomFinderMethods
   extend School::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   RelationType = T.type_alias { T.any(School::ActiveRecord_Relation, School::ActiveRecord_Associations_CollectionProxy, School::ActiveRecord_AssociationRelation) }
 end
 
@@ -272,8 +266,6 @@ class School::ActiveRecord_Relation < ActiveRecord::Relation
   include School::ActiveRelation_WhereNot
   include School::CustomFinderMethods
   include School::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: School)
 end
 
@@ -281,16 +273,12 @@ class School::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelati
   include School::ActiveRelation_WhereNot
   include School::CustomFinderMethods
   include School::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: School)
 end
 
 class School::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include School::CustomFinderMethods
   include School::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: School)
 
   sig { params(records: T.any(School, T::Array[School])).returns(T.self_type) }

--- a/spec/test_data/v6.0/expected_spell.rbi
+++ b/spec/test_data/v6.0/expected_spell.rbi
@@ -63,428 +63,238 @@ class Spell < ApplicationRecord
   include Spell::GeneratedAttributeMethods
   include Spell::GeneratedAssociationMethods
   extend Spell::CustomFinderMethods
+  extend Spell::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   RelationType = T.type_alias { T.any(Spell::ActiveRecord_Relation, Spell::ActiveRecord_Associations_CollectionProxy, Spell::ActiveRecord_AssociationRelation) }
+end
 
+module Spell::QueryMethodsReturningRelation
   sig { returns(Spell::ActiveRecord_Relation) }
-  def self.all; end
+  def all; end
 
   sig { params(block: T.nilable(T.proc.void)).returns(Spell::ActiveRecord_Relation) }
-  def self.unscoped(&block); end
+  def unscoped(&block); end
 
   sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def self.select(*args); end
+  def select(*args); end
 
   sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def self.reselect(*args); end
+  def reselect(*args); end
 
   sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def self.order(*args); end
+  def order(*args); end
 
   sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def self.reorder(*args); end
+  def reorder(*args); end
 
   sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def self.group(*args); end
+  def group(*args); end
 
   sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def self.limit(*args); end
+  def limit(*args); end
 
   sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def self.offset(*args); end
+  def offset(*args); end
 
   sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def self.joins(*args); end
+  def joins(*args); end
 
   sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def self.left_joins(*args); end
+  def left_joins(*args); end
 
   sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def self.left_outer_joins(*args); end
+  def left_outer_joins(*args); end
 
   sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def self.where(*args); end
+  def where(*args); end
 
   sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def self.rewhere(*args); end
+  def rewhere(*args); end
 
   sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def self.preload(*args); end
+  def preload(*args); end
 
   sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def self.extract_associated(*args); end
+  def extract_associated(*args); end
 
   sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def self.eager_load(*args); end
+  def eager_load(*args); end
 
   sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def self.includes(*args); end
+  def includes(*args); end
 
   sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def self.from(*args); end
+  def from(*args); end
 
   sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def self.lock(*args); end
+  def lock(*args); end
 
   sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def self.readonly(*args); end
+  def readonly(*args); end
 
   sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def self.or(*args); end
+  def or(*args); end
 
   sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def self.having(*args); end
+  def having(*args); end
 
   sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def self.create_with(*args); end
+  def create_with(*args); end
 
   sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def self.distinct(*args); end
+  def distinct(*args); end
 
   sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def self.references(*args); end
+  def references(*args); end
 
   sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def self.none(*args); end
+  def none(*args); end
 
   sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def self.unscope(*args); end
+  def unscope(*args); end
 
   sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def self.optimizer_hints(*args); end
+  def optimizer_hints(*args); end
 
   sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def self.merge(*args); end
+  def merge(*args); end
 
   sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def self.except(*args); end
+  def except(*args); end
 
   sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def self.only(*args); end
+  def only(*args); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Spell::ActiveRecord_Relation) }
-  def self.extending(*args, &block); end
+  def extending(*args, &block); end
+end
+
+module Spell::QueryMethodsReturningAssociationRelation
+  sig { returns(Spell::ActiveRecord_AssociationRelation) }
+  def all; end
+
+  sig { params(block: T.nilable(T.proc.void)).returns(Spell::ActiveRecord_Relation) }
+  def unscoped(&block); end
+
+  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
+  def select(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
+  def reselect(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
+  def order(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
+  def reorder(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
+  def group(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
+  def limit(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
+  def offset(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
+  def joins(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
+  def left_joins(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
+  def left_outer_joins(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
+  def where(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
+  def rewhere(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
+  def preload(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
+  def extract_associated(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
+  def eager_load(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
+  def includes(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
+  def from(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
+  def lock(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
+  def readonly(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
+  def or(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
+  def having(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
+  def create_with(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
+  def distinct(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
+  def references(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
+  def none(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
+  def unscope(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
+  def optimizer_hints(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
+  def merge(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
+  def except(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
+  def only(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Spell::ActiveRecord_AssociationRelation) }
+  def extending(*args, &block); end
 end
 
 class Spell::ActiveRecord_Relation < ActiveRecord::Relation
   include Spell::ActiveRelation_WhereNot
   include Spell::CustomFinderMethods
+  include Spell::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: Spell)
-
-  sig { returns(Spell::ActiveRecord_Relation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Spell::ActiveRecord_Relation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def reselect(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def extract_associated(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def optimizer_hints(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_Relation) }
-  def only(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Spell::ActiveRecord_Relation) }
-  def extending(*args, &block); end
 end
 
 class Spell::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
   include Spell::ActiveRelation_WhereNot
   include Spell::CustomFinderMethods
+  include Spell::QueryMethodsReturningAssociationRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: Spell)
-
-  sig { returns(Spell::ActiveRecord_AssociationRelation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Spell::ActiveRecord_AssociationRelation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def reselect(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def extract_associated(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def optimizer_hints(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def only(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Spell::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
 end
 
 class Spell::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include Spell::CustomFinderMethods
+  include Spell::QueryMethodsReturningAssociationRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: Spell)
-
-  sig { returns(Spell::ActiveRecord_AssociationRelation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Spell::ActiveRecord_AssociationRelation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def reselect(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def extract_associated(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def optimizer_hints(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::ActiveRecord_AssociationRelation) }
-  def only(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Spell::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
 
   sig { params(records: T.any(Spell, T::Array[Spell])).returns(T.self_type) }
   def <<(*records); end

--- a/spec/test_data/v6.0/expected_spell.rbi
+++ b/spec/test_data/v6.0/expected_spell.rbi
@@ -8,8 +8,6 @@ module Spell::ActiveRelation_WhereNot
 end
 
 module Spell::GeneratedAttributeMethods
-  extend T::Sig
-
   sig { returns(Integer) }
   def id; end
 
@@ -30,8 +28,6 @@ module Spell::GeneratedAttributeMethods
 end
 
 module Spell::GeneratedAssociationMethods
-  extend T::Sig
-
   sig { returns(::SpellBook::ActiveRecord_Associations_CollectionProxy) }
   def spell_books; end
 
@@ -64,8 +60,6 @@ class Spell < ApplicationRecord
   include Spell::GeneratedAssociationMethods
   extend Spell::CustomFinderMethods
   extend Spell::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   RelationType = T.type_alias { T.any(Spell::ActiveRecord_Relation, Spell::ActiveRecord_Associations_CollectionProxy, Spell::ActiveRecord_AssociationRelation) }
 end
 
@@ -275,8 +269,6 @@ class Spell::ActiveRecord_Relation < ActiveRecord::Relation
   include Spell::ActiveRelation_WhereNot
   include Spell::CustomFinderMethods
   include Spell::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Spell)
 end
 
@@ -284,16 +276,12 @@ class Spell::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelatio
   include Spell::ActiveRelation_WhereNot
   include Spell::CustomFinderMethods
   include Spell::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Spell)
 end
 
 class Spell::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include Spell::CustomFinderMethods
   include Spell::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Spell)
 
   sig { params(records: T.any(Spell, T::Array[Spell])).returns(T.self_type) }

--- a/spec/test_data/v6.0/expected_spell/habtm_spell_books.rbi
+++ b/spec/test_data/v6.0/expected_spell/habtm_spell_books.rbi
@@ -66,428 +66,238 @@ class Spell::HABTM_SpellBooks < ActiveRecord::Base
   include Spell::HABTM_SpellBooks::GeneratedAttributeMethods
   include Spell::HABTM_SpellBooks::GeneratedAssociationMethods
   extend Spell::HABTM_SpellBooks::CustomFinderMethods
+  extend Spell::HABTM_SpellBooks::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   RelationType = T.type_alias { T.any(Spell::HABTM_SpellBooks::ActiveRecord_Relation, Spell::HABTM_SpellBooks::ActiveRecord_Associations_CollectionProxy, Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
+end
 
+module Spell::HABTM_SpellBooks::QueryMethodsReturningRelation
   sig { returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def self.all; end
+  def all; end
 
   sig { params(block: T.nilable(T.proc.void)).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def self.unscoped(&block); end
+  def unscoped(&block); end
 
   sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def self.select(*args); end
+  def select(*args); end
 
   sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def self.reselect(*args); end
+  def reselect(*args); end
 
   sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def self.order(*args); end
+  def order(*args); end
 
   sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def self.reorder(*args); end
+  def reorder(*args); end
 
   sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def self.group(*args); end
+  def group(*args); end
 
   sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def self.limit(*args); end
+  def limit(*args); end
 
   sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def self.offset(*args); end
+  def offset(*args); end
 
   sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def self.joins(*args); end
+  def joins(*args); end
 
   sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def self.left_joins(*args); end
+  def left_joins(*args); end
 
   sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def self.left_outer_joins(*args); end
+  def left_outer_joins(*args); end
 
   sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def self.where(*args); end
+  def where(*args); end
 
   sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def self.rewhere(*args); end
+  def rewhere(*args); end
 
   sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def self.preload(*args); end
+  def preload(*args); end
 
   sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def self.extract_associated(*args); end
+  def extract_associated(*args); end
 
   sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def self.eager_load(*args); end
+  def eager_load(*args); end
 
   sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def self.includes(*args); end
+  def includes(*args); end
 
   sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def self.from(*args); end
+  def from(*args); end
 
   sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def self.lock(*args); end
+  def lock(*args); end
 
   sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def self.readonly(*args); end
+  def readonly(*args); end
 
   sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def self.or(*args); end
+  def or(*args); end
 
   sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def self.having(*args); end
+  def having(*args); end
 
   sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def self.create_with(*args); end
+  def create_with(*args); end
 
   sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def self.distinct(*args); end
+  def distinct(*args); end
 
   sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def self.references(*args); end
+  def references(*args); end
 
   sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def self.none(*args); end
+  def none(*args); end
 
   sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def self.unscope(*args); end
+  def unscope(*args); end
 
   sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def self.optimizer_hints(*args); end
+  def optimizer_hints(*args); end
 
   sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def self.merge(*args); end
+  def merge(*args); end
 
   sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def self.except(*args); end
+  def except(*args); end
 
   sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def self.only(*args); end
+  def only(*args); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def self.extending(*args, &block); end
+  def extending(*args, &block); end
+end
+
+module Spell::HABTM_SpellBooks::QueryMethodsReturningAssociationRelation
+  sig { returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
+  def all; end
+
+  sig { params(block: T.nilable(T.proc.void)).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
+  def unscoped(&block); end
+
+  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
+  def select(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
+  def reselect(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
+  def order(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
+  def reorder(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
+  def group(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
+  def limit(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
+  def offset(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
+  def joins(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
+  def left_joins(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
+  def left_outer_joins(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
+  def where(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
+  def rewhere(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
+  def preload(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
+  def extract_associated(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
+  def eager_load(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
+  def includes(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
+  def from(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
+  def lock(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
+  def readonly(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
+  def or(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
+  def having(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
+  def create_with(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
+  def distinct(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
+  def references(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
+  def none(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
+  def unscope(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
+  def optimizer_hints(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
+  def merge(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
+  def except(*args); end
+
+  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
+  def only(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
+  def extending(*args, &block); end
 end
 
 class Spell::HABTM_SpellBooks::ActiveRecord_Relation < ActiveRecord::Relation
   include Spell::HABTM_SpellBooks::ActiveRelation_WhereNot
   include Spell::HABTM_SpellBooks::CustomFinderMethods
+  include Spell::HABTM_SpellBooks::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: Spell::HABTM_SpellBooks)
-
-  sig { returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def reselect(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def extract_associated(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def optimizer_hints(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def only(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
-  def extending(*args, &block); end
 end
 
 class Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
   include Spell::HABTM_SpellBooks::ActiveRelation_WhereNot
   include Spell::HABTM_SpellBooks::CustomFinderMethods
+  include Spell::HABTM_SpellBooks::QueryMethodsReturningAssociationRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: Spell::HABTM_SpellBooks)
-
-  sig { returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def reselect(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def extract_associated(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def optimizer_hints(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def only(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
 end
 
 class Spell::HABTM_SpellBooks::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include Spell::HABTM_SpellBooks::CustomFinderMethods
+  include Spell::HABTM_SpellBooks::QueryMethodsReturningAssociationRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: Spell::HABTM_SpellBooks)
-
-  sig { returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def reselect(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def extract_associated(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def optimizer_hints(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def only(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
 
   sig { params(records: T.any(Spell::HABTM_SpellBooks, T::Array[Spell::HABTM_SpellBooks])).returns(T.self_type) }
   def <<(*records); end

--- a/spec/test_data/v6.0/expected_spell/habtm_spell_books.rbi
+++ b/spec/test_data/v6.0/expected_spell/habtm_spell_books.rbi
@@ -8,8 +8,6 @@ module Spell::HABTM_SpellBooks::ActiveRelation_WhereNot
 end
 
 module Spell::HABTM_SpellBooks::GeneratedAttributeMethods
-  extend T::Sig
-
   sig { returns(Integer) }
   def spell_book_id; end
 
@@ -30,8 +28,6 @@ module Spell::HABTM_SpellBooks::GeneratedAttributeMethods
 end
 
 module Spell::HABTM_SpellBooks::GeneratedAssociationMethods
-  extend T::Sig
-
   sig { returns(T.nilable(::Spell)) }
   def left_side; end
 
@@ -67,8 +63,6 @@ class Spell::HABTM_SpellBooks < ActiveRecord::Base
   include Spell::HABTM_SpellBooks::GeneratedAssociationMethods
   extend Spell::HABTM_SpellBooks::CustomFinderMethods
   extend Spell::HABTM_SpellBooks::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   RelationType = T.type_alias { T.any(Spell::HABTM_SpellBooks::ActiveRecord_Relation, Spell::HABTM_SpellBooks::ActiveRecord_Associations_CollectionProxy, Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
 end
 
@@ -278,8 +272,6 @@ class Spell::HABTM_SpellBooks::ActiveRecord_Relation < ActiveRecord::Relation
   include Spell::HABTM_SpellBooks::ActiveRelation_WhereNot
   include Spell::HABTM_SpellBooks::CustomFinderMethods
   include Spell::HABTM_SpellBooks::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Spell::HABTM_SpellBooks)
 end
 
@@ -287,16 +279,12 @@ class Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation < ActiveRecord::
   include Spell::HABTM_SpellBooks::ActiveRelation_WhereNot
   include Spell::HABTM_SpellBooks::CustomFinderMethods
   include Spell::HABTM_SpellBooks::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Spell::HABTM_SpellBooks)
 end
 
 class Spell::HABTM_SpellBooks::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include Spell::HABTM_SpellBooks::CustomFinderMethods
   include Spell::HABTM_SpellBooks::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Spell::HABTM_SpellBooks)
 
   sig { params(records: T.any(Spell::HABTM_SpellBooks, T::Array[Spell::HABTM_SpellBooks])).returns(T.self_type) }

--- a/spec/test_data/v6.0/expected_spell_book.rbi
+++ b/spec/test_data/v6.0/expected_spell_book.rbi
@@ -119,129 +119,13 @@ class SpellBook < ApplicationRecord
   include SpellBook::GeneratedAttributeMethods
   include SpellBook::GeneratedAssociationMethods
   extend SpellBook::CustomFinderMethods
+  extend SpellBook::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   RelationType = T.type_alias { T.any(SpellBook::ActiveRecord_Relation, SpellBook::ActiveRecord_Associations_CollectionProxy, SpellBook::ActiveRecord_AssociationRelation) }
 
   sig { returns(T::Hash[T.any(String, Symbol), Integer]) }
   def self.book_types; end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def self.biology(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def self.dark_art(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def self.not_biology(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def self.not_dark_art(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def self.not_unclassified(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def self.unclassified(*args); end
-
-  sig { returns(SpellBook::ActiveRecord_Relation) }
-  def self.all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def self.unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def self.select(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def self.reselect(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def self.order(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def self.reorder(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def self.group(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def self.limit(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def self.offset(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def self.joins(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def self.left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def self.left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def self.where(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def self.rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def self.preload(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def self.extract_associated(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def self.eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def self.includes(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def self.from(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def self.lock(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def self.readonly(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def self.or(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def self.having(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def self.create_with(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def self.distinct(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def self.references(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def self.none(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def self.unscope(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def self.optimizer_hints(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def self.merge(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def self.except(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
-  def self.only(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
-  def self.extending(*args, &block); end
 
   sig { returns(SpellBook::BookType) }
   def typed_book_type; end
@@ -250,13 +134,7 @@ class SpellBook < ApplicationRecord
   def typed_book_type=(value); end
 end
 
-class SpellBook::ActiveRecord_Relation < ActiveRecord::Relation
-  include SpellBook::ActiveRelation_WhereNot
-  include SpellBook::CustomFinderMethods
-  extend T::Sig
-  extend T::Generic
-  Elem = type_member(fixed: SpellBook)
-
+module SpellBook::QueryMethodsReturningRelation
   sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
   def biology(*args); end
 
@@ -271,6 +149,9 @@ class SpellBook::ActiveRecord_Relation < ActiveRecord::Relation
 
   sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
   def not_unclassified(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def recent(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
   def unclassified(*args); end
@@ -375,13 +256,7 @@ class SpellBook::ActiveRecord_Relation < ActiveRecord::Relation
   def extending(*args, &block); end
 end
 
-class SpellBook::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
-  include SpellBook::ActiveRelation_WhereNot
-  include SpellBook::CustomFinderMethods
-  extend T::Sig
-  extend T::Generic
-  Elem = type_member(fixed: SpellBook)
-
+module SpellBook::QueryMethodsReturningAssociationRelation
   sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
   def biology(*args); end
 
@@ -398,12 +273,15 @@ class SpellBook::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRel
   def not_unclassified(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def recent(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
   def unclassified(*args); end
 
   sig { returns(SpellBook::ActiveRecord_AssociationRelation) }
   def all; end
 
-  sig { params(block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  sig { params(block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def unscoped(&block); end
 
   sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
@@ -500,128 +378,30 @@ class SpellBook::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRel
   def extending(*args, &block); end
 end
 
-class SpellBook::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
+class SpellBook::ActiveRecord_Relation < ActiveRecord::Relation
+  include SpellBook::ActiveRelation_WhereNot
   include SpellBook::CustomFinderMethods
+  include SpellBook::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: SpellBook)
+end
 
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def biology(*args); end
+class SpellBook::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
+  include SpellBook::ActiveRelation_WhereNot
+  include SpellBook::CustomFinderMethods
+  include SpellBook::QueryMethodsReturningAssociationRelation
+  extend T::Sig
+  extend T::Generic
+  Elem = type_member(fixed: SpellBook)
+end
 
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def dark_art(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def not_biology(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def not_dark_art(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def not_unclassified(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def unclassified(*args); end
-
-  sig { returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def reselect(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def extract_associated(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def optimizer_hints(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def only(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
+class SpellBook::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
+  include SpellBook::CustomFinderMethods
+  include SpellBook::QueryMethodsReturningAssociationRelation
+  extend T::Sig
+  extend T::Generic
+  Elem = type_member(fixed: SpellBook)
 
   sig { params(records: T.any(SpellBook, T::Array[SpellBook])).returns(T.self_type) }
   def <<(*records); end

--- a/spec/test_data/v6.0/expected_spell_book.rbi
+++ b/spec/test_data/v6.0/expected_spell_book.rbi
@@ -3,8 +3,6 @@
 
 # typed: strong
 module SpellBook::EnumInstanceMethods
-  extend T::Sig
-
   sig { returns(T::Boolean) }
   def unclassified?; end
 
@@ -30,8 +28,6 @@ module SpellBook::ActiveRelation_WhereNot
 end
 
 module SpellBook::GeneratedAttributeMethods
-  extend T::Sig
-
   sig { returns(String) }
   def book_type; end
 
@@ -79,8 +75,6 @@ class SpellBook::BookType < T::Enum
 end
 
 module SpellBook::GeneratedAssociationMethods
-  extend T::Sig
-
   sig { returns(::Spell::ActiveRecord_Associations_CollectionProxy) }
   def spells; end
 
@@ -120,8 +114,6 @@ class SpellBook < ApplicationRecord
   include SpellBook::GeneratedAssociationMethods
   extend SpellBook::CustomFinderMethods
   extend SpellBook::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   RelationType = T.type_alias { T.any(SpellBook::ActiveRecord_Relation, SpellBook::ActiveRecord_Associations_CollectionProxy, SpellBook::ActiveRecord_AssociationRelation) }
 
   sig { returns(T::Hash[T.any(String, Symbol), Integer]) }
@@ -382,8 +374,6 @@ class SpellBook::ActiveRecord_Relation < ActiveRecord::Relation
   include SpellBook::ActiveRelation_WhereNot
   include SpellBook::CustomFinderMethods
   include SpellBook::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: SpellBook)
 end
 
@@ -391,16 +381,12 @@ class SpellBook::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRel
   include SpellBook::ActiveRelation_WhereNot
   include SpellBook::CustomFinderMethods
   include SpellBook::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: SpellBook)
 end
 
 class SpellBook::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include SpellBook::CustomFinderMethods
   include SpellBook::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: SpellBook)
 
   sig { params(records: T.any(SpellBook, T::Array[SpellBook])).returns(T.self_type) }

--- a/spec/test_data/v6.0/expected_spell_book/habtm_spells.rbi
+++ b/spec/test_data/v6.0/expected_spell_book/habtm_spells.rbi
@@ -66,428 +66,238 @@ class SpellBook::HABTM_Spells < ActiveRecord::Base
   include SpellBook::HABTM_Spells::GeneratedAttributeMethods
   include SpellBook::HABTM_Spells::GeneratedAssociationMethods
   extend SpellBook::HABTM_Spells::CustomFinderMethods
+  extend SpellBook::HABTM_Spells::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   RelationType = T.type_alias { T.any(SpellBook::HABTM_Spells::ActiveRecord_Relation, SpellBook::HABTM_Spells::ActiveRecord_Associations_CollectionProxy, SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
+end
 
+module SpellBook::HABTM_Spells::QueryMethodsReturningRelation
   sig { returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def self.all; end
+  def all; end
 
   sig { params(block: T.nilable(T.proc.void)).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def self.unscoped(&block); end
+  def unscoped(&block); end
 
   sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def self.select(*args); end
+  def select(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def self.reselect(*args); end
+  def reselect(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def self.order(*args); end
+  def order(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def self.reorder(*args); end
+  def reorder(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def self.group(*args); end
+  def group(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def self.limit(*args); end
+  def limit(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def self.offset(*args); end
+  def offset(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def self.joins(*args); end
+  def joins(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def self.left_joins(*args); end
+  def left_joins(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def self.left_outer_joins(*args); end
+  def left_outer_joins(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def self.where(*args); end
+  def where(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def self.rewhere(*args); end
+  def rewhere(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def self.preload(*args); end
+  def preload(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def self.extract_associated(*args); end
+  def extract_associated(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def self.eager_load(*args); end
+  def eager_load(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def self.includes(*args); end
+  def includes(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def self.from(*args); end
+  def from(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def self.lock(*args); end
+  def lock(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def self.readonly(*args); end
+  def readonly(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def self.or(*args); end
+  def or(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def self.having(*args); end
+  def having(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def self.create_with(*args); end
+  def create_with(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def self.distinct(*args); end
+  def distinct(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def self.references(*args); end
+  def references(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def self.none(*args); end
+  def none(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def self.unscope(*args); end
+  def unscope(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def self.optimizer_hints(*args); end
+  def optimizer_hints(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def self.merge(*args); end
+  def merge(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def self.except(*args); end
+  def except(*args); end
 
   sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def self.only(*args); end
+  def only(*args); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def self.extending(*args, &block); end
+  def extending(*args, &block); end
+end
+
+module SpellBook::HABTM_Spells::QueryMethodsReturningAssociationRelation
+  sig { returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
+  def all; end
+
+  sig { params(block: T.nilable(T.proc.void)).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
+  def unscoped(&block); end
+
+  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
+  def select(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
+  def reselect(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
+  def order(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
+  def reorder(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
+  def group(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
+  def limit(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
+  def offset(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
+  def joins(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
+  def left_joins(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
+  def left_outer_joins(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
+  def where(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
+  def rewhere(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
+  def preload(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
+  def extract_associated(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
+  def eager_load(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
+  def includes(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
+  def from(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
+  def lock(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
+  def readonly(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
+  def or(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
+  def having(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
+  def create_with(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
+  def distinct(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
+  def references(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
+  def none(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
+  def unscope(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
+  def optimizer_hints(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
+  def merge(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
+  def except(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
+  def only(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
+  def extending(*args, &block); end
 end
 
 class SpellBook::HABTM_Spells::ActiveRecord_Relation < ActiveRecord::Relation
   include SpellBook::HABTM_Spells::ActiveRelation_WhereNot
   include SpellBook::HABTM_Spells::CustomFinderMethods
+  include SpellBook::HABTM_Spells::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: SpellBook::HABTM_Spells)
-
-  sig { returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def reselect(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def extract_associated(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def optimizer_hints(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def only(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
-  def extending(*args, &block); end
 end
 
 class SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
   include SpellBook::HABTM_Spells::ActiveRelation_WhereNot
   include SpellBook::HABTM_Spells::CustomFinderMethods
+  include SpellBook::HABTM_Spells::QueryMethodsReturningAssociationRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: SpellBook::HABTM_Spells)
-
-  sig { returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def reselect(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def extract_associated(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def optimizer_hints(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def only(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
 end
 
 class SpellBook::HABTM_Spells::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include SpellBook::HABTM_Spells::CustomFinderMethods
+  include SpellBook::HABTM_Spells::QueryMethodsReturningAssociationRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: SpellBook::HABTM_Spells)
-
-  sig { returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def reselect(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def extract_associated(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def optimizer_hints(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def only(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
 
   sig { params(records: T.any(SpellBook::HABTM_Spells, T::Array[SpellBook::HABTM_Spells])).returns(T.self_type) }
   def <<(*records); end

--- a/spec/test_data/v6.0/expected_spell_book/habtm_spells.rbi
+++ b/spec/test_data/v6.0/expected_spell_book/habtm_spells.rbi
@@ -8,8 +8,6 @@ module SpellBook::HABTM_Spells::ActiveRelation_WhereNot
 end
 
 module SpellBook::HABTM_Spells::GeneratedAttributeMethods
-  extend T::Sig
-
   sig { returns(Integer) }
   def spell_book_id; end
 
@@ -30,8 +28,6 @@ module SpellBook::HABTM_Spells::GeneratedAttributeMethods
 end
 
 module SpellBook::HABTM_Spells::GeneratedAssociationMethods
-  extend T::Sig
-
   sig { returns(T.nilable(::SpellBook)) }
   def left_side; end
 
@@ -67,8 +63,6 @@ class SpellBook::HABTM_Spells < ActiveRecord::Base
   include SpellBook::HABTM_Spells::GeneratedAssociationMethods
   extend SpellBook::HABTM_Spells::CustomFinderMethods
   extend SpellBook::HABTM_Spells::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   RelationType = T.type_alias { T.any(SpellBook::HABTM_Spells::ActiveRecord_Relation, SpellBook::HABTM_Spells::ActiveRecord_Associations_CollectionProxy, SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
 end
 
@@ -278,8 +272,6 @@ class SpellBook::HABTM_Spells::ActiveRecord_Relation < ActiveRecord::Relation
   include SpellBook::HABTM_Spells::ActiveRelation_WhereNot
   include SpellBook::HABTM_Spells::CustomFinderMethods
   include SpellBook::HABTM_Spells::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: SpellBook::HABTM_Spells)
 end
 
@@ -287,16 +279,12 @@ class SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation < ActiveRecord::
   include SpellBook::HABTM_Spells::ActiveRelation_WhereNot
   include SpellBook::HABTM_Spells::CustomFinderMethods
   include SpellBook::HABTM_Spells::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: SpellBook::HABTM_Spells)
 end
 
 class SpellBook::HABTM_Spells::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include SpellBook::HABTM_Spells::CustomFinderMethods
   include SpellBook::HABTM_Spells::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: SpellBook::HABTM_Spells)
 
   sig { params(records: T.any(SpellBook::HABTM_Spells, T::Array[SpellBook::HABTM_Spells])).returns(T.self_type) }

--- a/spec/test_data/v6.0/expected_squib.rbi
+++ b/spec/test_data/v6.0/expected_squib.rbi
@@ -3,8 +3,6 @@
 
 # typed: strong
 module Squib::EnumInstanceMethods
-  extend T::Sig
-
   sig { returns(T::Boolean) }
   def broom_nimbus?; end
 
@@ -114,8 +112,6 @@ module Squib::ActiveRelation_WhereNot
 end
 
 module Squib::GeneratedAttributeMethods
-  extend T::Sig
-
   sig { returns(T.nilable(String)) }
   def broom; end
 
@@ -275,8 +271,6 @@ class Squib < Wizard
   include Squib::GeneratedAssociationMethods
   extend Squib::CustomFinderMethods
   extend Squib::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   RelationType = T.type_alias { T.any(Squib::ActiveRecord_Relation, Squib::ActiveRecord_Associations_CollectionProxy, Squib::ActiveRecord_AssociationRelation) }
 
   sig { returns(T::Hash[T.any(String, Symbol), String]) }
@@ -726,8 +720,6 @@ class Squib::ActiveRecord_Relation < ActiveRecord::Relation
   include Squib::ActiveRelation_WhereNot
   include Squib::CustomFinderMethods
   include Squib::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Squib)
 end
 
@@ -735,14 +727,10 @@ class Squib::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelatio
   include Squib::ActiveRelation_WhereNot
   include Squib::CustomFinderMethods
   include Squib::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Squib)
 end
 
 module Squib::GeneratedAssociationMethods
-  extend T::Sig
-
   sig { returns(::ActiveStorage::Attachment::ActiveRecord_Associations_CollectionProxy) }
   def hats_attachments; end
 
@@ -819,8 +807,6 @@ end
 class Squib::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include Squib::CustomFinderMethods
   include Squib::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Squib)
 
   sig { params(records: T.any(Squib, T::Array[Squib])).returns(T.self_type) }

--- a/spec/test_data/v6.0/expected_squib.rbi
+++ b/spec/test_data/v6.0/expected_squib.rbi
@@ -274,6 +274,7 @@ class Squib < Wizard
   include Squib::GeneratedAttributeMethods
   include Squib::GeneratedAssociationMethods
   extend Squib::CustomFinderMethods
+  extend Squib::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   RelationType = T.type_alias { T.any(Squib::ActiveRecord_Relation, Squib::ActiveRecord_Associations_CollectionProxy, Squib::ActiveRecord_AssociationRelation) }
@@ -295,881 +296,448 @@ class Squib < Wizard
 
   sig { returns(T::Hash[T.any(String, Symbol), Integer]) }
   def self.quidditch_positions; end
+end
+
+module Squib::QueryMethodsReturningRelation
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def Gryffindor(*args); end
 
   sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.Gryffindor(*args); end
+  def Hagrid(*args); end
 
   sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.Hagrid(*args); end
+  def Hufflepuff(*args); end
 
   sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.Hufflepuff(*args); end
+  def Ravenclaw(*args); end
 
   sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.Ravenclaw(*args); end
+  def Slytherin(*args); end
 
   sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.Slytherin(*args); end
+  def black_hair(*args); end
 
   sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.black_hair(*args); end
+  def blonde_hair(*args); end
 
   sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.blonde_hair(*args); end
+  def broom_firebolt(*args); end
 
   sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.broom_firebolt(*args); end
+  def broom_nimbus(*args); end
 
   sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.broom_nimbus(*args); end
+  def brown_hair(*args); end
 
   sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.brown_hair(*args); end
+  def color_blue_eyes(*args); end
 
   sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.color_blue_eyes(*args); end
+  def color_brown_eyes(*args); end
 
   sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.color_brown_eyes(*args); end
+  def color_green_eyes(*args); end
 
   sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.color_green_eyes(*args); end
+  def not_Gryffindor(*args); end
 
   sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.not_Gryffindor(*args); end
+  def not_Hagrid(*args); end
 
   sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.not_Hagrid(*args); end
+  def not_Hufflepuff(*args); end
 
   sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.not_Hufflepuff(*args); end
+  def not_Ravenclaw(*args); end
 
   sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.not_Ravenclaw(*args); end
+  def not_Slytherin(*args); end
 
   sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.not_Slytherin(*args); end
+  def not_black_hair(*args); end
 
   sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.not_black_hair(*args); end
+  def not_blonde_hair(*args); end
 
   sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.not_blonde_hair(*args); end
+  def not_broom_firebolt(*args); end
 
   sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.not_broom_firebolt(*args); end
+  def not_broom_nimbus(*args); end
 
   sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.not_broom_nimbus(*args); end
+  def not_brown_hair(*args); end
 
   sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.not_brown_hair(*args); end
+  def not_color_blue_eyes(*args); end
 
   sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.not_color_blue_eyes(*args); end
+  def not_color_brown_eyes(*args); end
 
   sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.not_color_brown_eyes(*args); end
+  def not_color_green_eyes(*args); end
 
   sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.not_color_green_eyes(*args); end
+  def not_quidditch_beater(*args); end
 
   sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.not_quidditch_beater(*args); end
+  def not_quidditch_chaser(*args); end
 
   sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.not_quidditch_chaser(*args); end
+  def not_quidditch_keeper(*args); end
 
   sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.not_quidditch_keeper(*args); end
+  def not_quidditch_seeker(*args); end
 
   sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.not_quidditch_seeker(*args); end
+  def quidditch_beater(*args); end
 
   sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.quidditch_beater(*args); end
+  def quidditch_chaser(*args); end
 
   sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.quidditch_chaser(*args); end
+  def quidditch_keeper(*args); end
 
   sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.quidditch_keeper(*args); end
+  def quidditch_seeker(*args); end
 
   sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.quidditch_seeker(*args); end
+  def recent(*args); end
 
   sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.recent(*args); end
+  def with_attached_hats(*args); end
 
   sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.with_attached_hats(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.with_attached_school_photo(*args); end
+  def with_attached_school_photo(*args); end
 
   sig { returns(Squib::ActiveRecord_Relation) }
-  def self.all; end
+  def all; end
 
   sig { params(block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def self.unscoped(&block); end
+  def unscoped(&block); end
 
   sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.select(*args); end
+  def select(*args); end
 
   sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.reselect(*args); end
+  def reselect(*args); end
 
   sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.order(*args); end
+  def order(*args); end
 
   sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.reorder(*args); end
+  def reorder(*args); end
 
   sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.group(*args); end
+  def group(*args); end
 
   sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.limit(*args); end
+  def limit(*args); end
 
   sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.offset(*args); end
+  def offset(*args); end
 
   sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.joins(*args); end
+  def joins(*args); end
 
   sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.left_joins(*args); end
+  def left_joins(*args); end
 
   sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.left_outer_joins(*args); end
+  def left_outer_joins(*args); end
 
   sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.where(*args); end
+  def where(*args); end
 
   sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.rewhere(*args); end
+  def rewhere(*args); end
 
   sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.preload(*args); end
+  def preload(*args); end
 
   sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.extract_associated(*args); end
+  def extract_associated(*args); end
 
   sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.eager_load(*args); end
+  def eager_load(*args); end
 
   sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.includes(*args); end
+  def includes(*args); end
 
   sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.from(*args); end
+  def from(*args); end
 
   sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.lock(*args); end
+  def lock(*args); end
 
   sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.readonly(*args); end
+  def readonly(*args); end
 
   sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.or(*args); end
+  def or(*args); end
 
   sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.having(*args); end
+  def having(*args); end
 
   sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.create_with(*args); end
+  def create_with(*args); end
 
   sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.distinct(*args); end
+  def distinct(*args); end
 
   sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.references(*args); end
+  def references(*args); end
 
   sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.none(*args); end
+  def none(*args); end
 
   sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.unscope(*args); end
+  def unscope(*args); end
 
   sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.optimizer_hints(*args); end
+  def optimizer_hints(*args); end
 
   sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.merge(*args); end
+  def merge(*args); end
 
   sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.except(*args); end
+  def except(*args); end
 
   sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def self.only(*args); end
+  def only(*args); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def self.extending(*args, &block); end
+  def extending(*args, &block); end
+end
+
+module Squib::QueryMethodsReturningAssociationRelation
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def Gryffindor(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def Hagrid(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def Hufflepuff(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def Ravenclaw(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def Slytherin(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def black_hair(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def blonde_hair(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def broom_firebolt(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def broom_nimbus(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def brown_hair(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def color_blue_eyes(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def color_brown_eyes(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def color_green_eyes(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def not_Gryffindor(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def not_Hagrid(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def not_Hufflepuff(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def not_Ravenclaw(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def not_Slytherin(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def not_black_hair(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def not_blonde_hair(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def not_broom_firebolt(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def not_broom_nimbus(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def not_brown_hair(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def not_color_blue_eyes(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def not_color_brown_eyes(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def not_color_green_eyes(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def not_quidditch_beater(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def not_quidditch_chaser(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def not_quidditch_keeper(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def not_quidditch_seeker(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def quidditch_beater(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def quidditch_chaser(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def quidditch_keeper(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def quidditch_seeker(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def recent(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def with_attached_hats(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def with_attached_school_photo(*args); end
+
+  sig { returns(Squib::ActiveRecord_AssociationRelation) }
+  def all; end
+
+  sig { params(block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
+  def unscoped(&block); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def select(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def reselect(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def order(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def reorder(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def group(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def limit(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def offset(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def joins(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def left_joins(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def left_outer_joins(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def where(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def rewhere(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def preload(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def extract_associated(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def eager_load(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def includes(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def from(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def lock(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def readonly(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def or(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def having(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def create_with(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def distinct(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def references(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def none(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def unscope(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def optimizer_hints(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def merge(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def except(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def only(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
+  def extending(*args, &block); end
 end
 
 class Squib::ActiveRecord_Relation < ActiveRecord::Relation
   include Squib::ActiveRelation_WhereNot
   include Squib::CustomFinderMethods
+  include Squib::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: Squib)
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def Gryffindor(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def Hagrid(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def Hufflepuff(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def Ravenclaw(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def Slytherin(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def black_hair(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def blonde_hair(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def broom_firebolt(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def broom_nimbus(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def brown_hair(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def color_blue_eyes(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def color_brown_eyes(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def color_green_eyes(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def not_Gryffindor(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def not_Hagrid(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def not_Hufflepuff(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def not_Ravenclaw(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def not_Slytherin(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def not_black_hair(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def not_blonde_hair(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def not_broom_firebolt(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def not_broom_nimbus(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def not_brown_hair(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def not_color_blue_eyes(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def not_color_brown_eyes(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def not_color_green_eyes(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def not_quidditch_beater(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def not_quidditch_chaser(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def not_quidditch_keeper(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def not_quidditch_seeker(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def quidditch_beater(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def quidditch_chaser(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def quidditch_keeper(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def quidditch_seeker(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def recent(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def with_attached_hats(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def with_attached_school_photo(*args); end
-
-  sig { returns(Squib::ActiveRecord_Relation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def reselect(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def extract_associated(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def optimizer_hints(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
-  def only(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
-  def extending(*args, &block); end
 end
 
 class Squib::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
   include Squib::ActiveRelation_WhereNot
   include Squib::CustomFinderMethods
+  include Squib::QueryMethodsReturningAssociationRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: Squib)
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def Gryffindor(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def Hagrid(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def Hufflepuff(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def Ravenclaw(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def Slytherin(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def black_hair(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def blonde_hair(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def broom_firebolt(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def broom_nimbus(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def brown_hair(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def color_blue_eyes(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def color_brown_eyes(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def color_green_eyes(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def not_Gryffindor(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def not_Hagrid(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def not_Hufflepuff(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def not_Ravenclaw(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def not_Slytherin(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def not_black_hair(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def not_blonde_hair(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def not_broom_firebolt(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def not_broom_nimbus(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def not_brown_hair(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def not_color_blue_eyes(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def not_color_brown_eyes(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def not_color_green_eyes(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def not_quidditch_beater(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def not_quidditch_chaser(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def not_quidditch_keeper(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def not_quidditch_seeker(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def quidditch_beater(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def quidditch_chaser(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def quidditch_keeper(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def quidditch_seeker(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def recent(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def with_attached_hats(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def with_attached_school_photo(*args); end
-
-  sig { returns(Squib::ActiveRecord_AssociationRelation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def reselect(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def extract_associated(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def optimizer_hints(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def only(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
-end
-
-class Squib::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
-  include Squib::CustomFinderMethods
-  extend T::Sig
-  extend T::Generic
-  Elem = type_member(fixed: Squib)
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def Gryffindor(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def Hagrid(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def Hufflepuff(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def Ravenclaw(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def Slytherin(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def black_hair(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def blonde_hair(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def broom_firebolt(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def broom_nimbus(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def brown_hair(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def color_blue_eyes(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def color_brown_eyes(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def color_green_eyes(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def not_Gryffindor(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def not_Hagrid(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def not_Hufflepuff(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def not_Ravenclaw(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def not_Slytherin(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def not_black_hair(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def not_blonde_hair(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def not_broom_firebolt(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def not_broom_nimbus(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def not_brown_hair(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def not_color_blue_eyes(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def not_color_brown_eyes(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def not_color_green_eyes(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def not_quidditch_beater(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def not_quidditch_chaser(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def not_quidditch_keeper(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def not_quidditch_seeker(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def quidditch_beater(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def quidditch_chaser(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def quidditch_keeper(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def quidditch_seeker(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def recent(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def with_attached_hats(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def with_attached_school_photo(*args); end
-
-  sig { returns(Squib::ActiveRecord_AssociationRelation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def reselect(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def extract_associated(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def optimizer_hints(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def only(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
-
-  sig { params(records: T.any(Squib, T::Array[Squib])).returns(T.self_type) }
-  def <<(*records); end
-
-  sig { params(records: T.any(Squib, T::Array[Squib])).returns(T.self_type) }
-  def append(*records); end
-
-  sig { params(records: T.any(Squib, T::Array[Squib])).returns(T.self_type) }
-  def push(*records); end
-
-  sig { params(records: T.any(Squib, T::Array[Squib])).returns(T.self_type) }
-  def concat(*records); end
 end
 
 module Squib::GeneratedAssociationMethods
@@ -1246,4 +814,24 @@ module Squib::GeneratedAssociationMethods
 
   sig { params(attachables: T.untyped).returns(T.untyped) }
   def hats=(*attachables); end
+end
+
+class Squib::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
+  include Squib::CustomFinderMethods
+  include Squib::QueryMethodsReturningAssociationRelation
+  extend T::Sig
+  extend T::Generic
+  Elem = type_member(fixed: Squib)
+
+  sig { params(records: T.any(Squib, T::Array[Squib])).returns(T.self_type) }
+  def <<(*records); end
+
+  sig { params(records: T.any(Squib, T::Array[Squib])).returns(T.self_type) }
+  def append(*records); end
+
+  sig { params(records: T.any(Squib, T::Array[Squib])).returns(T.self_type) }
+  def push(*records); end
+
+  sig { params(records: T.any(Squib, T::Array[Squib])).returns(T.self_type) }
+  def concat(*records); end
 end

--- a/spec/test_data/v6.0/expected_subject.rbi
+++ b/spec/test_data/v6.0/expected_subject.rbi
@@ -8,8 +8,6 @@ module Subject::ActiveRelation_WhereNot
 end
 
 module Subject::GeneratedAttributeMethods
-  extend T::Sig
-
   sig { returns(Integer) }
   def id; end
 
@@ -30,8 +28,6 @@ module Subject::GeneratedAttributeMethods
 end
 
 module Subject::GeneratedAssociationMethods
-  extend T::Sig
-
   sig { returns(::Wizard::ActiveRecord_Associations_CollectionProxy) }
   def wizards; end
 
@@ -64,8 +60,6 @@ class Subject < ApplicationRecord
   include Subject::GeneratedAssociationMethods
   extend Subject::CustomFinderMethods
   extend Subject::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   RelationType = T.type_alias { T.any(Subject::ActiveRecord_Relation, Subject::ActiveRecord_Associations_CollectionProxy, Subject::ActiveRecord_AssociationRelation) }
 end
 
@@ -275,8 +269,6 @@ class Subject::ActiveRecord_Relation < ActiveRecord::Relation
   include Subject::ActiveRelation_WhereNot
   include Subject::CustomFinderMethods
   include Subject::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Subject)
 end
 
@@ -284,16 +276,12 @@ class Subject::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelat
   include Subject::ActiveRelation_WhereNot
   include Subject::CustomFinderMethods
   include Subject::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Subject)
 end
 
 class Subject::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include Subject::CustomFinderMethods
   include Subject::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Subject)
 
   sig { params(records: T.any(Subject, T::Array[Subject])).returns(T.self_type) }

--- a/spec/test_data/v6.0/expected_subject.rbi
+++ b/spec/test_data/v6.0/expected_subject.rbi
@@ -63,428 +63,238 @@ class Subject < ApplicationRecord
   include Subject::GeneratedAttributeMethods
   include Subject::GeneratedAssociationMethods
   extend Subject::CustomFinderMethods
+  extend Subject::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   RelationType = T.type_alias { T.any(Subject::ActiveRecord_Relation, Subject::ActiveRecord_Associations_CollectionProxy, Subject::ActiveRecord_AssociationRelation) }
+end
 
+module Subject::QueryMethodsReturningRelation
   sig { returns(Subject::ActiveRecord_Relation) }
-  def self.all; end
+  def all; end
 
   sig { params(block: T.nilable(T.proc.void)).returns(Subject::ActiveRecord_Relation) }
-  def self.unscoped(&block); end
+  def unscoped(&block); end
 
   sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def self.select(*args); end
+  def select(*args); end
 
   sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def self.reselect(*args); end
+  def reselect(*args); end
 
   sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def self.order(*args); end
+  def order(*args); end
 
   sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def self.reorder(*args); end
+  def reorder(*args); end
 
   sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def self.group(*args); end
+  def group(*args); end
 
   sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def self.limit(*args); end
+  def limit(*args); end
 
   sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def self.offset(*args); end
+  def offset(*args); end
 
   sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def self.joins(*args); end
+  def joins(*args); end
 
   sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def self.left_joins(*args); end
+  def left_joins(*args); end
 
   sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def self.left_outer_joins(*args); end
+  def left_outer_joins(*args); end
 
   sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def self.where(*args); end
+  def where(*args); end
 
   sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def self.rewhere(*args); end
+  def rewhere(*args); end
 
   sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def self.preload(*args); end
+  def preload(*args); end
 
   sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def self.extract_associated(*args); end
+  def extract_associated(*args); end
 
   sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def self.eager_load(*args); end
+  def eager_load(*args); end
 
   sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def self.includes(*args); end
+  def includes(*args); end
 
   sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def self.from(*args); end
+  def from(*args); end
 
   sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def self.lock(*args); end
+  def lock(*args); end
 
   sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def self.readonly(*args); end
+  def readonly(*args); end
 
   sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def self.or(*args); end
+  def or(*args); end
 
   sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def self.having(*args); end
+  def having(*args); end
 
   sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def self.create_with(*args); end
+  def create_with(*args); end
 
   sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def self.distinct(*args); end
+  def distinct(*args); end
 
   sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def self.references(*args); end
+  def references(*args); end
 
   sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def self.none(*args); end
+  def none(*args); end
 
   sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def self.unscope(*args); end
+  def unscope(*args); end
 
   sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def self.optimizer_hints(*args); end
+  def optimizer_hints(*args); end
 
   sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def self.merge(*args); end
+  def merge(*args); end
 
   sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def self.except(*args); end
+  def except(*args); end
 
   sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def self.only(*args); end
+  def only(*args); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Subject::ActiveRecord_Relation) }
-  def self.extending(*args, &block); end
+  def extending(*args, &block); end
+end
+
+module Subject::QueryMethodsReturningAssociationRelation
+  sig { returns(Subject::ActiveRecord_AssociationRelation) }
+  def all; end
+
+  sig { params(block: T.nilable(T.proc.void)).returns(Subject::ActiveRecord_Relation) }
+  def unscoped(&block); end
+
+  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
+  def select(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
+  def reselect(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
+  def order(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
+  def reorder(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
+  def group(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
+  def limit(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
+  def offset(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
+  def joins(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
+  def left_joins(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
+  def left_outer_joins(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
+  def where(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
+  def rewhere(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
+  def preload(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
+  def extract_associated(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
+  def eager_load(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
+  def includes(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
+  def from(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
+  def lock(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
+  def readonly(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
+  def or(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
+  def having(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
+  def create_with(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
+  def distinct(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
+  def references(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
+  def none(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
+  def unscope(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
+  def optimizer_hints(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
+  def merge(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
+  def except(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
+  def only(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Subject::ActiveRecord_AssociationRelation) }
+  def extending(*args, &block); end
 end
 
 class Subject::ActiveRecord_Relation < ActiveRecord::Relation
   include Subject::ActiveRelation_WhereNot
   include Subject::CustomFinderMethods
+  include Subject::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: Subject)
-
-  sig { returns(Subject::ActiveRecord_Relation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Subject::ActiveRecord_Relation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def reselect(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def extract_associated(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def optimizer_hints(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_Relation) }
-  def only(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Subject::ActiveRecord_Relation) }
-  def extending(*args, &block); end
 end
 
 class Subject::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
   include Subject::ActiveRelation_WhereNot
   include Subject::CustomFinderMethods
+  include Subject::QueryMethodsReturningAssociationRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: Subject)
-
-  sig { returns(Subject::ActiveRecord_AssociationRelation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Subject::ActiveRecord_AssociationRelation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def reselect(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def extract_associated(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def optimizer_hints(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def only(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Subject::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
 end
 
 class Subject::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include Subject::CustomFinderMethods
+  include Subject::QueryMethodsReturningAssociationRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: Subject)
-
-  sig { returns(Subject::ActiveRecord_AssociationRelation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Subject::ActiveRecord_AssociationRelation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def reselect(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def extract_associated(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def optimizer_hints(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::ActiveRecord_AssociationRelation) }
-  def only(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Subject::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
 
   sig { params(records: T.any(Subject, T::Array[Subject])).returns(T.self_type) }
   def <<(*records); end

--- a/spec/test_data/v6.0/expected_subject/habtm_wizards.rbi
+++ b/spec/test_data/v6.0/expected_subject/habtm_wizards.rbi
@@ -66,428 +66,238 @@ class Subject::HABTM_Wizards < ActiveRecord::Base
   include Subject::HABTM_Wizards::GeneratedAttributeMethods
   include Subject::HABTM_Wizards::GeneratedAssociationMethods
   extend Subject::HABTM_Wizards::CustomFinderMethods
+  extend Subject::HABTM_Wizards::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   RelationType = T.type_alias { T.any(Subject::HABTM_Wizards::ActiveRecord_Relation, Subject::HABTM_Wizards::ActiveRecord_Associations_CollectionProxy, Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
+end
 
+module Subject::HABTM_Wizards::QueryMethodsReturningRelation
   sig { returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def self.all; end
+  def all; end
 
   sig { params(block: T.nilable(T.proc.void)).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def self.unscoped(&block); end
+  def unscoped(&block); end
 
   sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def self.select(*args); end
+  def select(*args); end
 
   sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def self.reselect(*args); end
+  def reselect(*args); end
 
   sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def self.order(*args); end
+  def order(*args); end
 
   sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def self.reorder(*args); end
+  def reorder(*args); end
 
   sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def self.group(*args); end
+  def group(*args); end
 
   sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def self.limit(*args); end
+  def limit(*args); end
 
   sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def self.offset(*args); end
+  def offset(*args); end
 
   sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def self.joins(*args); end
+  def joins(*args); end
 
   sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def self.left_joins(*args); end
+  def left_joins(*args); end
 
   sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def self.left_outer_joins(*args); end
+  def left_outer_joins(*args); end
 
   sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def self.where(*args); end
+  def where(*args); end
 
   sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def self.rewhere(*args); end
+  def rewhere(*args); end
 
   sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def self.preload(*args); end
+  def preload(*args); end
 
   sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def self.extract_associated(*args); end
+  def extract_associated(*args); end
 
   sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def self.eager_load(*args); end
+  def eager_load(*args); end
 
   sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def self.includes(*args); end
+  def includes(*args); end
 
   sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def self.from(*args); end
+  def from(*args); end
 
   sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def self.lock(*args); end
+  def lock(*args); end
 
   sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def self.readonly(*args); end
+  def readonly(*args); end
 
   sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def self.or(*args); end
+  def or(*args); end
 
   sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def self.having(*args); end
+  def having(*args); end
 
   sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def self.create_with(*args); end
+  def create_with(*args); end
 
   sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def self.distinct(*args); end
+  def distinct(*args); end
 
   sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def self.references(*args); end
+  def references(*args); end
 
   sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def self.none(*args); end
+  def none(*args); end
 
   sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def self.unscope(*args); end
+  def unscope(*args); end
 
   sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def self.optimizer_hints(*args); end
+  def optimizer_hints(*args); end
 
   sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def self.merge(*args); end
+  def merge(*args); end
 
   sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def self.except(*args); end
+  def except(*args); end
 
   sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def self.only(*args); end
+  def only(*args); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def self.extending(*args, &block); end
+  def extending(*args, &block); end
+end
+
+module Subject::HABTM_Wizards::QueryMethodsReturningAssociationRelation
+  sig { returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
+  def all; end
+
+  sig { params(block: T.nilable(T.proc.void)).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
+  def unscoped(&block); end
+
+  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
+  def select(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
+  def reselect(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
+  def order(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
+  def reorder(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
+  def group(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
+  def limit(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
+  def offset(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
+  def joins(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
+  def left_joins(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
+  def left_outer_joins(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
+  def where(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
+  def rewhere(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
+  def preload(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
+  def extract_associated(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
+  def eager_load(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
+  def includes(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
+  def from(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
+  def lock(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
+  def readonly(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
+  def or(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
+  def having(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
+  def create_with(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
+  def distinct(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
+  def references(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
+  def none(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
+  def unscope(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
+  def optimizer_hints(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
+  def merge(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
+  def except(*args); end
+
+  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
+  def only(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
+  def extending(*args, &block); end
 end
 
 class Subject::HABTM_Wizards::ActiveRecord_Relation < ActiveRecord::Relation
   include Subject::HABTM_Wizards::ActiveRelation_WhereNot
   include Subject::HABTM_Wizards::CustomFinderMethods
+  include Subject::HABTM_Wizards::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: Subject::HABTM_Wizards)
-
-  sig { returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def reselect(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def extract_associated(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def optimizer_hints(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def only(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
-  def extending(*args, &block); end
 end
 
 class Subject::HABTM_Wizards::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
   include Subject::HABTM_Wizards::ActiveRelation_WhereNot
   include Subject::HABTM_Wizards::CustomFinderMethods
+  include Subject::HABTM_Wizards::QueryMethodsReturningAssociationRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: Subject::HABTM_Wizards)
-
-  sig { returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def reselect(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def extract_associated(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def optimizer_hints(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def only(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
 end
 
 class Subject::HABTM_Wizards::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include Subject::HABTM_Wizards::CustomFinderMethods
+  include Subject::HABTM_Wizards::QueryMethodsReturningAssociationRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: Subject::HABTM_Wizards)
-
-  sig { returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def reselect(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def extract_associated(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def optimizer_hints(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def only(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
 
   sig { params(records: T.any(Subject::HABTM_Wizards, T::Array[Subject::HABTM_Wizards])).returns(T.self_type) }
   def <<(*records); end

--- a/spec/test_data/v6.0/expected_subject/habtm_wizards.rbi
+++ b/spec/test_data/v6.0/expected_subject/habtm_wizards.rbi
@@ -8,8 +8,6 @@ module Subject::HABTM_Wizards::ActiveRelation_WhereNot
 end
 
 module Subject::HABTM_Wizards::GeneratedAttributeMethods
-  extend T::Sig
-
   sig { returns(T.nilable(Integer)) }
   def subject_id; end
 
@@ -30,8 +28,6 @@ module Subject::HABTM_Wizards::GeneratedAttributeMethods
 end
 
 module Subject::HABTM_Wizards::GeneratedAssociationMethods
-  extend T::Sig
-
   sig { returns(T.nilable(::Subject)) }
   def left_side; end
 
@@ -67,8 +63,6 @@ class Subject::HABTM_Wizards < ActiveRecord::Base
   include Subject::HABTM_Wizards::GeneratedAssociationMethods
   extend Subject::HABTM_Wizards::CustomFinderMethods
   extend Subject::HABTM_Wizards::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   RelationType = T.type_alias { T.any(Subject::HABTM_Wizards::ActiveRecord_Relation, Subject::HABTM_Wizards::ActiveRecord_Associations_CollectionProxy, Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
 end
 
@@ -278,8 +272,6 @@ class Subject::HABTM_Wizards::ActiveRecord_Relation < ActiveRecord::Relation
   include Subject::HABTM_Wizards::ActiveRelation_WhereNot
   include Subject::HABTM_Wizards::CustomFinderMethods
   include Subject::HABTM_Wizards::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Subject::HABTM_Wizards)
 end
 
@@ -287,16 +279,12 @@ class Subject::HABTM_Wizards::ActiveRecord_AssociationRelation < ActiveRecord::A
   include Subject::HABTM_Wizards::ActiveRelation_WhereNot
   include Subject::HABTM_Wizards::CustomFinderMethods
   include Subject::HABTM_Wizards::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Subject::HABTM_Wizards)
 end
 
 class Subject::HABTM_Wizards::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include Subject::HABTM_Wizards::CustomFinderMethods
   include Subject::HABTM_Wizards::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Subject::HABTM_Wizards)
 
   sig { params(records: T.any(Subject::HABTM_Wizards, T::Array[Subject::HABTM_Wizards])).returns(T.self_type) }

--- a/spec/test_data/v6.0/expected_wand.rbi
+++ b/spec/test_data/v6.0/expected_wand.rbi
@@ -216,135 +216,13 @@ class Wand < ApplicationRecord
   include Wand::GeneratedAttributeMethods
   include Wand::GeneratedAssociationMethods
   extend Wand::CustomFinderMethods
+  extend Wand::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   RelationType = T.type_alias { T.any(Wand::ActiveRecord_Relation, Wand::ActiveRecord_Associations_CollectionProxy, Wand::ActiveRecord_AssociationRelation) }
 
   sig { returns(T::Hash[T.any(String, Symbol), Integer]) }
   def self.core_types; end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
-  def self.basilisk_horn(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
-  def self.dragon_heartstring(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
-  def self.not_basilisk_horn(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
-  def self.not_dragon_heartstring(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
-  def self.not_phoenix_feather(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
-  def self.not_unicorn_tail_hair(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
-  def self.phoenix_feather(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
-  def self.unicorn_tail_hair(*args); end
-
-  sig { returns(Wand::ActiveRecord_Relation) }
-  def self.all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def self.unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
-  def self.select(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
-  def self.reselect(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
-  def self.order(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
-  def self.reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
-  def self.group(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
-  def self.limit(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
-  def self.offset(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
-  def self.joins(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
-  def self.left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
-  def self.left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
-  def self.where(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
-  def self.rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
-  def self.preload(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
-  def self.extract_associated(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
-  def self.eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
-  def self.includes(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
-  def self.from(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
-  def self.lock(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
-  def self.readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
-  def self.or(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
-  def self.having(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
-  def self.create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
-  def self.distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
-  def self.references(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
-  def self.none(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
-  def self.unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
-  def self.optimizer_hints(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
-  def self.merge(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
-  def self.except(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
-  def self.only(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
-  def self.extending(*args, &block); end
 
   sig { returns(T.nilable(Wand::CoreType)) }
   def typed_core_type; end
@@ -356,13 +234,7 @@ class Wand < ApplicationRecord
   def self.mythicals; end
 end
 
-class Wand::ActiveRecord_Relation < ActiveRecord::Relation
-  include Wand::ActiveRelation_WhereNot
-  include Wand::CustomFinderMethods
-  extend T::Sig
-  extend T::Generic
-  Elem = type_member(fixed: Wand)
-
+module Wand::QueryMethodsReturningRelation
   sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
   def basilisk_horn(*args); end
 
@@ -487,13 +359,7 @@ class Wand::ActiveRecord_Relation < ActiveRecord::Relation
   def extending(*args, &block); end
 end
 
-class Wand::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
-  include Wand::ActiveRelation_WhereNot
-  include Wand::CustomFinderMethods
-  extend T::Sig
-  extend T::Generic
-  Elem = type_member(fixed: Wand)
-
+module Wand::QueryMethodsReturningAssociationRelation
   sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
   def basilisk_horn(*args); end
 
@@ -521,7 +387,7 @@ class Wand::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
   sig { returns(Wand::ActiveRecord_AssociationRelation) }
   def all; end
 
-  sig { params(block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
+  sig { params(block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def unscoped(&block); end
 
   sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
@@ -618,134 +484,30 @@ class Wand::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
   def extending(*args, &block); end
 end
 
-class Wand::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
+class Wand::ActiveRecord_Relation < ActiveRecord::Relation
+  include Wand::ActiveRelation_WhereNot
   include Wand::CustomFinderMethods
+  include Wand::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: Wand)
+end
 
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def basilisk_horn(*args); end
+class Wand::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
+  include Wand::ActiveRelation_WhereNot
+  include Wand::CustomFinderMethods
+  include Wand::QueryMethodsReturningAssociationRelation
+  extend T::Sig
+  extend T::Generic
+  Elem = type_member(fixed: Wand)
+end
 
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def dragon_heartstring(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def not_basilisk_horn(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def not_dragon_heartstring(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def not_phoenix_feather(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def not_unicorn_tail_hair(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def phoenix_feather(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def unicorn_tail_hair(*args); end
-
-  sig { returns(Wand::ActiveRecord_AssociationRelation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def reselect(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def extract_associated(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def optimizer_hints(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def only(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
+class Wand::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
+  include Wand::CustomFinderMethods
+  include Wand::QueryMethodsReturningAssociationRelation
+  extend T::Sig
+  extend T::Generic
+  Elem = type_member(fixed: Wand)
 
   sig { params(records: T.any(Wand, T::Array[Wand])).returns(T.self_type) }
   def <<(*records); end

--- a/spec/test_data/v6.0/expected_wand.rbi
+++ b/spec/test_data/v6.0/expected_wand.rbi
@@ -3,8 +3,6 @@
 
 # typed: strong
 module Wand::EnumInstanceMethods
-  extend T::Sig
-
   sig { returns(T::Boolean) }
   def phoenix_feather?; end
 
@@ -36,8 +34,6 @@ module Wand::ActiveRelation_WhereNot
 end
 
 module Wand::GeneratedAttributeMethods
-  extend T::Sig
-
   sig { returns(T::Boolean) }
   def broken; end
 
@@ -185,8 +181,6 @@ class Wand::CoreType < T::Enum
 end
 
 module Wand::GeneratedAssociationMethods
-  extend T::Sig
-
   sig { returns(::Wizard) }
   def wizard; end
 
@@ -217,8 +211,6 @@ class Wand < ApplicationRecord
   include Wand::GeneratedAssociationMethods
   extend Wand::CustomFinderMethods
   extend Wand::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   RelationType = T.type_alias { T.any(Wand::ActiveRecord_Relation, Wand::ActiveRecord_Associations_CollectionProxy, Wand::ActiveRecord_AssociationRelation) }
 
   sig { returns(T::Hash[T.any(String, Symbol), Integer]) }
@@ -488,8 +480,6 @@ class Wand::ActiveRecord_Relation < ActiveRecord::Relation
   include Wand::ActiveRelation_WhereNot
   include Wand::CustomFinderMethods
   include Wand::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Wand)
 end
 
@@ -497,16 +487,12 @@ class Wand::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
   include Wand::ActiveRelation_WhereNot
   include Wand::CustomFinderMethods
   include Wand::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Wand)
 end
 
 class Wand::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include Wand::CustomFinderMethods
   include Wand::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Wand)
 
   sig { params(records: T.any(Wand, T::Array[Wand])).returns(T.self_type) }

--- a/spec/test_data/v6.0/expected_wizard.rbi
+++ b/spec/test_data/v6.0/expected_wizard.rbi
@@ -314,6 +314,7 @@ class Wizard < ApplicationRecord
   include Wizard::GeneratedAttributeMethods
   include Wizard::GeneratedAssociationMethods
   extend Wizard::CustomFinderMethods
+  extend Wizard::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   RelationType = T.type_alias { T.any(Wizard::ActiveRecord_Relation, Wizard::ActiveRecord_Associations_CollectionProxy, Wizard::ActiveRecord_AssociationRelation) }
@@ -335,216 +336,6 @@ class Wizard < ApplicationRecord
 
   sig { returns(T::Hash[T.any(String, Symbol), Integer]) }
   def self.quidditch_positions; end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.Gryffindor(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.Hagrid(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.Hufflepuff(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.Ravenclaw(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.Slytherin(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.black_hair(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.blonde_hair(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.broom_firebolt(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.broom_nimbus(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.brown_hair(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.color_blue_eyes(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.color_brown_eyes(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.color_green_eyes(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.not_Gryffindor(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.not_Hagrid(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.not_Hufflepuff(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.not_Ravenclaw(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.not_Slytherin(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.not_black_hair(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.not_blonde_hair(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.not_broom_firebolt(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.not_broom_nimbus(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.not_brown_hair(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.not_color_blue_eyes(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.not_color_brown_eyes(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.not_color_green_eyes(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.not_quidditch_beater(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.not_quidditch_chaser(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.not_quidditch_keeper(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.not_quidditch_seeker(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.quidditch_beater(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.quidditch_chaser(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.quidditch_keeper(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.quidditch_seeker(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.recent(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.with_attached_hats(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.with_attached_school_photo(*args); end
-
-  sig { returns(Wizard::ActiveRecord_Relation) }
-  def self.all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.select(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.reselect(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.order(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.group(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.limit(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.offset(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.joins(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.where(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.preload(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.extract_associated(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.includes(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.from(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.lock(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.or(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.having(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.references(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.none(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.optimizer_hints(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.merge(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.except(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.only(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.extending(*args, &block); end
 
   sig { returns(T.nilable(Wizard::Broom)) }
   def typed_broom; end
@@ -583,13 +374,7 @@ class Wizard < ApplicationRecord
   def typed_quidditch_position=(value); end
 end
 
-class Wizard::ActiveRecord_Relation < ActiveRecord::Relation
-  include Wizard::ActiveRelation_WhereNot
-  include Wizard::CustomFinderMethods
-  extend T::Sig
-  extend T::Generic
-  Elem = type_member(fixed: Wizard)
-
+module Wizard::QueryMethodsReturningRelation
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
   def Gryffindor(*args); end
 
@@ -801,13 +586,7 @@ class Wizard::ActiveRecord_Relation < ActiveRecord::Relation
   def extending(*args, &block); end
 end
 
-class Wizard::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
-  include Wizard::ActiveRelation_WhereNot
-  include Wizard::CustomFinderMethods
-  extend T::Sig
-  extend T::Generic
-  Elem = type_member(fixed: Wizard)
-
+module Wizard::QueryMethodsReturningAssociationRelation
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
   def Gryffindor(*args); end
 
@@ -922,7 +701,7 @@ class Wizard::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelati
   sig { returns(Wizard::ActiveRecord_AssociationRelation) }
   def all; end
 
-  sig { params(block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
+  sig { params(block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def unscoped(&block); end
 
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
@@ -1019,233 +798,22 @@ class Wizard::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelati
   def extending(*args, &block); end
 end
 
-class Wizard::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
+class Wizard::ActiveRecord_Relation < ActiveRecord::Relation
+  include Wizard::ActiveRelation_WhereNot
   include Wizard::CustomFinderMethods
+  include Wizard::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: Wizard)
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def Gryffindor(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def Hagrid(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def Hufflepuff(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def Ravenclaw(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def Slytherin(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def black_hair(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def blonde_hair(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def broom_firebolt(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def broom_nimbus(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def brown_hair(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def color_blue_eyes(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def color_brown_eyes(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def color_green_eyes(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def not_Gryffindor(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def not_Hagrid(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def not_Hufflepuff(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def not_Ravenclaw(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def not_Slytherin(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def not_black_hair(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def not_blonde_hair(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def not_broom_firebolt(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def not_broom_nimbus(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def not_brown_hair(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def not_color_blue_eyes(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def not_color_brown_eyes(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def not_color_green_eyes(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def not_quidditch_beater(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def not_quidditch_chaser(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def not_quidditch_keeper(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def not_quidditch_seeker(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def quidditch_beater(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def quidditch_chaser(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def quidditch_keeper(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def quidditch_seeker(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def recent(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def with_attached_hats(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def with_attached_school_photo(*args); end
-
-  sig { returns(Wizard::ActiveRecord_AssociationRelation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def reselect(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def extract_associated(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def optimizer_hints(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def only(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
-
-  sig { params(records: T.any(Wizard, T::Array[Wizard])).returns(T.self_type) }
-  def <<(*records); end
-
-  sig { params(records: T.any(Wizard, T::Array[Wizard])).returns(T.self_type) }
-  def append(*records); end
-
-  sig { params(records: T.any(Wizard, T::Array[Wizard])).returns(T.self_type) }
-  def push(*records); end
-
-  sig { params(records: T.any(Wizard, T::Array[Wizard])).returns(T.self_type) }
-  def concat(*records); end
+end
+
+class Wizard::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
+  include Wizard::ActiveRelation_WhereNot
+  include Wizard::CustomFinderMethods
+  include Wizard::QueryMethodsReturningAssociationRelation
+  extend T::Sig
+  extend T::Generic
+  Elem = type_member(fixed: Wizard)
 end
 
 module Wizard::GeneratedAssociationMethods
@@ -1322,4 +890,24 @@ module Wizard::GeneratedAssociationMethods
 
   sig { params(attachables: T.untyped).returns(T.untyped) }
   def hats=(*attachables); end
+end
+
+class Wizard::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
+  include Wizard::CustomFinderMethods
+  include Wizard::QueryMethodsReturningAssociationRelation
+  extend T::Sig
+  extend T::Generic
+  Elem = type_member(fixed: Wizard)
+
+  sig { params(records: T.any(Wizard, T::Array[Wizard])).returns(T.self_type) }
+  def <<(*records); end
+
+  sig { params(records: T.any(Wizard, T::Array[Wizard])).returns(T.self_type) }
+  def append(*records); end
+
+  sig { params(records: T.any(Wizard, T::Array[Wizard])).returns(T.self_type) }
+  def push(*records); end
+
+  sig { params(records: T.any(Wizard, T::Array[Wizard])).returns(T.self_type) }
+  def concat(*records); end
 end

--- a/spec/test_data/v6.0/expected_wizard.rbi
+++ b/spec/test_data/v6.0/expected_wizard.rbi
@@ -3,8 +3,6 @@
 
 # typed: strong
 module Wizard::EnumInstanceMethods
-  extend T::Sig
-
   sig { returns(T::Boolean) }
   def broom_nimbus?; end
 
@@ -114,8 +112,6 @@ module Wizard::ActiveRelation_WhereNot
 end
 
 module Wizard::GeneratedAttributeMethods
-  extend T::Sig
-
   sig { returns(T::Boolean) }
   def broom?; end
 
@@ -315,8 +311,6 @@ class Wizard < ApplicationRecord
   include Wizard::GeneratedAssociationMethods
   extend Wizard::CustomFinderMethods
   extend Wizard::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   RelationType = T.type_alias { T.any(Wizard::ActiveRecord_Relation, Wizard::ActiveRecord_Associations_CollectionProxy, Wizard::ActiveRecord_AssociationRelation) }
 
   sig { returns(T::Hash[T.any(String, Symbol), String]) }
@@ -802,8 +796,6 @@ class Wizard::ActiveRecord_Relation < ActiveRecord::Relation
   include Wizard::ActiveRelation_WhereNot
   include Wizard::CustomFinderMethods
   include Wizard::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Wizard)
 end
 
@@ -811,14 +803,10 @@ class Wizard::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelati
   include Wizard::ActiveRelation_WhereNot
   include Wizard::CustomFinderMethods
   include Wizard::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Wizard)
 end
 
 module Wizard::GeneratedAssociationMethods
-  extend T::Sig
-
   sig { returns(::ActiveStorage::Attachment::ActiveRecord_Associations_CollectionProxy) }
   def hats_attachments; end
 
@@ -895,8 +883,6 @@ end
 class Wizard::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include Wizard::CustomFinderMethods
   include Wizard::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Wizard)
 
   sig { params(records: T.any(Wizard, T::Array[Wizard])).returns(T.self_type) }

--- a/spec/test_data/v6.0/expected_wizard/habtm_subjects.rbi
+++ b/spec/test_data/v6.0/expected_wizard/habtm_subjects.rbi
@@ -8,8 +8,6 @@ module Wizard::HABTM_Subjects::ActiveRelation_WhereNot
 end
 
 module Wizard::HABTM_Subjects::GeneratedAttributeMethods
-  extend T::Sig
-
   sig { returns(T.nilable(Integer)) }
   def subject_id; end
 
@@ -30,8 +28,6 @@ module Wizard::HABTM_Subjects::GeneratedAttributeMethods
 end
 
 module Wizard::HABTM_Subjects::GeneratedAssociationMethods
-  extend T::Sig
-
   sig { returns(T.nilable(::Wizard)) }
   def left_side; end
 
@@ -67,8 +63,6 @@ class Wizard::HABTM_Subjects < ActiveRecord::Base
   include Wizard::HABTM_Subjects::GeneratedAssociationMethods
   extend Wizard::HABTM_Subjects::CustomFinderMethods
   extend Wizard::HABTM_Subjects::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   RelationType = T.type_alias { T.any(Wizard::HABTM_Subjects::ActiveRecord_Relation, Wizard::HABTM_Subjects::ActiveRecord_Associations_CollectionProxy, Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
 end
 
@@ -278,8 +272,6 @@ class Wizard::HABTM_Subjects::ActiveRecord_Relation < ActiveRecord::Relation
   include Wizard::HABTM_Subjects::ActiveRelation_WhereNot
   include Wizard::HABTM_Subjects::CustomFinderMethods
   include Wizard::HABTM_Subjects::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Wizard::HABTM_Subjects)
 end
 
@@ -287,16 +279,12 @@ class Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation < ActiveRecord::A
   include Wizard::HABTM_Subjects::ActiveRelation_WhereNot
   include Wizard::HABTM_Subjects::CustomFinderMethods
   include Wizard::HABTM_Subjects::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Wizard::HABTM_Subjects)
 end
 
 class Wizard::HABTM_Subjects::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include Wizard::HABTM_Subjects::CustomFinderMethods
   include Wizard::HABTM_Subjects::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Wizard::HABTM_Subjects)
 
   sig { params(records: T.any(Wizard::HABTM_Subjects, T::Array[Wizard::HABTM_Subjects])).returns(T.self_type) }

--- a/spec/test_data/v6.0/expected_wizard/habtm_subjects.rbi
+++ b/spec/test_data/v6.0/expected_wizard/habtm_subjects.rbi
@@ -66,428 +66,238 @@ class Wizard::HABTM_Subjects < ActiveRecord::Base
   include Wizard::HABTM_Subjects::GeneratedAttributeMethods
   include Wizard::HABTM_Subjects::GeneratedAssociationMethods
   extend Wizard::HABTM_Subjects::CustomFinderMethods
+  extend Wizard::HABTM_Subjects::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   RelationType = T.type_alias { T.any(Wizard::HABTM_Subjects::ActiveRecord_Relation, Wizard::HABTM_Subjects::ActiveRecord_Associations_CollectionProxy, Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
+end
 
+module Wizard::HABTM_Subjects::QueryMethodsReturningRelation
   sig { returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def self.all; end
+  def all; end
 
   sig { params(block: T.nilable(T.proc.void)).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def self.unscoped(&block); end
+  def unscoped(&block); end
 
   sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def self.select(*args); end
+  def select(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def self.reselect(*args); end
+  def reselect(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def self.order(*args); end
+  def order(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def self.reorder(*args); end
+  def reorder(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def self.group(*args); end
+  def group(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def self.limit(*args); end
+  def limit(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def self.offset(*args); end
+  def offset(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def self.joins(*args); end
+  def joins(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def self.left_joins(*args); end
+  def left_joins(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def self.left_outer_joins(*args); end
+  def left_outer_joins(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def self.where(*args); end
+  def where(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def self.rewhere(*args); end
+  def rewhere(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def self.preload(*args); end
+  def preload(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def self.extract_associated(*args); end
+  def extract_associated(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def self.eager_load(*args); end
+  def eager_load(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def self.includes(*args); end
+  def includes(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def self.from(*args); end
+  def from(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def self.lock(*args); end
+  def lock(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def self.readonly(*args); end
+  def readonly(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def self.or(*args); end
+  def or(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def self.having(*args); end
+  def having(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def self.create_with(*args); end
+  def create_with(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def self.distinct(*args); end
+  def distinct(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def self.references(*args); end
+  def references(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def self.none(*args); end
+  def none(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def self.unscope(*args); end
+  def unscope(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def self.optimizer_hints(*args); end
+  def optimizer_hints(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def self.merge(*args); end
+  def merge(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def self.except(*args); end
+  def except(*args); end
 
   sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def self.only(*args); end
+  def only(*args); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def self.extending(*args, &block); end
+  def extending(*args, &block); end
+end
+
+module Wizard::HABTM_Subjects::QueryMethodsReturningAssociationRelation
+  sig { returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
+  def all; end
+
+  sig { params(block: T.nilable(T.proc.void)).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
+  def unscoped(&block); end
+
+  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
+  def select(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
+  def reselect(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
+  def order(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
+  def reorder(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
+  def group(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
+  def limit(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
+  def offset(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
+  def joins(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
+  def left_joins(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
+  def left_outer_joins(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
+  def where(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
+  def rewhere(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
+  def preload(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
+  def extract_associated(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
+  def eager_load(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
+  def includes(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
+  def from(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
+  def lock(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
+  def readonly(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
+  def or(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
+  def having(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
+  def create_with(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
+  def distinct(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
+  def references(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
+  def none(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
+  def unscope(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
+  def optimizer_hints(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
+  def merge(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
+  def except(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
+  def only(*args); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
+  def extending(*args, &block); end
 end
 
 class Wizard::HABTM_Subjects::ActiveRecord_Relation < ActiveRecord::Relation
   include Wizard::HABTM_Subjects::ActiveRelation_WhereNot
   include Wizard::HABTM_Subjects::CustomFinderMethods
+  include Wizard::HABTM_Subjects::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: Wizard::HABTM_Subjects)
-
-  sig { returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def reselect(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def extract_associated(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def optimizer_hints(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def only(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
-  def extending(*args, &block); end
 end
 
 class Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
   include Wizard::HABTM_Subjects::ActiveRelation_WhereNot
   include Wizard::HABTM_Subjects::CustomFinderMethods
+  include Wizard::HABTM_Subjects::QueryMethodsReturningAssociationRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: Wizard::HABTM_Subjects)
-
-  sig { returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def reselect(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def extract_associated(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def optimizer_hints(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def only(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
 end
 
 class Wizard::HABTM_Subjects::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include Wizard::HABTM_Subjects::CustomFinderMethods
+  include Wizard::HABTM_Subjects::QueryMethodsReturningAssociationRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: Wizard::HABTM_Subjects)
-
-  sig { returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def reselect(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def extract_associated(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def optimizer_hints(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def only(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
 
   sig { params(records: T.any(Wizard::HABTM_Subjects, T::Array[Wizard::HABTM_Subjects])).returns(T.self_type) }
   def <<(*records); end

--- a/spec/test_data/v6.0/expected_wizard_wo_spellbook.rbi
+++ b/spec/test_data/v6.0/expected_wizard_wo_spellbook.rbi
@@ -3,8 +3,6 @@
 
 # typed: strong
 module Wizard::EnumInstanceMethods
-  extend T::Sig
-
   sig { returns(T::Boolean) }
   def broom_nimbus?; end
 
@@ -114,8 +112,6 @@ module Wizard::ActiveRelation_WhereNot
 end
 
 module Wizard::GeneratedAttributeMethods
-  extend T::Sig
-
   sig { returns(T::Boolean) }
   def broom?; end
 
@@ -315,8 +311,6 @@ class Wizard < ApplicationRecord
   include Wizard::GeneratedAssociationMethods
   extend Wizard::CustomFinderMethods
   extend Wizard::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   RelationType = T.type_alias { T.any(Wizard::ActiveRecord_Relation, Wizard::ActiveRecord_Associations_CollectionProxy, Wizard::ActiveRecord_AssociationRelation) }
 
   sig { returns(T::Hash[T.any(String, Symbol), String]) }
@@ -802,8 +796,6 @@ class Wizard::ActiveRecord_Relation < ActiveRecord::Relation
   include Wizard::ActiveRelation_WhereNot
   include Wizard::CustomFinderMethods
   include Wizard::QueryMethodsReturningRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Wizard)
 end
 
@@ -811,14 +803,10 @@ class Wizard::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelati
   include Wizard::ActiveRelation_WhereNot
   include Wizard::CustomFinderMethods
   include Wizard::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Wizard)
 end
 
 module Wizard::GeneratedAssociationMethods
-  extend T::Sig
-
   sig { returns(::ActiveStorage::Attachment::ActiveRecord_Associations_CollectionProxy) }
   def hats_attachments; end
 
@@ -889,8 +877,6 @@ end
 class Wizard::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
   include Wizard::CustomFinderMethods
   include Wizard::QueryMethodsReturningAssociationRelation
-  extend T::Sig
-  extend T::Generic
   Elem = type_member(fixed: Wizard)
 
   sig { params(records: T.any(Wizard, T::Array[Wizard])).returns(T.self_type) }

--- a/spec/test_data/v6.0/expected_wizard_wo_spellbook.rbi
+++ b/spec/test_data/v6.0/expected_wizard_wo_spellbook.rbi
@@ -314,6 +314,7 @@ class Wizard < ApplicationRecord
   include Wizard::GeneratedAttributeMethods
   include Wizard::GeneratedAssociationMethods
   extend Wizard::CustomFinderMethods
+  extend Wizard::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   RelationType = T.type_alias { T.any(Wizard::ActiveRecord_Relation, Wizard::ActiveRecord_Associations_CollectionProxy, Wizard::ActiveRecord_AssociationRelation) }
@@ -335,216 +336,6 @@ class Wizard < ApplicationRecord
 
   sig { returns(T::Hash[T.any(String, Symbol), Integer]) }
   def self.quidditch_positions; end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.Gryffindor(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.Hagrid(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.Hufflepuff(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.Ravenclaw(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.Slytherin(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.black_hair(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.blonde_hair(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.broom_firebolt(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.broom_nimbus(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.brown_hair(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.color_blue_eyes(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.color_brown_eyes(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.color_green_eyes(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.not_Gryffindor(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.not_Hagrid(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.not_Hufflepuff(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.not_Ravenclaw(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.not_Slytherin(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.not_black_hair(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.not_blonde_hair(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.not_broom_firebolt(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.not_broom_nimbus(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.not_brown_hair(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.not_color_blue_eyes(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.not_color_brown_eyes(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.not_color_green_eyes(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.not_quidditch_beater(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.not_quidditch_chaser(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.not_quidditch_keeper(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.not_quidditch_seeker(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.quidditch_beater(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.quidditch_chaser(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.quidditch_keeper(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.quidditch_seeker(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.recent(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.with_attached_hats(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.with_attached_school_photo(*args); end
-
-  sig { returns(Wizard::ActiveRecord_Relation) }
-  def self.all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.select(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.reselect(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.order(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.group(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.limit(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.offset(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.joins(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.where(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.preload(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.extract_associated(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.includes(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.from(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.lock(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.or(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.having(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.references(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.none(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.optimizer_hints(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.merge(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.except(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
-  def self.only(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
-  def self.extending(*args, &block); end
 
   sig { returns(T.nilable(Wizard::Broom)) }
   def typed_broom; end
@@ -583,13 +374,7 @@ class Wizard < ApplicationRecord
   def typed_quidditch_position=(value); end
 end
 
-class Wizard::ActiveRecord_Relation < ActiveRecord::Relation
-  include Wizard::ActiveRelation_WhereNot
-  include Wizard::CustomFinderMethods
-  extend T::Sig
-  extend T::Generic
-  Elem = type_member(fixed: Wizard)
-
+module Wizard::QueryMethodsReturningRelation
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
   def Gryffindor(*args); end
 
@@ -801,13 +586,7 @@ class Wizard::ActiveRecord_Relation < ActiveRecord::Relation
   def extending(*args, &block); end
 end
 
-class Wizard::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
-  include Wizard::ActiveRelation_WhereNot
-  include Wizard::CustomFinderMethods
-  extend T::Sig
-  extend T::Generic
-  Elem = type_member(fixed: Wizard)
-
+module Wizard::QueryMethodsReturningAssociationRelation
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
   def Gryffindor(*args); end
 
@@ -922,7 +701,7 @@ class Wizard::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelati
   sig { returns(Wizard::ActiveRecord_AssociationRelation) }
   def all; end
 
-  sig { params(block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
+  sig { params(block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def unscoped(&block); end
 
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
@@ -1019,233 +798,22 @@ class Wizard::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelati
   def extending(*args, &block); end
 end
 
-class Wizard::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
+class Wizard::ActiveRecord_Relation < ActiveRecord::Relation
+  include Wizard::ActiveRelation_WhereNot
   include Wizard::CustomFinderMethods
+  include Wizard::QueryMethodsReturningRelation
   extend T::Sig
   extend T::Generic
   Elem = type_member(fixed: Wizard)
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def Gryffindor(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def Hagrid(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def Hufflepuff(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def Ravenclaw(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def Slytherin(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def black_hair(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def blonde_hair(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def broom_firebolt(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def broom_nimbus(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def brown_hair(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def color_blue_eyes(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def color_brown_eyes(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def color_green_eyes(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def not_Gryffindor(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def not_Hagrid(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def not_Hufflepuff(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def not_Ravenclaw(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def not_Slytherin(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def not_black_hair(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def not_blonde_hair(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def not_broom_firebolt(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def not_broom_nimbus(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def not_brown_hair(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def not_color_blue_eyes(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def not_color_brown_eyes(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def not_color_green_eyes(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def not_quidditch_beater(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def not_quidditch_chaser(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def not_quidditch_keeper(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def not_quidditch_seeker(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def quidditch_beater(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def quidditch_chaser(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def quidditch_keeper(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def quidditch_seeker(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def recent(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def with_attached_hats(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def with_attached_school_photo(*args); end
-
-  sig { returns(Wizard::ActiveRecord_AssociationRelation) }
-  def all; end
-
-  sig { params(block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def unscoped(&block); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def select(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def reselect(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def order(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def reorder(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def group(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def limit(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def offset(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def joins(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def left_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def left_outer_joins(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def where(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def rewhere(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def preload(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def extract_associated(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def eager_load(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def includes(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def from(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def lock(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def readonly(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def or(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def having(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def create_with(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def distinct(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def references(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def none(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def unscope(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def optimizer_hints(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def merge(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def except(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def only(*args); end
-
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def extending(*args, &block); end
-
-  sig { params(records: T.any(Wizard, T::Array[Wizard])).returns(T.self_type) }
-  def <<(*records); end
-
-  sig { params(records: T.any(Wizard, T::Array[Wizard])).returns(T.self_type) }
-  def append(*records); end
-
-  sig { params(records: T.any(Wizard, T::Array[Wizard])).returns(T.self_type) }
-  def push(*records); end
-
-  sig { params(records: T.any(Wizard, T::Array[Wizard])).returns(T.self_type) }
-  def concat(*records); end
+end
+
+class Wizard::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
+  include Wizard::ActiveRelation_WhereNot
+  include Wizard::CustomFinderMethods
+  include Wizard::QueryMethodsReturningAssociationRelation
+  extend T::Sig
+  extend T::Generic
+  Elem = type_member(fixed: Wizard)
 end
 
 module Wizard::GeneratedAssociationMethods
@@ -1316,4 +884,24 @@ module Wizard::GeneratedAssociationMethods
 
   sig { params(attachables: T.untyped).returns(T.untyped) }
   def hats=(*attachables); end
+end
+
+class Wizard::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
+  include Wizard::CustomFinderMethods
+  include Wizard::QueryMethodsReturningAssociationRelation
+  extend T::Sig
+  extend T::Generic
+  Elem = type_member(fixed: Wizard)
+
+  sig { params(records: T.any(Wizard, T::Array[Wizard])).returns(T.self_type) }
+  def <<(*records); end
+
+  sig { params(records: T.any(Wizard, T::Array[Wizard])).returns(T.self_type) }
+  def append(*records); end
+
+  sig { params(records: T.any(Wizard, T::Array[Wizard])).returns(T.self_type) }
+  def push(*records); end
+
+  sig { params(records: T.any(Wizard, T::Array[Wizard])).returns(T.self_type) }
+  def concat(*records); end
 end


### PR DESCRIPTION
One more PR that could help significantly reduce the side of the generated RBI.

There's a comment in the codebase that describes the query methods:
> a relation querying method will be available on
> - model (as a class method)
> - activerecord relation
> - asocciation collection proxy
> - association relation
>
> in case (1) and (2), it returns a Model::ActiveRecord_Relation
> in case (3) and (4), it returns a Model::ActiveRecord_AssociationRelation

Given that, this PR defines two modules per model:
```
module SomeModel::QueryMethodsReturningRelation
end

module SomeModel::QueryMethodsReturningAssociationRelation
end
```

- For case (1), they need to be class methods so we `extend QueryMethodsReturningRelation`.
- For case (2), they need to be instance methods so we `include QueryMethodsReturningRelation` 
- For case (3) and (4) they both need be instance methods so we `include QueryMethodsReturningAssociationRelation`

This allows us to remove half of the query methods since they only need to be defined in twice instead of four times.