### PR TITLE
Stop infering `validate :on` as unconditional

### DIFF
--- a/lib/sorbet-rails/model_plugins/base.rb
+++ b/lib/sorbet-rails/model_plugins/base.rb
@@ -35,7 +35,8 @@ module SorbetRails::ModelPlugins
       model_class.validators_on(attribute).any? do |validator|
         validator.is_a?(ActiveModel::Validations::PresenceValidator) &&
           !validator.options.key?(:if) &&
-          !validator.options.key?(:unless)
+          !validator.options.key?(:unless) &&
+          !validator.options.key?(:on)
       end
     end
   end


### PR DESCRIPTION
Recent version of sorbet-rails added a neat optimization to make
attributes non nilable if they had an "unconditional validation".
After updating we had some parts of the code report wrongly unreachable code.
This is becase we have some validations using `:on` which are detected
– wrongly – as unconditional.

Didn't add any test since I saw that only the `:if` clause was actually
tested.