### PR TITLE
Fix an incorrect parameter for association relation classes on Rails 6.

### DIFF
--- a/lib/sorbet-rails/active_record_rbi_formatter.rb
+++ b/lib/sorbet-rails/active_record_rbi_formatter.rb
@@ -85,11 +85,16 @@ class SorbetRails::ActiveRecordRbiFormatter
       # parameters than the ones defined by `create_elem_specific_query_methods` so
       # we need to match the signatures in that conflicting rbi.
       build_methods = %w(new build create create!)
+      if Rails.version =~ /^5\.\d/
+        create_parameter = Parameter.new("*args", type: "T.untyped")
+      else
+        create_parameter = Parameter.new("attributes", type: "T.untyped", default: 'nil')
+      end
       build_methods.each do |build_method|
         class_rbi.create_method(
           build_method,
           parameters: [
-            Parameter.new("*args", type: "T.untyped"),
+            create_parameter,
             Parameter.new(
               "&block",
               type: "T.nilable(T.proc.params(object: Elem).void)",

--- a/spec/test_data/v6.0/expected_active_record_relation.rbi
+++ b/spec/test_data/v6.0/expected_active_record_relation.rbi
@@ -136,17 +136,17 @@ end
 class ActiveRecord::AssociationRelation < ActiveRecord::Relation
   Elem = type_member(fixed: T.untyped)
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.params(object: Elem).void)).returns(Elem) }
-  def new(*args, &block); end
+  sig { params(attributes: T.untyped, block: T.nilable(T.proc.params(object: Elem).void)).returns(Elem) }
+  def new(attributes = nil, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.params(object: Elem).void)).returns(Elem) }
-  def build(*args, &block); end
+  sig { params(attributes: T.untyped, block: T.nilable(T.proc.params(object: Elem).void)).returns(Elem) }
+  def build(attributes = nil, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.params(object: Elem).void)).returns(Elem) }
-  def create(*args, &block); end
+  sig { params(attributes: T.untyped, block: T.nilable(T.proc.params(object: Elem).void)).returns(Elem) }
+  def create(attributes = nil, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.params(object: Elem).void)).returns(Elem) }
-  def create!(*args, &block); end
+  sig { params(attributes: T.untyped, block: T.nilable(T.proc.params(object: Elem).void)).returns(Elem) }
+  def create!(attributes = nil, &block); end
 end
 
 class ActiveRecord::Associations::CollectionProxy < ActiveRecord::Relation

--- a/spec/test_data/v6.0/expected_routes.rbi
+++ b/spec/test_data/v6.0/expected_routes.rbi
@@ -21,13 +21,6 @@ module GeneratedUrlHelpers
   sig { params(args: T.untyped, kwargs: T.untyped).returns(String) }
   def test_index_url(*args, **kwargs); end
 
-  # Sigs for route /rails/action_mailbox/mandrill/inbound_emails(.:format)
-  sig { params(args: T.untyped, kwargs: T.untyped).returns(String) }
-  def rails_mandrill_inbound_emails_path(*args, **kwargs); end
-
-  sig { params(args: T.untyped, kwargs: T.untyped).returns(String) }
-  def rails_mandrill_inbound_emails_url(*args, **kwargs); end
-
   # Sigs for route /rails/action_mailbox/postmark/inbound_emails(.:format)
   sig { params(args: T.untyped, kwargs: T.untyped).returns(String) }
   def rails_postmark_inbound_emails_path(*args, **kwargs); end
@@ -48,6 +41,20 @@ module GeneratedUrlHelpers
 
   sig { params(args: T.untyped, kwargs: T.untyped).returns(String) }
   def rails_sendgrid_inbound_emails_url(*args, **kwargs); end
+
+  # Sigs for route /rails/action_mailbox/mandrill/inbound_emails(.:format)
+  sig { params(args: T.untyped, kwargs: T.untyped).returns(String) }
+  def rails_mandrill_inbound_health_check_path(*args, **kwargs); end
+
+  sig { params(args: T.untyped, kwargs: T.untyped).returns(String) }
+  def rails_mandrill_inbound_health_check_url(*args, **kwargs); end
+
+  # Sigs for route /rails/action_mailbox/mandrill/inbound_emails(.:format)
+  sig { params(args: T.untyped, kwargs: T.untyped).returns(String) }
+  def rails_mandrill_inbound_emails_path(*args, **kwargs); end
+
+  sig { params(args: T.untyped, kwargs: T.untyped).returns(String) }
+  def rails_mandrill_inbound_emails_url(*args, **kwargs); end
 
   # Sigs for route /rails/action_mailbox/mailgun/inbound_emails/mime(.:format)
   sig { params(args: T.untyped, kwargs: T.untyped).returns(String) }


### PR DESCRIPTION
Fixes an issue introduced with #313 / Rails 6.0.3. I'm not 100% sure this issue is exclusive to 6.0.3, but if it is I guess the regex should exclude 6.0.0, 6.0.1, and 6.0.2?

Unfortunately, there are still other typecheck errors in the test suite that I haven't been able to track down with Rails 6.0.3.