### PR TITLE
fix spec failures in rails 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,8 @@ matrix:
     env: RAILS_VERSION=6.0
   allow_failures:
   - rvm: ruby-head
+  - rvm: 2.7
+    env: RAILS_VERSION=6.0
 before_install:
 - gem install bundler -v 2.0.1 --no-doc
 - gem install bundler -v 1.17.3 --no-doc

--- a/lib/sorbet-rails/active_record_rbi_formatter.rb
+++ b/lib/sorbet-rails/active_record_rbi_formatter.rb
@@ -85,11 +85,18 @@ class SorbetRails::ActiveRecordRbiFormatter
       # parameters than the ones defined by `create_elem_specific_query_methods` so
       # we need to match the signatures in that conflicting rbi.
       build_methods = %w(new build create create!)
+      # This needs to match the generated method signature in activerecord.rbi and
+      # in Rails 5.0 and 5.1 the param is a splat.
+      if Rails.version =~ /^5\./
+        build_param = Parameter.new("*args", type: "T.untyped")
+      else
+        build_param = Parameter.new("attributes", type: "T.untyped", default: 'nil')
+      end
       build_methods.each do |build_method|
         class_rbi.create_method(
           build_method,
           parameters: [
-            Parameter.new("*args", type: "T.untyped"),
+            build_param,
             Parameter.new(
               "&block",
               type: "T.nilable(T.proc.params(object: Elem).void)",

--- a/lib/sorbet-rails/model_plugins/active_storage_methods.rb
+++ b/lib/sorbet-rails/model_plugins/active_storage_methods.rb
@@ -52,7 +52,7 @@ class SorbetRails::ModelPlugins::ActiveStorageMethods < SorbetRails::ModelPlugin
     mod.create_method(
       "#{assoc_name}=",
       parameters: [
-        Parameter.new('*attachables', type: 'T.untyped')
+        Parameter.new('attachables', type: 'T.untyped')
       ],
       return_type: 'T.untyped'
     )

--- a/lib/sorbet-rails/model_utils.rb
+++ b/lib/sorbet-rails/model_utils.rb
@@ -106,7 +106,7 @@ module SorbetRails::ModelUtils
     # model. However, in Rails 5 query methods that come from scopes or enums
     # get overridden in hidden-definitions so we need to explicitly define them
     # on the model and relation classes.
-    if builtin_query_method || Rails.version =~ /^6\./
+    if builtin_query_method
       relation_module_rbi = root.create_module(self.model_query_methods_returning_relation_module_name)
       relation_module_rbi.create_method(
         method_name,

--- a/spec/test_data/v6.0/expected_active_record_relation.rbi
+++ b/spec/test_data/v6.0/expected_active_record_relation.rbi
@@ -136,17 +136,17 @@ end
 class ActiveRecord::AssociationRelation < ActiveRecord::Relation
   Elem = type_member(fixed: T.untyped)
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.params(object: Elem).void)).returns(Elem) }
-  def new(*args, &block); end
+  sig { params(attributes: T.untyped, block: T.nilable(T.proc.params(object: Elem).void)).returns(Elem) }
+  def new(attributes = nil, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.params(object: Elem).void)).returns(Elem) }
-  def build(*args, &block); end
+  sig { params(attributes: T.untyped, block: T.nilable(T.proc.params(object: Elem).void)).returns(Elem) }
+  def build(attributes = nil, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.params(object: Elem).void)).returns(Elem) }
-  def create(*args, &block); end
+  sig { params(attributes: T.untyped, block: T.nilable(T.proc.params(object: Elem).void)).returns(Elem) }
+  def create(attributes = nil, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.params(object: Elem).void)).returns(Elem) }
-  def create!(*args, &block); end
+  sig { params(attributes: T.untyped, block: T.nilable(T.proc.params(object: Elem).void)).returns(Elem) }
+  def create!(attributes = nil, &block); end
 end
 
 class ActiveRecord::Associations::CollectionProxy < ActiveRecord::Relation

--- a/spec/test_data/v6.0/expected_blob.rbi
+++ b/spec/test_data/v6.0/expected_blob.rbi
@@ -29,15 +29,65 @@ class ActiveStorage::Blob < ActiveRecord::Base
   extend ActiveStorage::Blob::CustomFinderMethods
   extend ActiveStorage::Blob::QueryMethodsReturningRelation
   RelationType = T.type_alias { T.any(ActiveStorage::Blob::ActiveRecord_Relation, ActiveStorage::Blob::ActiveRecord_Associations_CollectionProxy, ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def self.unattached(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def self.with_attached_preview_image(*args); end
 end
 
-module ActiveStorage::Blob::QueryMethodsReturningRelation
+class ActiveStorage::Blob::ActiveRecord_Relation < ActiveRecord::Relation
+  include ActiveStorage::Blob::ActiveRelation_WhereNot
+  include ActiveStorage::Blob::CustomFinderMethods
+  include ActiveStorage::Blob::QueryMethodsReturningRelation
+  Elem = type_member(fixed: ActiveStorage::Blob)
+
   sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
   def unattached(*args); end
 
   sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
   def with_attached_preview_image(*args); end
+end
 
+class ActiveStorage::Blob::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
+  include ActiveStorage::Blob::ActiveRelation_WhereNot
+  include ActiveStorage::Blob::CustomFinderMethods
+  include ActiveStorage::Blob::QueryMethodsReturningAssociationRelation
+  Elem = type_member(fixed: ActiveStorage::Blob)
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def unattached(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def with_attached_preview_image(*args); end
+end
+
+class ActiveStorage::Blob::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
+  include ActiveStorage::Blob::CustomFinderMethods
+  include ActiveStorage::Blob::QueryMethodsReturningAssociationRelation
+  Elem = type_member(fixed: ActiveStorage::Blob)
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def unattached(*args); end
+
+  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def with_attached_preview_image(*args); end
+
+  sig { params(records: T.any(ActiveStorage::Blob, T::Array[ActiveStorage::Blob])).returns(T.self_type) }
+  def <<(*records); end
+
+  sig { params(records: T.any(ActiveStorage::Blob, T::Array[ActiveStorage::Blob])).returns(T.self_type) }
+  def append(*records); end
+
+  sig { params(records: T.any(ActiveStorage::Blob, T::Array[ActiveStorage::Blob])).returns(T.self_type) }
+  def push(*records); end
+
+  sig { params(records: T.any(ActiveStorage::Blob, T::Array[ActiveStorage::Blob])).returns(T.self_type) }
+  def concat(*records); end
+end
+
+module ActiveStorage::Blob::QueryMethodsReturningRelation
   sig { returns(ActiveStorage::Blob::ActiveRecord_Relation) }
   def all; end
 
@@ -139,12 +189,6 @@ module ActiveStorage::Blob::QueryMethodsReturningRelation
 end
 
 module ActiveStorage::Blob::QueryMethodsReturningAssociationRelation
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def unattached(*args); end
-
-  sig { params(args: T.untyped).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
-  def with_attached_preview_image(*args); end
-
   sig { returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
   def all; end
 
@@ -245,20 +289,6 @@ module ActiveStorage::Blob::QueryMethodsReturningAssociationRelation
   def extending(*args, &block); end
 end
 
-class ActiveStorage::Blob::ActiveRecord_Relation < ActiveRecord::Relation
-  include ActiveStorage::Blob::ActiveRelation_WhereNot
-  include ActiveStorage::Blob::CustomFinderMethods
-  include ActiveStorage::Blob::QueryMethodsReturningRelation
-  Elem = type_member(fixed: ActiveStorage::Blob)
-end
-
-class ActiveStorage::Blob::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
-  include ActiveStorage::Blob::ActiveRelation_WhereNot
-  include ActiveStorage::Blob::CustomFinderMethods
-  include ActiveStorage::Blob::QueryMethodsReturningAssociationRelation
-  Elem = type_member(fixed: ActiveStorage::Blob)
-end
-
 module ActiveStorage::Blob::GeneratedAssociationMethods
   sig { returns(::ActiveStorage::Attachment::ActiveRecord_Associations_CollectionProxy) }
   def attachments; end
@@ -286,22 +316,4 @@ module ActiveStorage::Blob::GeneratedAssociationMethods
 
   sig { params(attachable: T.untyped).returns(T.untyped) }
   def preview_image=(attachable); end
-end
-
-class ActiveStorage::Blob::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
-  include ActiveStorage::Blob::CustomFinderMethods
-  include ActiveStorage::Blob::QueryMethodsReturningAssociationRelation
-  Elem = type_member(fixed: ActiveStorage::Blob)
-
-  sig { params(records: T.any(ActiveStorage::Blob, T::Array[ActiveStorage::Blob])).returns(T.self_type) }
-  def <<(*records); end
-
-  sig { params(records: T.any(ActiveStorage::Blob, T::Array[ActiveStorage::Blob])).returns(T.self_type) }
-  def append(*records); end
-
-  sig { params(records: T.any(ActiveStorage::Blob, T::Array[ActiveStorage::Blob])).returns(T.self_type) }
-  def push(*records); end
-
-  sig { params(records: T.any(ActiveStorage::Blob, T::Array[ActiveStorage::Blob])).returns(T.self_type) }
-  def concat(*records); end
 end

--- a/spec/test_data/v6.0/expected_routes.rbi
+++ b/spec/test_data/v6.0/expected_routes.rbi
@@ -21,13 +21,6 @@ module GeneratedUrlHelpers
   sig { params(args: T.untyped, kwargs: T.untyped).returns(String) }
   def test_index_url(*args, **kwargs); end
 
-  # Sigs for route /rails/action_mailbox/mandrill/inbound_emails(.:format)
-  sig { params(args: T.untyped, kwargs: T.untyped).returns(String) }
-  def rails_mandrill_inbound_emails_path(*args, **kwargs); end
-
-  sig { params(args: T.untyped, kwargs: T.untyped).returns(String) }
-  def rails_mandrill_inbound_emails_url(*args, **kwargs); end
-
   # Sigs for route /rails/action_mailbox/postmark/inbound_emails(.:format)
   sig { params(args: T.untyped, kwargs: T.untyped).returns(String) }
   def rails_postmark_inbound_emails_path(*args, **kwargs); end
@@ -48,6 +41,20 @@ module GeneratedUrlHelpers
 
   sig { params(args: T.untyped, kwargs: T.untyped).returns(String) }
   def rails_sendgrid_inbound_emails_url(*args, **kwargs); end
+
+  # Sigs for route /rails/action_mailbox/mandrill/inbound_emails(.:format)
+  sig { params(args: T.untyped, kwargs: T.untyped).returns(String) }
+  def rails_mandrill_inbound_health_check_path(*args, **kwargs); end
+
+  sig { params(args: T.untyped, kwargs: T.untyped).returns(String) }
+  def rails_mandrill_inbound_health_check_url(*args, **kwargs); end
+
+  # Sigs for route /rails/action_mailbox/mandrill/inbound_emails(.:format)
+  sig { params(args: T.untyped, kwargs: T.untyped).returns(String) }
+  def rails_mandrill_inbound_emails_path(*args, **kwargs); end
+
+  sig { params(args: T.untyped, kwargs: T.untyped).returns(String) }
+  def rails_mandrill_inbound_emails_url(*args, **kwargs); end
 
   # Sigs for route /rails/action_mailbox/mailgun/inbound_emails/mime(.:format)
   sig { params(args: T.untyped, kwargs: T.untyped).returns(String) }

--- a/spec/test_data/v6.0/expected_spell_book.rbi
+++ b/spec/test_data/v6.0/expected_spell_book.rbi
@@ -119,6 +119,27 @@ class SpellBook < ApplicationRecord
   sig { returns(T::Hash[T.any(String, Symbol), Integer]) }
   def self.book_types; end
 
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def self.biology(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def self.dark_art(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def self.not_biology(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def self.not_dark_art(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def self.not_unclassified(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def self.recent(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
+  def self.unclassified(*args); end
+
   sig { returns(SpellBook::BookType) }
   def typed_book_type; end
 
@@ -126,7 +147,12 @@ class SpellBook < ApplicationRecord
   def typed_book_type=(value); end
 end
 
-module SpellBook::QueryMethodsReturningRelation
+class SpellBook::ActiveRecord_Relation < ActiveRecord::Relation
+  include SpellBook::ActiveRelation_WhereNot
+  include SpellBook::CustomFinderMethods
+  include SpellBook::QueryMethodsReturningRelation
+  Elem = type_member(fixed: SpellBook)
+
   sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
   def biology(*args); end
 
@@ -147,7 +173,76 @@ module SpellBook::QueryMethodsReturningRelation
 
   sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_Relation) }
   def unclassified(*args); end
+end
 
+class SpellBook::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
+  include SpellBook::ActiveRelation_WhereNot
+  include SpellBook::CustomFinderMethods
+  include SpellBook::QueryMethodsReturningAssociationRelation
+  Elem = type_member(fixed: SpellBook)
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def biology(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def dark_art(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def not_biology(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def not_dark_art(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def not_unclassified(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def recent(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def unclassified(*args); end
+end
+
+class SpellBook::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
+  include SpellBook::CustomFinderMethods
+  include SpellBook::QueryMethodsReturningAssociationRelation
+  Elem = type_member(fixed: SpellBook)
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def biology(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def dark_art(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def not_biology(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def not_dark_art(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def not_unclassified(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def recent(*args); end
+
+  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def unclassified(*args); end
+
+  sig { params(records: T.any(SpellBook, T::Array[SpellBook])).returns(T.self_type) }
+  def <<(*records); end
+
+  sig { params(records: T.any(SpellBook, T::Array[SpellBook])).returns(T.self_type) }
+  def append(*records); end
+
+  sig { params(records: T.any(SpellBook, T::Array[SpellBook])).returns(T.self_type) }
+  def push(*records); end
+
+  sig { params(records: T.any(SpellBook, T::Array[SpellBook])).returns(T.self_type) }
+  def concat(*records); end
+end
+
+module SpellBook::QueryMethodsReturningRelation
   sig { returns(SpellBook::ActiveRecord_Relation) }
   def all; end
 
@@ -249,27 +344,6 @@ module SpellBook::QueryMethodsReturningRelation
 end
 
 module SpellBook::QueryMethodsReturningAssociationRelation
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def biology(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def dark_art(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def not_biology(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def not_dark_art(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def not_unclassified(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def recent(*args); end
-
-  sig { params(args: T.untyped).returns(SpellBook::ActiveRecord_AssociationRelation) }
-  def unclassified(*args); end
-
   sig { returns(SpellBook::ActiveRecord_AssociationRelation) }
   def all; end
 
@@ -368,36 +442,4 @@ module SpellBook::QueryMethodsReturningAssociationRelation
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
   def extending(*args, &block); end
-end
-
-class SpellBook::ActiveRecord_Relation < ActiveRecord::Relation
-  include SpellBook::ActiveRelation_WhereNot
-  include SpellBook::CustomFinderMethods
-  include SpellBook::QueryMethodsReturningRelation
-  Elem = type_member(fixed: SpellBook)
-end
-
-class SpellBook::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
-  include SpellBook::ActiveRelation_WhereNot
-  include SpellBook::CustomFinderMethods
-  include SpellBook::QueryMethodsReturningAssociationRelation
-  Elem = type_member(fixed: SpellBook)
-end
-
-class SpellBook::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
-  include SpellBook::CustomFinderMethods
-  include SpellBook::QueryMethodsReturningAssociationRelation
-  Elem = type_member(fixed: SpellBook)
-
-  sig { params(records: T.any(SpellBook, T::Array[SpellBook])).returns(T.self_type) }
-  def <<(*records); end
-
-  sig { params(records: T.any(SpellBook, T::Array[SpellBook])).returns(T.self_type) }
-  def append(*records); end
-
-  sig { params(records: T.any(SpellBook, T::Array[SpellBook])).returns(T.self_type) }
-  def push(*records); end
-
-  sig { params(records: T.any(SpellBook, T::Array[SpellBook])).returns(T.self_type) }
-  def concat(*records); end
 end

--- a/spec/test_data/v6.0/expected_squib.rbi
+++ b/spec/test_data/v6.0/expected_squib.rbi
@@ -290,9 +290,125 @@ class Squib < Wizard
 
   sig { returns(T::Hash[T.any(String, Symbol), Integer]) }
   def self.quidditch_positions; end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.Gryffindor(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.Hagrid(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.Hufflepuff(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.Ravenclaw(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.Slytherin(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.black_hair(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.blonde_hair(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.broom_firebolt(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.broom_nimbus(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.brown_hair(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.color_blue_eyes(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.color_brown_eyes(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.color_green_eyes(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.not_Gryffindor(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.not_Hagrid(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.not_Hufflepuff(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.not_Ravenclaw(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.not_Slytherin(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.not_black_hair(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.not_blonde_hair(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.not_broom_firebolt(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.not_broom_nimbus(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.not_brown_hair(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.not_color_blue_eyes(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.not_color_brown_eyes(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.not_color_green_eyes(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.not_quidditch_beater(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.not_quidditch_chaser(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.not_quidditch_keeper(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.not_quidditch_seeker(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.quidditch_beater(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.quidditch_chaser(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.quidditch_keeper(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.quidditch_seeker(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.recent(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.with_attached_hats(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
+  def self.with_attached_school_photo(*args); end
 end
 
-module Squib::QueryMethodsReturningRelation
+class Squib::ActiveRecord_Relation < ActiveRecord::Relation
+  include Squib::ActiveRelation_WhereNot
+  include Squib::CustomFinderMethods
+  include Squib::QueryMethodsReturningRelation
+  Elem = type_member(fixed: Squib)
+
   sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
   def Gryffindor(*args); end
 
@@ -403,7 +519,256 @@ module Squib::QueryMethodsReturningRelation
 
   sig { params(args: T.untyped).returns(Squib::ActiveRecord_Relation) }
   def with_attached_school_photo(*args); end
+end
 
+class Squib::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
+  include Squib::ActiveRelation_WhereNot
+  include Squib::CustomFinderMethods
+  include Squib::QueryMethodsReturningAssociationRelation
+  Elem = type_member(fixed: Squib)
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def Gryffindor(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def Hagrid(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def Hufflepuff(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def Ravenclaw(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def Slytherin(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def black_hair(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def blonde_hair(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def broom_firebolt(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def broom_nimbus(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def brown_hair(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def color_blue_eyes(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def color_brown_eyes(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def color_green_eyes(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def not_Gryffindor(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def not_Hagrid(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def not_Hufflepuff(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def not_Ravenclaw(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def not_Slytherin(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def not_black_hair(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def not_blonde_hair(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def not_broom_firebolt(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def not_broom_nimbus(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def not_brown_hair(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def not_color_blue_eyes(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def not_color_brown_eyes(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def not_color_green_eyes(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def not_quidditch_beater(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def not_quidditch_chaser(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def not_quidditch_keeper(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def not_quidditch_seeker(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def quidditch_beater(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def quidditch_chaser(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def quidditch_keeper(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def quidditch_seeker(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def recent(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def with_attached_hats(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def with_attached_school_photo(*args); end
+end
+
+class Squib::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
+  include Squib::CustomFinderMethods
+  include Squib::QueryMethodsReturningAssociationRelation
+  Elem = type_member(fixed: Squib)
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def Gryffindor(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def Hagrid(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def Hufflepuff(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def Ravenclaw(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def Slytherin(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def black_hair(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def blonde_hair(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def broom_firebolt(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def broom_nimbus(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def brown_hair(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def color_blue_eyes(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def color_brown_eyes(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def color_green_eyes(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def not_Gryffindor(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def not_Hagrid(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def not_Hufflepuff(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def not_Ravenclaw(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def not_Slytherin(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def not_black_hair(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def not_blonde_hair(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def not_broom_firebolt(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def not_broom_nimbus(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def not_brown_hair(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def not_color_blue_eyes(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def not_color_brown_eyes(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def not_color_green_eyes(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def not_quidditch_beater(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def not_quidditch_chaser(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def not_quidditch_keeper(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def not_quidditch_seeker(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def quidditch_beater(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def quidditch_chaser(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def quidditch_keeper(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def quidditch_seeker(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def recent(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def with_attached_hats(*args); end
+
+  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
+  def with_attached_school_photo(*args); end
+
+  sig { params(records: T.any(Squib, T::Array[Squib])).returns(T.self_type) }
+  def <<(*records); end
+
+  sig { params(records: T.any(Squib, T::Array[Squib])).returns(T.self_type) }
+  def append(*records); end
+
+  sig { params(records: T.any(Squib, T::Array[Squib])).returns(T.self_type) }
+  def push(*records); end
+
+  sig { params(records: T.any(Squib, T::Array[Squib])).returns(T.self_type) }
+  def concat(*records); end
+end
+
+module Squib::QueryMethodsReturningRelation
   sig { returns(Squib::ActiveRecord_Relation) }
   def all; end
 
@@ -505,117 +870,6 @@ module Squib::QueryMethodsReturningRelation
 end
 
 module Squib::QueryMethodsReturningAssociationRelation
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def Gryffindor(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def Hagrid(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def Hufflepuff(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def Ravenclaw(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def Slytherin(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def black_hair(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def blonde_hair(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def broom_firebolt(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def broom_nimbus(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def brown_hair(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def color_blue_eyes(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def color_brown_eyes(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def color_green_eyes(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def not_Gryffindor(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def not_Hagrid(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def not_Hufflepuff(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def not_Ravenclaw(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def not_Slytherin(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def not_black_hair(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def not_blonde_hair(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def not_broom_firebolt(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def not_broom_nimbus(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def not_brown_hair(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def not_color_blue_eyes(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def not_color_brown_eyes(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def not_color_green_eyes(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def not_quidditch_beater(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def not_quidditch_chaser(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def not_quidditch_keeper(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def not_quidditch_seeker(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def quidditch_beater(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def quidditch_chaser(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def quidditch_keeper(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def quidditch_seeker(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def recent(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def with_attached_hats(*args); end
-
-  sig { params(args: T.untyped).returns(Squib::ActiveRecord_AssociationRelation) }
-  def with_attached_school_photo(*args); end
-
   sig { returns(Squib::ActiveRecord_AssociationRelation) }
   def all; end
 
@@ -716,20 +970,6 @@ module Squib::QueryMethodsReturningAssociationRelation
   def extending(*args, &block); end
 end
 
-class Squib::ActiveRecord_Relation < ActiveRecord::Relation
-  include Squib::ActiveRelation_WhereNot
-  include Squib::CustomFinderMethods
-  include Squib::QueryMethodsReturningRelation
-  Elem = type_member(fixed: Squib)
-end
-
-class Squib::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
-  include Squib::ActiveRelation_WhereNot
-  include Squib::CustomFinderMethods
-  include Squib::QueryMethodsReturningAssociationRelation
-  Elem = type_member(fixed: Squib)
-end
-
 module Squib::GeneratedAssociationMethods
   sig { returns(::ActiveStorage::Attachment::ActiveRecord_Associations_CollectionProxy) }
   def hats_attachments; end
@@ -801,23 +1041,5 @@ module Squib::GeneratedAssociationMethods
   def hats; end
 
   sig { params(attachables: T.untyped).returns(T.untyped) }
-  def hats=(*attachables); end
-end
-
-class Squib::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
-  include Squib::CustomFinderMethods
-  include Squib::QueryMethodsReturningAssociationRelation
-  Elem = type_member(fixed: Squib)
-
-  sig { params(records: T.any(Squib, T::Array[Squib])).returns(T.self_type) }
-  def <<(*records); end
-
-  sig { params(records: T.any(Squib, T::Array[Squib])).returns(T.self_type) }
-  def append(*records); end
-
-  sig { params(records: T.any(Squib, T::Array[Squib])).returns(T.self_type) }
-  def push(*records); end
-
-  sig { params(records: T.any(Squib, T::Array[Squib])).returns(T.self_type) }
-  def concat(*records); end
+  def hats=(attachables); end
 end

--- a/spec/test_data/v6.0/expected_wand.rbi
+++ b/spec/test_data/v6.0/expected_wand.rbi
@@ -216,6 +216,30 @@ class Wand < ApplicationRecord
   sig { returns(T::Hash[T.any(String, Symbol), Integer]) }
   def self.core_types; end
 
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.basilisk_horn(*args); end
+
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.dragon_heartstring(*args); end
+
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.not_basilisk_horn(*args); end
+
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.not_dragon_heartstring(*args); end
+
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.not_phoenix_feather(*args); end
+
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.not_unicorn_tail_hair(*args); end
+
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.phoenix_feather(*args); end
+
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
+  def self.unicorn_tail_hair(*args); end
+
   sig { returns(T.nilable(Wand::CoreType)) }
   def typed_core_type; end
 
@@ -226,7 +250,12 @@ class Wand < ApplicationRecord
   def self.mythicals; end
 end
 
-module Wand::QueryMethodsReturningRelation
+class Wand::ActiveRecord_Relation < ActiveRecord::Relation
+  include Wand::ActiveRelation_WhereNot
+  include Wand::CustomFinderMethods
+  include Wand::QueryMethodsReturningRelation
+  Elem = type_member(fixed: Wand)
+
   sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
   def basilisk_horn(*args); end
 
@@ -250,7 +279,82 @@ module Wand::QueryMethodsReturningRelation
 
   sig { params(args: T.untyped).returns(Wand::ActiveRecord_Relation) }
   def unicorn_tail_hair(*args); end
+end
 
+class Wand::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
+  include Wand::ActiveRelation_WhereNot
+  include Wand::CustomFinderMethods
+  include Wand::QueryMethodsReturningAssociationRelation
+  Elem = type_member(fixed: Wand)
+
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def basilisk_horn(*args); end
+
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def dragon_heartstring(*args); end
+
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def not_basilisk_horn(*args); end
+
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def not_dragon_heartstring(*args); end
+
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def not_phoenix_feather(*args); end
+
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def not_unicorn_tail_hair(*args); end
+
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def phoenix_feather(*args); end
+
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def unicorn_tail_hair(*args); end
+end
+
+class Wand::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
+  include Wand::CustomFinderMethods
+  include Wand::QueryMethodsReturningAssociationRelation
+  Elem = type_member(fixed: Wand)
+
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def basilisk_horn(*args); end
+
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def dragon_heartstring(*args); end
+
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def not_basilisk_horn(*args); end
+
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def not_dragon_heartstring(*args); end
+
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def not_phoenix_feather(*args); end
+
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def not_unicorn_tail_hair(*args); end
+
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def phoenix_feather(*args); end
+
+  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
+  def unicorn_tail_hair(*args); end
+
+  sig { params(records: T.any(Wand, T::Array[Wand])).returns(T.self_type) }
+  def <<(*records); end
+
+  sig { params(records: T.any(Wand, T::Array[Wand])).returns(T.self_type) }
+  def append(*records); end
+
+  sig { params(records: T.any(Wand, T::Array[Wand])).returns(T.self_type) }
+  def push(*records); end
+
+  sig { params(records: T.any(Wand, T::Array[Wand])).returns(T.self_type) }
+  def concat(*records); end
+end
+
+module Wand::QueryMethodsReturningRelation
   sig { returns(Wand::ActiveRecord_Relation) }
   def all; end
 
@@ -352,30 +456,6 @@ module Wand::QueryMethodsReturningRelation
 end
 
 module Wand::QueryMethodsReturningAssociationRelation
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def basilisk_horn(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def dragon_heartstring(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def not_basilisk_horn(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def not_dragon_heartstring(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def not_phoenix_feather(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def not_unicorn_tail_hair(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def phoenix_feather(*args); end
-
-  sig { params(args: T.untyped).returns(Wand::ActiveRecord_AssociationRelation) }
-  def unicorn_tail_hair(*args); end
-
   sig { returns(Wand::ActiveRecord_AssociationRelation) }
   def all; end
 
@@ -474,36 +554,4 @@ module Wand::QueryMethodsReturningAssociationRelation
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
   def extending(*args, &block); end
-end
-
-class Wand::ActiveRecord_Relation < ActiveRecord::Relation
-  include Wand::ActiveRelation_WhereNot
-  include Wand::CustomFinderMethods
-  include Wand::QueryMethodsReturningRelation
-  Elem = type_member(fixed: Wand)
-end
-
-class Wand::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
-  include Wand::ActiveRelation_WhereNot
-  include Wand::CustomFinderMethods
-  include Wand::QueryMethodsReturningAssociationRelation
-  Elem = type_member(fixed: Wand)
-end
-
-class Wand::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
-  include Wand::CustomFinderMethods
-  include Wand::QueryMethodsReturningAssociationRelation
-  Elem = type_member(fixed: Wand)
-
-  sig { params(records: T.any(Wand, T::Array[Wand])).returns(T.self_type) }
-  def <<(*records); end
-
-  sig { params(records: T.any(Wand, T::Array[Wand])).returns(T.self_type) }
-  def append(*records); end
-
-  sig { params(records: T.any(Wand, T::Array[Wand])).returns(T.self_type) }
-  def push(*records); end
-
-  sig { params(records: T.any(Wand, T::Array[Wand])).returns(T.self_type) }
-  def concat(*records); end
 end

--- a/spec/test_data/v6.0/expected_wizard.rbi
+++ b/spec/test_data/v6.0/expected_wizard.rbi
@@ -331,6 +331,117 @@ class Wizard < ApplicationRecord
   sig { returns(T::Hash[T.any(String, Symbol), Integer]) }
   def self.quidditch_positions; end
 
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.Gryffindor(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.Hagrid(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.Hufflepuff(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.Ravenclaw(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.Slytherin(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.black_hair(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.blonde_hair(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.broom_firebolt(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.broom_nimbus(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.brown_hair(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.color_blue_eyes(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.color_brown_eyes(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.color_green_eyes(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.not_Gryffindor(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.not_Hagrid(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.not_Hufflepuff(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.not_Ravenclaw(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.not_Slytherin(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.not_black_hair(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.not_blonde_hair(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.not_broom_firebolt(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.not_broom_nimbus(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.not_brown_hair(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.not_color_blue_eyes(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.not_color_brown_eyes(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.not_color_green_eyes(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.not_quidditch_beater(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.not_quidditch_chaser(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.not_quidditch_keeper(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.not_quidditch_seeker(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.quidditch_beater(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.quidditch_chaser(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.quidditch_keeper(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.quidditch_seeker(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.recent(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.with_attached_hats(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.with_attached_school_photo(*args); end
+
   sig { returns(T.nilable(Wizard::Broom)) }
   def typed_broom; end
 
@@ -368,7 +479,12 @@ class Wizard < ApplicationRecord
   def typed_quidditch_position=(value); end
 end
 
-module Wizard::QueryMethodsReturningRelation
+class Wizard::ActiveRecord_Relation < ActiveRecord::Relation
+  include Wizard::ActiveRelation_WhereNot
+  include Wizard::CustomFinderMethods
+  include Wizard::QueryMethodsReturningRelation
+  Elem = type_member(fixed: Wizard)
+
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
   def Gryffindor(*args); end
 
@@ -479,7 +595,256 @@ module Wizard::QueryMethodsReturningRelation
 
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
   def with_attached_school_photo(*args); end
+end
 
+class Wizard::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
+  include Wizard::ActiveRelation_WhereNot
+  include Wizard::CustomFinderMethods
+  include Wizard::QueryMethodsReturningAssociationRelation
+  Elem = type_member(fixed: Wizard)
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def Gryffindor(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def Hagrid(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def Hufflepuff(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def Ravenclaw(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def Slytherin(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def black_hair(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def blonde_hair(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def broom_firebolt(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def broom_nimbus(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def brown_hair(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def color_blue_eyes(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def color_brown_eyes(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def color_green_eyes(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def not_Gryffindor(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def not_Hagrid(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def not_Hufflepuff(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def not_Ravenclaw(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def not_Slytherin(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def not_black_hair(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def not_blonde_hair(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def not_broom_firebolt(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def not_broom_nimbus(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def not_brown_hair(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def not_color_blue_eyes(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def not_color_brown_eyes(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def not_color_green_eyes(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def not_quidditch_beater(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def not_quidditch_chaser(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def not_quidditch_keeper(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def not_quidditch_seeker(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def quidditch_beater(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def quidditch_chaser(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def quidditch_keeper(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def quidditch_seeker(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def recent(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def with_attached_hats(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def with_attached_school_photo(*args); end
+end
+
+class Wizard::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
+  include Wizard::CustomFinderMethods
+  include Wizard::QueryMethodsReturningAssociationRelation
+  Elem = type_member(fixed: Wizard)
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def Gryffindor(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def Hagrid(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def Hufflepuff(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def Ravenclaw(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def Slytherin(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def black_hair(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def blonde_hair(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def broom_firebolt(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def broom_nimbus(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def brown_hair(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def color_blue_eyes(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def color_brown_eyes(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def color_green_eyes(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def not_Gryffindor(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def not_Hagrid(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def not_Hufflepuff(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def not_Ravenclaw(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def not_Slytherin(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def not_black_hair(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def not_blonde_hair(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def not_broom_firebolt(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def not_broom_nimbus(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def not_brown_hair(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def not_color_blue_eyes(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def not_color_brown_eyes(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def not_color_green_eyes(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def not_quidditch_beater(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def not_quidditch_chaser(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def not_quidditch_keeper(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def not_quidditch_seeker(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def quidditch_beater(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def quidditch_chaser(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def quidditch_keeper(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def quidditch_seeker(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def recent(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def with_attached_hats(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def with_attached_school_photo(*args); end
+
+  sig { params(records: T.any(Wizard, T::Array[Wizard])).returns(T.self_type) }
+  def <<(*records); end
+
+  sig { params(records: T.any(Wizard, T::Array[Wizard])).returns(T.self_type) }
+  def append(*records); end
+
+  sig { params(records: T.any(Wizard, T::Array[Wizard])).returns(T.self_type) }
+  def push(*records); end
+
+  sig { params(records: T.any(Wizard, T::Array[Wizard])).returns(T.self_type) }
+  def concat(*records); end
+end
+
+module Wizard::QueryMethodsReturningRelation
   sig { returns(Wizard::ActiveRecord_Relation) }
   def all; end
 
@@ -581,117 +946,6 @@ module Wizard::QueryMethodsReturningRelation
 end
 
 module Wizard::QueryMethodsReturningAssociationRelation
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def Gryffindor(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def Hagrid(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def Hufflepuff(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def Ravenclaw(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def Slytherin(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def black_hair(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def blonde_hair(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def broom_firebolt(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def broom_nimbus(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def brown_hair(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def color_blue_eyes(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def color_brown_eyes(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def color_green_eyes(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def not_Gryffindor(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def not_Hagrid(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def not_Hufflepuff(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def not_Ravenclaw(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def not_Slytherin(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def not_black_hair(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def not_blonde_hair(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def not_broom_firebolt(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def not_broom_nimbus(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def not_brown_hair(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def not_color_blue_eyes(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def not_color_brown_eyes(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def not_color_green_eyes(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def not_quidditch_beater(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def not_quidditch_chaser(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def not_quidditch_keeper(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def not_quidditch_seeker(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def quidditch_beater(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def quidditch_chaser(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def quidditch_keeper(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def quidditch_seeker(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def recent(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def with_attached_hats(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def with_attached_school_photo(*args); end
-
   sig { returns(Wizard::ActiveRecord_AssociationRelation) }
   def all; end
 
@@ -792,20 +1046,6 @@ module Wizard::QueryMethodsReturningAssociationRelation
   def extending(*args, &block); end
 end
 
-class Wizard::ActiveRecord_Relation < ActiveRecord::Relation
-  include Wizard::ActiveRelation_WhereNot
-  include Wizard::CustomFinderMethods
-  include Wizard::QueryMethodsReturningRelation
-  Elem = type_member(fixed: Wizard)
-end
-
-class Wizard::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
-  include Wizard::ActiveRelation_WhereNot
-  include Wizard::CustomFinderMethods
-  include Wizard::QueryMethodsReturningAssociationRelation
-  Elem = type_member(fixed: Wizard)
-end
-
 module Wizard::GeneratedAssociationMethods
   sig { returns(::ActiveStorage::Attachment::ActiveRecord_Associations_CollectionProxy) }
   def hats_attachments; end
@@ -877,23 +1117,5 @@ module Wizard::GeneratedAssociationMethods
   def hats; end
 
   sig { params(attachables: T.untyped).returns(T.untyped) }
-  def hats=(*attachables); end
-end
-
-class Wizard::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
-  include Wizard::CustomFinderMethods
-  include Wizard::QueryMethodsReturningAssociationRelation
-  Elem = type_member(fixed: Wizard)
-
-  sig { params(records: T.any(Wizard, T::Array[Wizard])).returns(T.self_type) }
-  def <<(*records); end
-
-  sig { params(records: T.any(Wizard, T::Array[Wizard])).returns(T.self_type) }
-  def append(*records); end
-
-  sig { params(records: T.any(Wizard, T::Array[Wizard])).returns(T.self_type) }
-  def push(*records); end
-
-  sig { params(records: T.any(Wizard, T::Array[Wizard])).returns(T.self_type) }
-  def concat(*records); end
+  def hats=(attachables); end
 end

--- a/spec/test_data/v6.0/expected_wizard_wo_spellbook.rbi
+++ b/spec/test_data/v6.0/expected_wizard_wo_spellbook.rbi
@@ -331,6 +331,117 @@ class Wizard < ApplicationRecord
   sig { returns(T::Hash[T.any(String, Symbol), Integer]) }
   def self.quidditch_positions; end
 
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.Gryffindor(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.Hagrid(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.Hufflepuff(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.Ravenclaw(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.Slytherin(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.black_hair(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.blonde_hair(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.broom_firebolt(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.broom_nimbus(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.brown_hair(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.color_blue_eyes(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.color_brown_eyes(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.color_green_eyes(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.not_Gryffindor(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.not_Hagrid(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.not_Hufflepuff(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.not_Ravenclaw(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.not_Slytherin(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.not_black_hair(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.not_blonde_hair(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.not_broom_firebolt(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.not_broom_nimbus(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.not_brown_hair(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.not_color_blue_eyes(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.not_color_brown_eyes(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.not_color_green_eyes(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.not_quidditch_beater(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.not_quidditch_chaser(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.not_quidditch_keeper(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.not_quidditch_seeker(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.quidditch_beater(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.quidditch_chaser(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.quidditch_keeper(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.quidditch_seeker(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.recent(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.with_attached_hats(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
+  def self.with_attached_school_photo(*args); end
+
   sig { returns(T.nilable(Wizard::Broom)) }
   def typed_broom; end
 
@@ -368,7 +479,12 @@ class Wizard < ApplicationRecord
   def typed_quidditch_position=(value); end
 end
 
-module Wizard::QueryMethodsReturningRelation
+class Wizard::ActiveRecord_Relation < ActiveRecord::Relation
+  include Wizard::ActiveRelation_WhereNot
+  include Wizard::CustomFinderMethods
+  include Wizard::QueryMethodsReturningRelation
+  Elem = type_member(fixed: Wizard)
+
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
   def Gryffindor(*args); end
 
@@ -479,7 +595,256 @@ module Wizard::QueryMethodsReturningRelation
 
   sig { params(args: T.untyped).returns(Wizard::ActiveRecord_Relation) }
   def with_attached_school_photo(*args); end
+end
 
+class Wizard::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
+  include Wizard::ActiveRelation_WhereNot
+  include Wizard::CustomFinderMethods
+  include Wizard::QueryMethodsReturningAssociationRelation
+  Elem = type_member(fixed: Wizard)
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def Gryffindor(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def Hagrid(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def Hufflepuff(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def Ravenclaw(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def Slytherin(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def black_hair(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def blonde_hair(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def broom_firebolt(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def broom_nimbus(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def brown_hair(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def color_blue_eyes(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def color_brown_eyes(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def color_green_eyes(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def not_Gryffindor(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def not_Hagrid(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def not_Hufflepuff(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def not_Ravenclaw(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def not_Slytherin(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def not_black_hair(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def not_blonde_hair(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def not_broom_firebolt(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def not_broom_nimbus(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def not_brown_hair(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def not_color_blue_eyes(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def not_color_brown_eyes(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def not_color_green_eyes(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def not_quidditch_beater(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def not_quidditch_chaser(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def not_quidditch_keeper(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def not_quidditch_seeker(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def quidditch_beater(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def quidditch_chaser(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def quidditch_keeper(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def quidditch_seeker(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def recent(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def with_attached_hats(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def with_attached_school_photo(*args); end
+end
+
+class Wizard::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
+  include Wizard::CustomFinderMethods
+  include Wizard::QueryMethodsReturningAssociationRelation
+  Elem = type_member(fixed: Wizard)
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def Gryffindor(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def Hagrid(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def Hufflepuff(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def Ravenclaw(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def Slytherin(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def black_hair(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def blonde_hair(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def broom_firebolt(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def broom_nimbus(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def brown_hair(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def color_blue_eyes(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def color_brown_eyes(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def color_green_eyes(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def not_Gryffindor(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def not_Hagrid(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def not_Hufflepuff(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def not_Ravenclaw(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def not_Slytherin(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def not_black_hair(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def not_blonde_hair(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def not_broom_firebolt(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def not_broom_nimbus(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def not_brown_hair(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def not_color_blue_eyes(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def not_color_brown_eyes(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def not_color_green_eyes(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def not_quidditch_beater(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def not_quidditch_chaser(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def not_quidditch_keeper(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def not_quidditch_seeker(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def quidditch_beater(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def quidditch_chaser(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def quidditch_keeper(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def quidditch_seeker(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def recent(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def with_attached_hats(*args); end
+
+  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def with_attached_school_photo(*args); end
+
+  sig { params(records: T.any(Wizard, T::Array[Wizard])).returns(T.self_type) }
+  def <<(*records); end
+
+  sig { params(records: T.any(Wizard, T::Array[Wizard])).returns(T.self_type) }
+  def append(*records); end
+
+  sig { params(records: T.any(Wizard, T::Array[Wizard])).returns(T.self_type) }
+  def push(*records); end
+
+  sig { params(records: T.any(Wizard, T::Array[Wizard])).returns(T.self_type) }
+  def concat(*records); end
+end
+
+module Wizard::QueryMethodsReturningRelation
   sig { returns(Wizard::ActiveRecord_Relation) }
   def all; end
 
@@ -581,117 +946,6 @@ module Wizard::QueryMethodsReturningRelation
 end
 
 module Wizard::QueryMethodsReturningAssociationRelation
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def Gryffindor(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def Hagrid(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def Hufflepuff(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def Ravenclaw(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def Slytherin(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def black_hair(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def blonde_hair(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def broom_firebolt(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def broom_nimbus(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def brown_hair(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def color_blue_eyes(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def color_brown_eyes(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def color_green_eyes(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def not_Gryffindor(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def not_Hagrid(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def not_Hufflepuff(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def not_Ravenclaw(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def not_Slytherin(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def not_black_hair(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def not_blonde_hair(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def not_broom_firebolt(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def not_broom_nimbus(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def not_brown_hair(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def not_color_blue_eyes(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def not_color_brown_eyes(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def not_color_green_eyes(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def not_quidditch_beater(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def not_quidditch_chaser(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def not_quidditch_keeper(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def not_quidditch_seeker(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def quidditch_beater(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def quidditch_chaser(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def quidditch_keeper(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def quidditch_seeker(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def recent(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def with_attached_hats(*args); end
-
-  sig { params(args: T.untyped).returns(Wizard::ActiveRecord_AssociationRelation) }
-  def with_attached_school_photo(*args); end
-
   sig { returns(Wizard::ActiveRecord_AssociationRelation) }
   def all; end
 
@@ -792,20 +1046,6 @@ module Wizard::QueryMethodsReturningAssociationRelation
   def extending(*args, &block); end
 end
 
-class Wizard::ActiveRecord_Relation < ActiveRecord::Relation
-  include Wizard::ActiveRelation_WhereNot
-  include Wizard::CustomFinderMethods
-  include Wizard::QueryMethodsReturningRelation
-  Elem = type_member(fixed: Wizard)
-end
-
-class Wizard::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
-  include Wizard::ActiveRelation_WhereNot
-  include Wizard::CustomFinderMethods
-  include Wizard::QueryMethodsReturningAssociationRelation
-  Elem = type_member(fixed: Wizard)
-end
-
 module Wizard::GeneratedAssociationMethods
   sig { returns(::ActiveStorage::Attachment::ActiveRecord_Associations_CollectionProxy) }
   def hats_attachments; end
@@ -871,23 +1111,5 @@ module Wizard::GeneratedAssociationMethods
   def hats; end
 
   sig { params(attachables: T.untyped).returns(T.untyped) }
-  def hats=(*attachables); end
-end
-
-class Wizard::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
-  include Wizard::CustomFinderMethods
-  include Wizard::QueryMethodsReturningAssociationRelation
-  Elem = type_member(fixed: Wizard)
-
-  sig { params(records: T.any(Wizard, T::Array[Wizard])).returns(T.self_type) }
-  def <<(*records); end
-
-  sig { params(records: T.any(Wizard, T::Array[Wizard])).returns(T.self_type) }
-  def append(*records); end
-
-  sig { params(records: T.any(Wizard, T::Array[Wizard])).returns(T.self_type) }
-  def push(*records); end
-
-  sig { params(records: T.any(Wizard, T::Array[Wizard])).returns(T.self_type) }
-  def concat(*records); end
+  def hats=(attachables); end
 end


### PR DESCRIPTION
- The build/create/create!/new method on ActiveRecord Relation now use a new sig
- Force generating named scope methods in Rails 6
- Fix sig with active_storage: attachables shouldn't have *
- Regenerate routes.rbi for Rails 6.
- Disable test for Ruby 2.7, Rails 6 due to a RBI generation error: https://github.com/sorbet/sorbet/issues/2994