### PR TITLE
Change in_batches to return BatchEnumerator object

### DIFF
--- a/lib/sorbet-rails/model_plugins/active_record_querying.rb
+++ b/lib/sorbet-rails/model_plugins/active_record_querying.rb
@@ -74,7 +74,7 @@ class SorbetRails::ModelPlugins::ActiveRecordQuerying < SorbetRails::ModelPlugin
         Parameter.new("error_on_ignore:", type: "T.nilable(T::Boolean)", default: "nil"),
         Parameter.new("&block", type: "T.nilable(T.proc.params(e: #{inner_type}).void)"),
       ],
-      return_type: "T::Enumerable[#{inner_type}]",
+      return_type: "ActiveRecord::Batches::BatchEnumerator",
     )
   end
 end

--- a/spec/generators/sorbet_test_cases.rb
+++ b/spec/generators/sorbet_test_cases.rb
@@ -64,7 +64,7 @@ T.assert_type!(Wizard.find_each, T::Enumerator[Wizard])
 Wizard.find_in_batches { |w| T.assert_type!(w, T::Array[Wizard]) }
 T.assert_type!(Wizard.find_in_batches, T::Enumerator[T::Array[Wizard]])
 Wizard.in_batches { |w| T.assert_type!(w, Wizard::ActiveRecord_Relation) }
-T.assert_type!(Wizard.in_batches, T::Enumerable[Wizard::ActiveRecord_Relation])
+T.assert_type!(Wizard.in_batches, ActiveRecord::Batches::BatchEnumerator)
 # T.assert_type!(Wizard.destroy_all, T::Array[Wizard]) # Ignored until we add support
 T.assert_type!(Wizard.any?, T::Boolean)
 T.assert_type!(Wizard.many?, T::Boolean)

--- a/spec/support/v5.0/sorbet_test_cases.rb
+++ b/spec/support/v5.0/sorbet_test_cases.rb
@@ -64,7 +64,7 @@ T.assert_type!(Wizard.find_each, T::Enumerator[Wizard])
 Wizard.find_in_batches { |w| T.assert_type!(w, T::Array[Wizard]) }
 T.assert_type!(Wizard.find_in_batches, T::Enumerator[T::Array[Wizard]])
 Wizard.in_batches { |w| T.assert_type!(w, Wizard::ActiveRecord_Relation) }
-T.assert_type!(Wizard.in_batches, T::Enumerable[Wizard::ActiveRecord_Relation])
+T.assert_type!(Wizard.in_batches, ActiveRecord::Batches::BatchEnumerator)
 # T.assert_type!(Wizard.destroy_all, T::Array[Wizard]) # Ignored until we add support
 T.assert_type!(Wizard.any?, T::Boolean)
 T.assert_type!(Wizard.many?, T::Boolean)

--- a/spec/support/v5.1/sorbet_test_cases.rb
+++ b/spec/support/v5.1/sorbet_test_cases.rb
@@ -64,7 +64,7 @@ T.assert_type!(Wizard.find_each, T::Enumerator[Wizard])
 Wizard.find_in_batches { |w| T.assert_type!(w, T::Array[Wizard]) }
 T.assert_type!(Wizard.find_in_batches, T::Enumerator[T::Array[Wizard]])
 Wizard.in_batches { |w| T.assert_type!(w, Wizard::ActiveRecord_Relation) }
-T.assert_type!(Wizard.in_batches, T::Enumerable[Wizard::ActiveRecord_Relation])
+T.assert_type!(Wizard.in_batches, ActiveRecord::Batches::BatchEnumerator)
 # T.assert_type!(Wizard.destroy_all, T::Array[Wizard]) # Ignored until we add support
 T.assert_type!(Wizard.any?, T::Boolean)
 T.assert_type!(Wizard.many?, T::Boolean)

--- a/spec/support/v5.2/sorbet_test_cases.rb
+++ b/spec/support/v5.2/sorbet_test_cases.rb
@@ -64,7 +64,7 @@ T.assert_type!(Wizard.find_each, T::Enumerator[Wizard])
 Wizard.find_in_batches { |w| T.assert_type!(w, T::Array[Wizard]) }
 T.assert_type!(Wizard.find_in_batches, T::Enumerator[T::Array[Wizard]])
 Wizard.in_batches { |w| T.assert_type!(w, Wizard::ActiveRecord_Relation) }
-T.assert_type!(Wizard.in_batches, T::Enumerable[Wizard::ActiveRecord_Relation])
+T.assert_type!(Wizard.in_batches, ActiveRecord::Batches::BatchEnumerator)
 # T.assert_type!(Wizard.destroy_all, T::Array[Wizard]) # Ignored until we add support
 T.assert_type!(Wizard.any?, T::Boolean)
 T.assert_type!(Wizard.many?, T::Boolean)

--- a/spec/support/v6.0/sorbet_test_cases.rb
+++ b/spec/support/v6.0/sorbet_test_cases.rb
@@ -64,7 +64,7 @@ T.assert_type!(Wizard.find_each, T::Enumerator[Wizard])
 Wizard.find_in_batches { |w| T.assert_type!(w, T::Array[Wizard]) }
 T.assert_type!(Wizard.find_in_batches, T::Enumerator[T::Array[Wizard]])
 Wizard.in_batches { |w| T.assert_type!(w, Wizard::ActiveRecord_Relation) }
-T.assert_type!(Wizard.in_batches, T::Enumerable[Wizard::ActiveRecord_Relation])
+T.assert_type!(Wizard.in_batches, ActiveRecord::Batches::BatchEnumerator)
 # T.assert_type!(Wizard.destroy_all, T::Array[Wizard]) # Ignored until we add support
 T.assert_type!(Wizard.any?, T::Boolean)
 T.assert_type!(Wizard.many?, T::Boolean)

--- a/spec/test_data/v5.0/expected_headmaster.rbi
+++ b/spec/test_data/v5.0/expected_headmaster.rbi
@@ -168,7 +168,7 @@ module Headmaster::QueryMethodsReturningRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: Headmaster::ActiveRecord_Relation).void)
-    ).returns(T::Enumerable[Headmaster::ActiveRecord_Relation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end
@@ -266,7 +266,7 @@ module Headmaster::QueryMethodsReturningAssociationRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: Headmaster::ActiveRecord_AssociationRelation).void)
-    ).returns(T::Enumerable[Headmaster::ActiveRecord_AssociationRelation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end

--- a/spec/test_data/v5.0/expected_internal_metadata.rbi
+++ b/spec/test_data/v5.0/expected_internal_metadata.rbi
@@ -162,7 +162,7 @@ module ActiveRecord::InternalMetadata::QueryMethodsReturningRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: ActiveRecord::InternalMetadata::ActiveRecord_Relation).void)
-    ).returns(T::Enumerable[ActiveRecord::InternalMetadata::ActiveRecord_Relation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end
@@ -260,7 +260,7 @@ module ActiveRecord::InternalMetadata::QueryMethodsReturningAssociationRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation).void)
-    ).returns(T::Enumerable[ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end

--- a/spec/test_data/v5.0/expected_potion.rbi
+++ b/spec/test_data/v5.0/expected_potion.rbi
@@ -132,7 +132,7 @@ module Potion::QueryMethodsReturningRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: Potion::ActiveRecord_Relation).void)
-    ).returns(T::Enumerable[Potion::ActiveRecord_Relation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end
@@ -230,7 +230,7 @@ module Potion::QueryMethodsReturningAssociationRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: Potion::ActiveRecord_AssociationRelation).void)
-    ).returns(T::Enumerable[Potion::ActiveRecord_AssociationRelation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end

--- a/spec/test_data/v5.0/expected_robe.rbi
+++ b/spec/test_data/v5.0/expected_robe.rbi
@@ -153,7 +153,7 @@ module Robe::QueryMethodsReturningRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: Robe::ActiveRecord_Relation).void)
-    ).returns(T::Enumerable[Robe::ActiveRecord_Relation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end
@@ -251,7 +251,7 @@ module Robe::QueryMethodsReturningAssociationRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: Robe::ActiveRecord_AssociationRelation).void)
-    ).returns(T::Enumerable[Robe::ActiveRecord_AssociationRelation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end

--- a/spec/test_data/v5.0/expected_schema_migration.rbi
+++ b/spec/test_data/v5.0/expected_schema_migration.rbi
@@ -135,7 +135,7 @@ module ActiveRecord::SchemaMigration::QueryMethodsReturningRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: ActiveRecord::SchemaMigration::ActiveRecord_Relation).void)
-    ).returns(T::Enumerable[ActiveRecord::SchemaMigration::ActiveRecord_Relation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end
@@ -233,7 +233,7 @@ module ActiveRecord::SchemaMigration::QueryMethodsReturningAssociationRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation).void)
-    ).returns(T::Enumerable[ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end

--- a/spec/test_data/v5.0/expected_school.rbi
+++ b/spec/test_data/v5.0/expected_school.rbi
@@ -153,7 +153,7 @@ module School::QueryMethodsReturningRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: School::ActiveRecord_Relation).void)
-    ).returns(T::Enumerable[School::ActiveRecord_Relation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end
@@ -251,7 +251,7 @@ module School::QueryMethodsReturningAssociationRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: School::ActiveRecord_AssociationRelation).void)
-    ).returns(T::Enumerable[School::ActiveRecord_AssociationRelation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end

--- a/spec/test_data/v5.0/expected_spell.rbi
+++ b/spec/test_data/v5.0/expected_spell.rbi
@@ -156,7 +156,7 @@ module Spell::QueryMethodsReturningRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: Spell::ActiveRecord_Relation).void)
-    ).returns(T::Enumerable[Spell::ActiveRecord_Relation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end
@@ -254,7 +254,7 @@ module Spell::QueryMethodsReturningAssociationRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: Spell::ActiveRecord_AssociationRelation).void)
-    ).returns(T::Enumerable[Spell::ActiveRecord_AssociationRelation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end

--- a/spec/test_data/v5.0/expected_spell/habtm_spell_books.rbi
+++ b/spec/test_data/v5.0/expected_spell/habtm_spell_books.rbi
@@ -159,7 +159,7 @@ module Spell::HABTM_SpellBooks::QueryMethodsReturningRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: Spell::HABTM_SpellBooks::ActiveRecord_Relation).void)
-    ).returns(T::Enumerable[Spell::HABTM_SpellBooks::ActiveRecord_Relation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end
@@ -257,7 +257,7 @@ module Spell::HABTM_SpellBooks::QueryMethodsReturningAssociationRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation).void)
-    ).returns(T::Enumerable[Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end

--- a/spec/test_data/v5.0/expected_spell_book.rbi
+++ b/spec/test_data/v5.0/expected_spell_book.rbi
@@ -299,7 +299,7 @@ module SpellBook::QueryMethodsReturningRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: SpellBook::ActiveRecord_Relation).void)
-    ).returns(T::Enumerable[SpellBook::ActiveRecord_Relation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end
@@ -397,7 +397,7 @@ module SpellBook::QueryMethodsReturningAssociationRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: SpellBook::ActiveRecord_AssociationRelation).void)
-    ).returns(T::Enumerable[SpellBook::ActiveRecord_AssociationRelation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end

--- a/spec/test_data/v5.0/expected_spell_book/habtm_spells.rbi
+++ b/spec/test_data/v5.0/expected_spell_book/habtm_spells.rbi
@@ -159,7 +159,7 @@ module SpellBook::HABTM_Spells::QueryMethodsReturningRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: SpellBook::HABTM_Spells::ActiveRecord_Relation).void)
-    ).returns(T::Enumerable[SpellBook::HABTM_Spells::ActiveRecord_Relation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end
@@ -257,7 +257,7 @@ module SpellBook::HABTM_Spells::QueryMethodsReturningAssociationRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation).void)
-    ).returns(T::Enumerable[SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end

--- a/spec/test_data/v5.0/expected_squib.rbi
+++ b/spec/test_data/v5.0/expected_squib.rbi
@@ -665,7 +665,7 @@ module Squib::QueryMethodsReturningRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: Squib::ActiveRecord_Relation).void)
-    ).returns(T::Enumerable[Squib::ActiveRecord_Relation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end
@@ -763,7 +763,7 @@ module Squib::QueryMethodsReturningAssociationRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: Squib::ActiveRecord_AssociationRelation).void)
-    ).returns(T::Enumerable[Squib::ActiveRecord_AssociationRelation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end

--- a/spec/test_data/v5.0/expected_subject.rbi
+++ b/spec/test_data/v5.0/expected_subject.rbi
@@ -156,7 +156,7 @@ module Subject::QueryMethodsReturningRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: Subject::ActiveRecord_Relation).void)
-    ).returns(T::Enumerable[Subject::ActiveRecord_Relation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end
@@ -254,7 +254,7 @@ module Subject::QueryMethodsReturningAssociationRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: Subject::ActiveRecord_AssociationRelation).void)
-    ).returns(T::Enumerable[Subject::ActiveRecord_AssociationRelation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end

--- a/spec/test_data/v5.0/expected_subject/habtm_wizards.rbi
+++ b/spec/test_data/v5.0/expected_subject/habtm_wizards.rbi
@@ -159,7 +159,7 @@ module Subject::HABTM_Wizards::QueryMethodsReturningRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: Subject::HABTM_Wizards::ActiveRecord_Relation).void)
-    ).returns(T::Enumerable[Subject::HABTM_Wizards::ActiveRecord_Relation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end
@@ -257,7 +257,7 @@ module Subject::HABTM_Wizards::QueryMethodsReturningAssociationRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: Subject::HABTM_Wizards::ActiveRecord_AssociationRelation).void)
-    ).returns(T::Enumerable[Subject::HABTM_Wizards::ActiveRecord_AssociationRelation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end

--- a/spec/test_data/v5.0/expected_wand.rbi
+++ b/spec/test_data/v5.0/expected_wand.rbi
@@ -381,7 +381,7 @@ module Wand::QueryMethodsReturningRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: Wand::ActiveRecord_Relation).void)
-    ).returns(T::Enumerable[Wand::ActiveRecord_Relation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end
@@ -479,7 +479,7 @@ module Wand::QueryMethodsReturningAssociationRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: Wand::ActiveRecord_AssociationRelation).void)
-    ).returns(T::Enumerable[Wand::ActiveRecord_AssociationRelation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end

--- a/spec/test_data/v5.0/expected_wizard.rbi
+++ b/spec/test_data/v5.0/expected_wizard.rbi
@@ -741,7 +741,7 @@ module Wizard::QueryMethodsReturningRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: Wizard::ActiveRecord_Relation).void)
-    ).returns(T::Enumerable[Wizard::ActiveRecord_Relation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end
@@ -839,7 +839,7 @@ module Wizard::QueryMethodsReturningAssociationRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: Wizard::ActiveRecord_AssociationRelation).void)
-    ).returns(T::Enumerable[Wizard::ActiveRecord_AssociationRelation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end

--- a/spec/test_data/v5.0/expected_wizard/habtm_subjects.rbi
+++ b/spec/test_data/v5.0/expected_wizard/habtm_subjects.rbi
@@ -159,7 +159,7 @@ module Wizard::HABTM_Subjects::QueryMethodsReturningRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: Wizard::HABTM_Subjects::ActiveRecord_Relation).void)
-    ).returns(T::Enumerable[Wizard::HABTM_Subjects::ActiveRecord_Relation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end
@@ -257,7 +257,7 @@ module Wizard::HABTM_Subjects::QueryMethodsReturningAssociationRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation).void)
-    ).returns(T::Enumerable[Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end

--- a/spec/test_data/v5.0/expected_wizard_wo_spellbook.rbi
+++ b/spec/test_data/v5.0/expected_wizard_wo_spellbook.rbi
@@ -735,7 +735,7 @@ module Wizard::QueryMethodsReturningRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: Wizard::ActiveRecord_Relation).void)
-    ).returns(T::Enumerable[Wizard::ActiveRecord_Relation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end
@@ -833,7 +833,7 @@ module Wizard::QueryMethodsReturningAssociationRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: Wizard::ActiveRecord_AssociationRelation).void)
-    ).returns(T::Enumerable[Wizard::ActiveRecord_AssociationRelation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end

--- a/spec/test_data/v5.1/expected_headmaster.rbi
+++ b/spec/test_data/v5.1/expected_headmaster.rbi
@@ -171,7 +171,7 @@ module Headmaster::QueryMethodsReturningRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: Headmaster::ActiveRecord_Relation).void)
-    ).returns(T::Enumerable[Headmaster::ActiveRecord_Relation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end
@@ -272,7 +272,7 @@ module Headmaster::QueryMethodsReturningAssociationRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: Headmaster::ActiveRecord_AssociationRelation).void)
-    ).returns(T::Enumerable[Headmaster::ActiveRecord_AssociationRelation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end

--- a/spec/test_data/v5.1/expected_internal_metadata.rbi
+++ b/spec/test_data/v5.1/expected_internal_metadata.rbi
@@ -165,7 +165,7 @@ module ActiveRecord::InternalMetadata::QueryMethodsReturningRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: ActiveRecord::InternalMetadata::ActiveRecord_Relation).void)
-    ).returns(T::Enumerable[ActiveRecord::InternalMetadata::ActiveRecord_Relation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end
@@ -266,7 +266,7 @@ module ActiveRecord::InternalMetadata::QueryMethodsReturningAssociationRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation).void)
-    ).returns(T::Enumerable[ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end

--- a/spec/test_data/v5.1/expected_potion.rbi
+++ b/spec/test_data/v5.1/expected_potion.rbi
@@ -135,7 +135,7 @@ module Potion::QueryMethodsReturningRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: Potion::ActiveRecord_Relation).void)
-    ).returns(T::Enumerable[Potion::ActiveRecord_Relation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end
@@ -236,7 +236,7 @@ module Potion::QueryMethodsReturningAssociationRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: Potion::ActiveRecord_AssociationRelation).void)
-    ).returns(T::Enumerable[Potion::ActiveRecord_AssociationRelation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end

--- a/spec/test_data/v5.1/expected_robe.rbi
+++ b/spec/test_data/v5.1/expected_robe.rbi
@@ -156,7 +156,7 @@ module Robe::QueryMethodsReturningRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: Robe::ActiveRecord_Relation).void)
-    ).returns(T::Enumerable[Robe::ActiveRecord_Relation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end
@@ -257,7 +257,7 @@ module Robe::QueryMethodsReturningAssociationRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: Robe::ActiveRecord_AssociationRelation).void)
-    ).returns(T::Enumerable[Robe::ActiveRecord_AssociationRelation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end

--- a/spec/test_data/v5.1/expected_schema_migration.rbi
+++ b/spec/test_data/v5.1/expected_schema_migration.rbi
@@ -138,7 +138,7 @@ module ActiveRecord::SchemaMigration::QueryMethodsReturningRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: ActiveRecord::SchemaMigration::ActiveRecord_Relation).void)
-    ).returns(T::Enumerable[ActiveRecord::SchemaMigration::ActiveRecord_Relation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end
@@ -239,7 +239,7 @@ module ActiveRecord::SchemaMigration::QueryMethodsReturningAssociationRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation).void)
-    ).returns(T::Enumerable[ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end

--- a/spec/test_data/v5.1/expected_school.rbi
+++ b/spec/test_data/v5.1/expected_school.rbi
@@ -156,7 +156,7 @@ module School::QueryMethodsReturningRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: School::ActiveRecord_Relation).void)
-    ).returns(T::Enumerable[School::ActiveRecord_Relation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end
@@ -257,7 +257,7 @@ module School::QueryMethodsReturningAssociationRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: School::ActiveRecord_AssociationRelation).void)
-    ).returns(T::Enumerable[School::ActiveRecord_AssociationRelation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end

--- a/spec/test_data/v5.1/expected_spell.rbi
+++ b/spec/test_data/v5.1/expected_spell.rbi
@@ -159,7 +159,7 @@ module Spell::QueryMethodsReturningRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: Spell::ActiveRecord_Relation).void)
-    ).returns(T::Enumerable[Spell::ActiveRecord_Relation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end
@@ -260,7 +260,7 @@ module Spell::QueryMethodsReturningAssociationRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: Spell::ActiveRecord_AssociationRelation).void)
-    ).returns(T::Enumerable[Spell::ActiveRecord_AssociationRelation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end

--- a/spec/test_data/v5.1/expected_spell/habtm_spell_books.rbi
+++ b/spec/test_data/v5.1/expected_spell/habtm_spell_books.rbi
@@ -162,7 +162,7 @@ module Spell::HABTM_SpellBooks::QueryMethodsReturningRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: Spell::HABTM_SpellBooks::ActiveRecord_Relation).void)
-    ).returns(T::Enumerable[Spell::HABTM_SpellBooks::ActiveRecord_Relation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end
@@ -263,7 +263,7 @@ module Spell::HABTM_SpellBooks::QueryMethodsReturningAssociationRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation).void)
-    ).returns(T::Enumerable[Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end

--- a/spec/test_data/v5.1/expected_spell_book.rbi
+++ b/spec/test_data/v5.1/expected_spell_book.rbi
@@ -302,7 +302,7 @@ module SpellBook::QueryMethodsReturningRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: SpellBook::ActiveRecord_Relation).void)
-    ).returns(T::Enumerable[SpellBook::ActiveRecord_Relation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end
@@ -403,7 +403,7 @@ module SpellBook::QueryMethodsReturningAssociationRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: SpellBook::ActiveRecord_AssociationRelation).void)
-    ).returns(T::Enumerable[SpellBook::ActiveRecord_AssociationRelation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end

--- a/spec/test_data/v5.1/expected_spell_book/habtm_spells.rbi
+++ b/spec/test_data/v5.1/expected_spell_book/habtm_spells.rbi
@@ -162,7 +162,7 @@ module SpellBook::HABTM_Spells::QueryMethodsReturningRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: SpellBook::HABTM_Spells::ActiveRecord_Relation).void)
-    ).returns(T::Enumerable[SpellBook::HABTM_Spells::ActiveRecord_Relation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end
@@ -263,7 +263,7 @@ module SpellBook::HABTM_Spells::QueryMethodsReturningAssociationRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation).void)
-    ).returns(T::Enumerable[SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end

--- a/spec/test_data/v5.1/expected_squib.rbi
+++ b/spec/test_data/v5.1/expected_squib.rbi
@@ -668,7 +668,7 @@ module Squib::QueryMethodsReturningRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: Squib::ActiveRecord_Relation).void)
-    ).returns(T::Enumerable[Squib::ActiveRecord_Relation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end
@@ -769,7 +769,7 @@ module Squib::QueryMethodsReturningAssociationRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: Squib::ActiveRecord_AssociationRelation).void)
-    ).returns(T::Enumerable[Squib::ActiveRecord_AssociationRelation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end

--- a/spec/test_data/v5.1/expected_subject.rbi
+++ b/spec/test_data/v5.1/expected_subject.rbi
@@ -159,7 +159,7 @@ module Subject::QueryMethodsReturningRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: Subject::ActiveRecord_Relation).void)
-    ).returns(T::Enumerable[Subject::ActiveRecord_Relation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end
@@ -260,7 +260,7 @@ module Subject::QueryMethodsReturningAssociationRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: Subject::ActiveRecord_AssociationRelation).void)
-    ).returns(T::Enumerable[Subject::ActiveRecord_AssociationRelation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end

--- a/spec/test_data/v5.1/expected_subject/habtm_wizards.rbi
+++ b/spec/test_data/v5.1/expected_subject/habtm_wizards.rbi
@@ -162,7 +162,7 @@ module Subject::HABTM_Wizards::QueryMethodsReturningRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: Subject::HABTM_Wizards::ActiveRecord_Relation).void)
-    ).returns(T::Enumerable[Subject::HABTM_Wizards::ActiveRecord_Relation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end
@@ -263,7 +263,7 @@ module Subject::HABTM_Wizards::QueryMethodsReturningAssociationRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: Subject::HABTM_Wizards::ActiveRecord_AssociationRelation).void)
-    ).returns(T::Enumerable[Subject::HABTM_Wizards::ActiveRecord_AssociationRelation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end

--- a/spec/test_data/v5.1/expected_wand.rbi
+++ b/spec/test_data/v5.1/expected_wand.rbi
@@ -384,7 +384,7 @@ module Wand::QueryMethodsReturningRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: Wand::ActiveRecord_Relation).void)
-    ).returns(T::Enumerable[Wand::ActiveRecord_Relation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end
@@ -485,7 +485,7 @@ module Wand::QueryMethodsReturningAssociationRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: Wand::ActiveRecord_AssociationRelation).void)
-    ).returns(T::Enumerable[Wand::ActiveRecord_AssociationRelation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end

--- a/spec/test_data/v5.1/expected_wizard.rbi
+++ b/spec/test_data/v5.1/expected_wizard.rbi
@@ -744,7 +744,7 @@ module Wizard::QueryMethodsReturningRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: Wizard::ActiveRecord_Relation).void)
-    ).returns(T::Enumerable[Wizard::ActiveRecord_Relation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end
@@ -845,7 +845,7 @@ module Wizard::QueryMethodsReturningAssociationRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: Wizard::ActiveRecord_AssociationRelation).void)
-    ).returns(T::Enumerable[Wizard::ActiveRecord_AssociationRelation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end

--- a/spec/test_data/v5.1/expected_wizard/habtm_subjects.rbi
+++ b/spec/test_data/v5.1/expected_wizard/habtm_subjects.rbi
@@ -162,7 +162,7 @@ module Wizard::HABTM_Subjects::QueryMethodsReturningRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: Wizard::HABTM_Subjects::ActiveRecord_Relation).void)
-    ).returns(T::Enumerable[Wizard::HABTM_Subjects::ActiveRecord_Relation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end
@@ -263,7 +263,7 @@ module Wizard::HABTM_Subjects::QueryMethodsReturningAssociationRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation).void)
-    ).returns(T::Enumerable[Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end

--- a/spec/test_data/v5.1/expected_wizard_wo_spellbook.rbi
+++ b/spec/test_data/v5.1/expected_wizard_wo_spellbook.rbi
@@ -738,7 +738,7 @@ module Wizard::QueryMethodsReturningRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: Wizard::ActiveRecord_Relation).void)
-    ).returns(T::Enumerable[Wizard::ActiveRecord_Relation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end
@@ -839,7 +839,7 @@ module Wizard::QueryMethodsReturningAssociationRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: Wizard::ActiveRecord_AssociationRelation).void)
-    ).returns(T::Enumerable[Wizard::ActiveRecord_AssociationRelation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end

--- a/spec/test_data/v5.2/expected_attachment.rbi
+++ b/spec/test_data/v5.2/expected_attachment.rbi
@@ -141,7 +141,7 @@ module ActiveStorage::Attachment::QueryMethodsReturningRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: ActiveStorage::Attachment::ActiveRecord_Relation).void)
-    ).returns(T::Enumerable[ActiveStorage::Attachment::ActiveRecord_Relation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end
@@ -242,7 +242,7 @@ module ActiveStorage::Attachment::QueryMethodsReturningAssociationRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: ActiveStorage::Attachment::ActiveRecord_AssociationRelation).void)
-    ).returns(T::Enumerable[ActiveStorage::Attachment::ActiveRecord_AssociationRelation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end

--- a/spec/test_data/v5.2/expected_blob.rbi
+++ b/spec/test_data/v5.2/expected_blob.rbi
@@ -206,7 +206,7 @@ module ActiveStorage::Blob::QueryMethodsReturningRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: ActiveStorage::Blob::ActiveRecord_Relation).void)
-    ).returns(T::Enumerable[ActiveStorage::Blob::ActiveRecord_Relation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end
@@ -307,7 +307,7 @@ module ActiveStorage::Blob::QueryMethodsReturningAssociationRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: ActiveStorage::Blob::ActiveRecord_AssociationRelation).void)
-    ).returns(T::Enumerable[ActiveStorage::Blob::ActiveRecord_AssociationRelation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end

--- a/spec/test_data/v5.2/expected_headmaster.rbi
+++ b/spec/test_data/v5.2/expected_headmaster.rbi
@@ -171,7 +171,7 @@ module Headmaster::QueryMethodsReturningRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: Headmaster::ActiveRecord_Relation).void)
-    ).returns(T::Enumerable[Headmaster::ActiveRecord_Relation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end
@@ -272,7 +272,7 @@ module Headmaster::QueryMethodsReturningAssociationRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: Headmaster::ActiveRecord_AssociationRelation).void)
-    ).returns(T::Enumerable[Headmaster::ActiveRecord_AssociationRelation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end

--- a/spec/test_data/v5.2/expected_internal_metadata.rbi
+++ b/spec/test_data/v5.2/expected_internal_metadata.rbi
@@ -165,7 +165,7 @@ module ActiveRecord::InternalMetadata::QueryMethodsReturningRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: ActiveRecord::InternalMetadata::ActiveRecord_Relation).void)
-    ).returns(T::Enumerable[ActiveRecord::InternalMetadata::ActiveRecord_Relation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end
@@ -266,7 +266,7 @@ module ActiveRecord::InternalMetadata::QueryMethodsReturningAssociationRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation).void)
-    ).returns(T::Enumerable[ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end

--- a/spec/test_data/v5.2/expected_potion.rbi
+++ b/spec/test_data/v5.2/expected_potion.rbi
@@ -135,7 +135,7 @@ module Potion::QueryMethodsReturningRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: Potion::ActiveRecord_Relation).void)
-    ).returns(T::Enumerable[Potion::ActiveRecord_Relation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end
@@ -236,7 +236,7 @@ module Potion::QueryMethodsReturningAssociationRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: Potion::ActiveRecord_AssociationRelation).void)
-    ).returns(T::Enumerable[Potion::ActiveRecord_AssociationRelation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end

--- a/spec/test_data/v5.2/expected_robe.rbi
+++ b/spec/test_data/v5.2/expected_robe.rbi
@@ -156,7 +156,7 @@ module Robe::QueryMethodsReturningRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: Robe::ActiveRecord_Relation).void)
-    ).returns(T::Enumerable[Robe::ActiveRecord_Relation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end
@@ -257,7 +257,7 @@ module Robe::QueryMethodsReturningAssociationRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: Robe::ActiveRecord_AssociationRelation).void)
-    ).returns(T::Enumerable[Robe::ActiveRecord_AssociationRelation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end

--- a/spec/test_data/v5.2/expected_schema_migration.rbi
+++ b/spec/test_data/v5.2/expected_schema_migration.rbi
@@ -138,7 +138,7 @@ module ActiveRecord::SchemaMigration::QueryMethodsReturningRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: ActiveRecord::SchemaMigration::ActiveRecord_Relation).void)
-    ).returns(T::Enumerable[ActiveRecord::SchemaMigration::ActiveRecord_Relation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end
@@ -239,7 +239,7 @@ module ActiveRecord::SchemaMigration::QueryMethodsReturningAssociationRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation).void)
-    ).returns(T::Enumerable[ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end

--- a/spec/test_data/v5.2/expected_school.rbi
+++ b/spec/test_data/v5.2/expected_school.rbi
@@ -156,7 +156,7 @@ module School::QueryMethodsReturningRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: School::ActiveRecord_Relation).void)
-    ).returns(T::Enumerable[School::ActiveRecord_Relation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end
@@ -257,7 +257,7 @@ module School::QueryMethodsReturningAssociationRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: School::ActiveRecord_AssociationRelation).void)
-    ).returns(T::Enumerable[School::ActiveRecord_AssociationRelation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end

--- a/spec/test_data/v5.2/expected_spell.rbi
+++ b/spec/test_data/v5.2/expected_spell.rbi
@@ -159,7 +159,7 @@ module Spell::QueryMethodsReturningRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: Spell::ActiveRecord_Relation).void)
-    ).returns(T::Enumerable[Spell::ActiveRecord_Relation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end
@@ -260,7 +260,7 @@ module Spell::QueryMethodsReturningAssociationRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: Spell::ActiveRecord_AssociationRelation).void)
-    ).returns(T::Enumerable[Spell::ActiveRecord_AssociationRelation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end

--- a/spec/test_data/v5.2/expected_spell/habtm_spell_books.rbi
+++ b/spec/test_data/v5.2/expected_spell/habtm_spell_books.rbi
@@ -162,7 +162,7 @@ module Spell::HABTM_SpellBooks::QueryMethodsReturningRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: Spell::HABTM_SpellBooks::ActiveRecord_Relation).void)
-    ).returns(T::Enumerable[Spell::HABTM_SpellBooks::ActiveRecord_Relation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end
@@ -263,7 +263,7 @@ module Spell::HABTM_SpellBooks::QueryMethodsReturningAssociationRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation).void)
-    ).returns(T::Enumerable[Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end

--- a/spec/test_data/v5.2/expected_spell_book.rbi
+++ b/spec/test_data/v5.2/expected_spell_book.rbi
@@ -302,7 +302,7 @@ module SpellBook::QueryMethodsReturningRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: SpellBook::ActiveRecord_Relation).void)
-    ).returns(T::Enumerable[SpellBook::ActiveRecord_Relation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end
@@ -403,7 +403,7 @@ module SpellBook::QueryMethodsReturningAssociationRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: SpellBook::ActiveRecord_AssociationRelation).void)
-    ).returns(T::Enumerable[SpellBook::ActiveRecord_AssociationRelation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end

--- a/spec/test_data/v5.2/expected_spell_book/habtm_spells.rbi
+++ b/spec/test_data/v5.2/expected_spell_book/habtm_spells.rbi
@@ -162,7 +162,7 @@ module SpellBook::HABTM_Spells::QueryMethodsReturningRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: SpellBook::HABTM_Spells::ActiveRecord_Relation).void)
-    ).returns(T::Enumerable[SpellBook::HABTM_Spells::ActiveRecord_Relation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end
@@ -263,7 +263,7 @@ module SpellBook::HABTM_Spells::QueryMethodsReturningAssociationRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation).void)
-    ).returns(T::Enumerable[SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end

--- a/spec/test_data/v5.2/expected_squib.rbi
+++ b/spec/test_data/v5.2/expected_squib.rbi
@@ -722,7 +722,7 @@ module Squib::QueryMethodsReturningRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: Squib::ActiveRecord_Relation).void)
-    ).returns(T::Enumerable[Squib::ActiveRecord_Relation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end
@@ -823,7 +823,7 @@ module Squib::QueryMethodsReturningAssociationRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: Squib::ActiveRecord_AssociationRelation).void)
-    ).returns(T::Enumerable[Squib::ActiveRecord_AssociationRelation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end

--- a/spec/test_data/v5.2/expected_subject.rbi
+++ b/spec/test_data/v5.2/expected_subject.rbi
@@ -159,7 +159,7 @@ module Subject::QueryMethodsReturningRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: Subject::ActiveRecord_Relation).void)
-    ).returns(T::Enumerable[Subject::ActiveRecord_Relation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end
@@ -260,7 +260,7 @@ module Subject::QueryMethodsReturningAssociationRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: Subject::ActiveRecord_AssociationRelation).void)
-    ).returns(T::Enumerable[Subject::ActiveRecord_AssociationRelation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end

--- a/spec/test_data/v5.2/expected_subject/habtm_wizards.rbi
+++ b/spec/test_data/v5.2/expected_subject/habtm_wizards.rbi
@@ -162,7 +162,7 @@ module Subject::HABTM_Wizards::QueryMethodsReturningRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: Subject::HABTM_Wizards::ActiveRecord_Relation).void)
-    ).returns(T::Enumerable[Subject::HABTM_Wizards::ActiveRecord_Relation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end
@@ -263,7 +263,7 @@ module Subject::HABTM_Wizards::QueryMethodsReturningAssociationRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: Subject::HABTM_Wizards::ActiveRecord_AssociationRelation).void)
-    ).returns(T::Enumerable[Subject::HABTM_Wizards::ActiveRecord_AssociationRelation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end

--- a/spec/test_data/v5.2/expected_wand.rbi
+++ b/spec/test_data/v5.2/expected_wand.rbi
@@ -402,7 +402,7 @@ module Wand::QueryMethodsReturningRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: Wand::ActiveRecord_Relation).void)
-    ).returns(T::Enumerable[Wand::ActiveRecord_Relation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end
@@ -503,7 +503,7 @@ module Wand::QueryMethodsReturningAssociationRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: Wand::ActiveRecord_AssociationRelation).void)
-    ).returns(T::Enumerable[Wand::ActiveRecord_AssociationRelation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end

--- a/spec/test_data/v5.2/expected_wizard.rbi
+++ b/spec/test_data/v5.2/expected_wizard.rbi
@@ -798,7 +798,7 @@ module Wizard::QueryMethodsReturningRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: Wizard::ActiveRecord_Relation).void)
-    ).returns(T::Enumerable[Wizard::ActiveRecord_Relation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end
@@ -899,7 +899,7 @@ module Wizard::QueryMethodsReturningAssociationRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: Wizard::ActiveRecord_AssociationRelation).void)
-    ).returns(T::Enumerable[Wizard::ActiveRecord_AssociationRelation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end

--- a/spec/test_data/v5.2/expected_wizard/habtm_subjects.rbi
+++ b/spec/test_data/v5.2/expected_wizard/habtm_subjects.rbi
@@ -162,7 +162,7 @@ module Wizard::HABTM_Subjects::QueryMethodsReturningRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: Wizard::HABTM_Subjects::ActiveRecord_Relation).void)
-    ).returns(T::Enumerable[Wizard::HABTM_Subjects::ActiveRecord_Relation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end
@@ -263,7 +263,7 @@ module Wizard::HABTM_Subjects::QueryMethodsReturningAssociationRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation).void)
-    ).returns(T::Enumerable[Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end

--- a/spec/test_data/v5.2/expected_wizard_wo_spellbook.rbi
+++ b/spec/test_data/v5.2/expected_wizard_wo_spellbook.rbi
@@ -792,7 +792,7 @@ module Wizard::QueryMethodsReturningRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: Wizard::ActiveRecord_Relation).void)
-    ).returns(T::Enumerable[Wizard::ActiveRecord_Relation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end
@@ -893,7 +893,7 @@ module Wizard::QueryMethodsReturningAssociationRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: Wizard::ActiveRecord_AssociationRelation).void)
-    ).returns(T::Enumerable[Wizard::ActiveRecord_AssociationRelation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end

--- a/spec/test_data/v6.0/expected_attachment.rbi
+++ b/spec/test_data/v6.0/expected_attachment.rbi
@@ -153,7 +153,7 @@ module ActiveStorage::Attachment::QueryMethodsReturningRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: ActiveStorage::Attachment::ActiveRecord_Relation).void)
-    ).returns(T::Enumerable[ActiveStorage::Attachment::ActiveRecord_Relation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end
@@ -266,7 +266,7 @@ module ActiveStorage::Attachment::QueryMethodsReturningAssociationRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: ActiveStorage::Attachment::ActiveRecord_AssociationRelation).void)
-    ).returns(T::Enumerable[ActiveStorage::Attachment::ActiveRecord_AssociationRelation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end

--- a/spec/test_data/v6.0/expected_blob.rbi
+++ b/spec/test_data/v6.0/expected_blob.rbi
@@ -195,7 +195,7 @@ module ActiveStorage::Blob::QueryMethodsReturningRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: ActiveStorage::Blob::ActiveRecord_Relation).void)
-    ).returns(T::Enumerable[ActiveStorage::Blob::ActiveRecord_Relation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end
@@ -308,7 +308,7 @@ module ActiveStorage::Blob::QueryMethodsReturningAssociationRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: ActiveStorage::Blob::ActiveRecord_AssociationRelation).void)
-    ).returns(T::Enumerable[ActiveStorage::Blob::ActiveRecord_AssociationRelation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end

--- a/spec/test_data/v6.0/expected_headmaster.rbi
+++ b/spec/test_data/v6.0/expected_headmaster.rbi
@@ -183,7 +183,7 @@ module Headmaster::QueryMethodsReturningRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: Headmaster::ActiveRecord_Relation).void)
-    ).returns(T::Enumerable[Headmaster::ActiveRecord_Relation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end
@@ -296,7 +296,7 @@ module Headmaster::QueryMethodsReturningAssociationRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: Headmaster::ActiveRecord_AssociationRelation).void)
-    ).returns(T::Enumerable[Headmaster::ActiveRecord_AssociationRelation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end

--- a/spec/test_data/v6.0/expected_internal_metadata.rbi
+++ b/spec/test_data/v6.0/expected_internal_metadata.rbi
@@ -177,7 +177,7 @@ module ActiveRecord::InternalMetadata::QueryMethodsReturningRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: ActiveRecord::InternalMetadata::ActiveRecord_Relation).void)
-    ).returns(T::Enumerable[ActiveRecord::InternalMetadata::ActiveRecord_Relation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end
@@ -290,7 +290,7 @@ module ActiveRecord::InternalMetadata::QueryMethodsReturningAssociationRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation).void)
-    ).returns(T::Enumerable[ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end

--- a/spec/test_data/v6.0/expected_potion.rbi
+++ b/spec/test_data/v6.0/expected_potion.rbi
@@ -147,7 +147,7 @@ module Potion::QueryMethodsReturningRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: Potion::ActiveRecord_Relation).void)
-    ).returns(T::Enumerable[Potion::ActiveRecord_Relation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end
@@ -260,7 +260,7 @@ module Potion::QueryMethodsReturningAssociationRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: Potion::ActiveRecord_AssociationRelation).void)
-    ).returns(T::Enumerable[Potion::ActiveRecord_AssociationRelation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end

--- a/spec/test_data/v6.0/expected_robe.rbi
+++ b/spec/test_data/v6.0/expected_robe.rbi
@@ -168,7 +168,7 @@ module Robe::QueryMethodsReturningRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: Robe::ActiveRecord_Relation).void)
-    ).returns(T::Enumerable[Robe::ActiveRecord_Relation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end
@@ -281,7 +281,7 @@ module Robe::QueryMethodsReturningAssociationRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: Robe::ActiveRecord_AssociationRelation).void)
-    ).returns(T::Enumerable[Robe::ActiveRecord_AssociationRelation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end

--- a/spec/test_data/v6.0/expected_schema_migration.rbi
+++ b/spec/test_data/v6.0/expected_schema_migration.rbi
@@ -150,7 +150,7 @@ module ActiveRecord::SchemaMigration::QueryMethodsReturningRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: ActiveRecord::SchemaMigration::ActiveRecord_Relation).void)
-    ).returns(T::Enumerable[ActiveRecord::SchemaMigration::ActiveRecord_Relation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end
@@ -263,7 +263,7 @@ module ActiveRecord::SchemaMigration::QueryMethodsReturningAssociationRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation).void)
-    ).returns(T::Enumerable[ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end

--- a/spec/test_data/v6.0/expected_school.rbi
+++ b/spec/test_data/v6.0/expected_school.rbi
@@ -168,7 +168,7 @@ module School::QueryMethodsReturningRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: School::ActiveRecord_Relation).void)
-    ).returns(T::Enumerable[School::ActiveRecord_Relation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end
@@ -281,7 +281,7 @@ module School::QueryMethodsReturningAssociationRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: School::ActiveRecord_AssociationRelation).void)
-    ).returns(T::Enumerable[School::ActiveRecord_AssociationRelation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end

--- a/spec/test_data/v6.0/expected_spell.rbi
+++ b/spec/test_data/v6.0/expected_spell.rbi
@@ -171,7 +171,7 @@ module Spell::QueryMethodsReturningRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: Spell::ActiveRecord_Relation).void)
-    ).returns(T::Enumerable[Spell::ActiveRecord_Relation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end
@@ -284,7 +284,7 @@ module Spell::QueryMethodsReturningAssociationRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: Spell::ActiveRecord_AssociationRelation).void)
-    ).returns(T::Enumerable[Spell::ActiveRecord_AssociationRelation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end

--- a/spec/test_data/v6.0/expected_spell/habtm_spell_books.rbi
+++ b/spec/test_data/v6.0/expected_spell/habtm_spell_books.rbi
@@ -174,7 +174,7 @@ module Spell::HABTM_SpellBooks::QueryMethodsReturningRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: Spell::HABTM_SpellBooks::ActiveRecord_Relation).void)
-    ).returns(T::Enumerable[Spell::HABTM_SpellBooks::ActiveRecord_Relation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end
@@ -287,7 +287,7 @@ module Spell::HABTM_SpellBooks::QueryMethodsReturningAssociationRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation).void)
-    ).returns(T::Enumerable[Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end

--- a/spec/test_data/v6.0/expected_spell_book.rbi
+++ b/spec/test_data/v6.0/expected_spell_book.rbi
@@ -350,7 +350,7 @@ module SpellBook::QueryMethodsReturningRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: SpellBook::ActiveRecord_Relation).void)
-    ).returns(T::Enumerable[SpellBook::ActiveRecord_Relation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end
@@ -463,7 +463,7 @@ module SpellBook::QueryMethodsReturningAssociationRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: SpellBook::ActiveRecord_AssociationRelation).void)
-    ).returns(T::Enumerable[SpellBook::ActiveRecord_AssociationRelation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end

--- a/spec/test_data/v6.0/expected_spell_book/habtm_spells.rbi
+++ b/spec/test_data/v6.0/expected_spell_book/habtm_spells.rbi
@@ -174,7 +174,7 @@ module SpellBook::HABTM_Spells::QueryMethodsReturningRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: SpellBook::HABTM_Spells::ActiveRecord_Relation).void)
-    ).returns(T::Enumerable[SpellBook::HABTM_Spells::ActiveRecord_Relation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end
@@ -287,7 +287,7 @@ module SpellBook::HABTM_Spells::QueryMethodsReturningAssociationRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation).void)
-    ).returns(T::Enumerable[SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end

--- a/spec/test_data/v6.0/expected_squib.rbi
+++ b/spec/test_data/v6.0/expected_squib.rbi
@@ -876,7 +876,7 @@ module Squib::QueryMethodsReturningRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: Squib::ActiveRecord_Relation).void)
-    ).returns(T::Enumerable[Squib::ActiveRecord_Relation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end
@@ -989,7 +989,7 @@ module Squib::QueryMethodsReturningAssociationRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: Squib::ActiveRecord_AssociationRelation).void)
-    ).returns(T::Enumerable[Squib::ActiveRecord_AssociationRelation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end

--- a/spec/test_data/v6.0/expected_subject.rbi
+++ b/spec/test_data/v6.0/expected_subject.rbi
@@ -171,7 +171,7 @@ module Subject::QueryMethodsReturningRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: Subject::ActiveRecord_Relation).void)
-    ).returns(T::Enumerable[Subject::ActiveRecord_Relation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end
@@ -284,7 +284,7 @@ module Subject::QueryMethodsReturningAssociationRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: Subject::ActiveRecord_AssociationRelation).void)
-    ).returns(T::Enumerable[Subject::ActiveRecord_AssociationRelation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end

--- a/spec/test_data/v6.0/expected_subject/habtm_wizards.rbi
+++ b/spec/test_data/v6.0/expected_subject/habtm_wizards.rbi
@@ -174,7 +174,7 @@ module Subject::HABTM_Wizards::QueryMethodsReturningRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: Subject::HABTM_Wizards::ActiveRecord_Relation).void)
-    ).returns(T::Enumerable[Subject::HABTM_Wizards::ActiveRecord_Relation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end
@@ -287,7 +287,7 @@ module Subject::HABTM_Wizards::QueryMethodsReturningAssociationRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: Subject::HABTM_Wizards::ActiveRecord_AssociationRelation).void)
-    ).returns(T::Enumerable[Subject::HABTM_Wizards::ActiveRecord_AssociationRelation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end

--- a/spec/test_data/v6.0/expected_wand.rbi
+++ b/spec/test_data/v6.0/expected_wand.rbi
@@ -462,7 +462,7 @@ module Wand::QueryMethodsReturningRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: Wand::ActiveRecord_Relation).void)
-    ).returns(T::Enumerable[Wand::ActiveRecord_Relation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end
@@ -575,7 +575,7 @@ module Wand::QueryMethodsReturningAssociationRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: Wand::ActiveRecord_AssociationRelation).void)
-    ).returns(T::Enumerable[Wand::ActiveRecord_AssociationRelation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end

--- a/spec/test_data/v6.0/expected_wizard.rbi
+++ b/spec/test_data/v6.0/expected_wizard.rbi
@@ -952,7 +952,7 @@ module Wizard::QueryMethodsReturningRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: Wizard::ActiveRecord_Relation).void)
-    ).returns(T::Enumerable[Wizard::ActiveRecord_Relation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end
@@ -1065,7 +1065,7 @@ module Wizard::QueryMethodsReturningAssociationRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: Wizard::ActiveRecord_AssociationRelation).void)
-    ).returns(T::Enumerable[Wizard::ActiveRecord_AssociationRelation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end

--- a/spec/test_data/v6.0/expected_wizard/habtm_subjects.rbi
+++ b/spec/test_data/v6.0/expected_wizard/habtm_subjects.rbi
@@ -174,7 +174,7 @@ module Wizard::HABTM_Subjects::QueryMethodsReturningRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: Wizard::HABTM_Subjects::ActiveRecord_Relation).void)
-    ).returns(T::Enumerable[Wizard::HABTM_Subjects::ActiveRecord_Relation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end
@@ -287,7 +287,7 @@ module Wizard::HABTM_Subjects::QueryMethodsReturningAssociationRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation).void)
-    ).returns(T::Enumerable[Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end

--- a/spec/test_data/v6.0/expected_wizard_wo_spellbook.rbi
+++ b/spec/test_data/v6.0/expected_wizard_wo_spellbook.rbi
@@ -952,7 +952,7 @@ module Wizard::QueryMethodsReturningRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: Wizard::ActiveRecord_Relation).void)
-    ).returns(T::Enumerable[Wizard::ActiveRecord_Relation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end
@@ -1065,7 +1065,7 @@ module Wizard::QueryMethodsReturningAssociationRelation
       load: T.nilable(T::Boolean),
       error_on_ignore: T.nilable(T::Boolean),
       block: T.nilable(T.proc.params(e: Wizard::ActiveRecord_AssociationRelation).void)
-    ).returns(T::Enumerable[Wizard::ActiveRecord_AssociationRelation])
+    ).returns(ActiveRecord::Batches::BatchEnumerator)
   end
   def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, &block); end
 end


### PR DESCRIPTION
Based on the doc, `in_batches` return a custom BatchEnumerator object. This has additional methods (on top of being an enumerator), such as `delete_all`. 

The downside of using `in_batches` return value is that the elements are untyped. So it's still advisable to use `in_batches` with block if you want to perform more complex logic on each element 

https://apidock.com/rails/ActiveRecord/Batches/in_batches