### PR TITLE
add a bundled typed_enum.rbi

### DIFF
--- a/lib/bundled_rbi/typed_enum.rbi
+++ b/lib/bundled_rbi/typed_enum.rbi
@@ -1,0 +1,7 @@
+# typed: strong
+module ActiveRecord::Enum
+
+  sig { params(definitions: T::Hash[Symbol, T.untyped]).void }
+  def typed_enum(definitions); end
+
+end

--- a/lib/sorbet-rails/tasks/rails_rbi.rake
+++ b/lib/sorbet-rails/tasks/rails_rbi.rake
@@ -41,6 +41,7 @@ namespace :rails_rbi do
     copy_bundled_rbi('parameters.rbi')
     copy_bundled_rbi('pluck_to_tstruct.rbi')
     copy_bundled_rbi('typed_params.rbi')
+    copy_bundled_rbi('typed_enum.rbi')
 
     # These files were previously bundled_rbi but are now generated so this
     # is needed for backwards compatibility with anyone using `rails_rbi:custom`


### PR DESCRIPTION
Previously we relied on hidden-definitions to add this method. It's better to provide our own so in case people haven't run hidden-definitions or don't run hidden-definitions, it is still recognized.