### PR TITLE
fix build due to a new version of sorbet

### DIFF
--- a/sorbet/rbi/hidden-definitions/hidden.rbi
+++ b/sorbet/rbi/hidden-definitions/hidden.rbi
@@ -9485,9 +9485,6 @@ class OpenSSL::PKey::EC::Point
 end
 
 class OpenSSL::PKey::RSA
-  def sign_pss(*_); end
-
-  def verify_pss(*_); end
 end
 
 module OpenSSL::SSL


### PR DESCRIPTION
new build failure due to new signature for OpenSSL::PKey::RSA#sign_pss and OpenSSL::PKey::RSA#verify_pss