### PR TITLE
Add default url options to url helpers

### DIFF
--- a/lib/sorbet-rails/rails_mixins/generated_url_helpers.rb
+++ b/lib/sorbet-rails/rails_mixins/generated_url_helpers.rb
@@ -11,6 +11,5 @@
 # + include GeneratedUrlHelpers
 # end
 #
-module GeneratedUrlHelpers
-  include Rails.application.routes.url_helpers
-end
+# Reference: https://github.com/rails/rails/blob/master/actionpack/lib/action_dispatch/routing/route_set.rb
+GeneratedUrlHelpers = Rails.application.routes.url_helpers

--- a/spec/generators/sorbet_test_cases.rb
+++ b/spec/generators/sorbet_test_cases.rb
@@ -377,8 +377,12 @@ Wizard.all.pluck_to_tstruct(TA[WizardStruct].new).each do |row|
   T.assert_type!(row, WizardStruct)
 end
 
-
 # -- GeneratedUrlHelpers
+class TestHelperWithoutUrlOptions
+  include GeneratedUrlHelpers
+end
+T.assert_type!(TestHelperWithoutUrlOptions.new.test_index_path, String)
+
 class TestHelper
   include GeneratedUrlHelpers
 
@@ -390,10 +394,5 @@ class TestHelper
       port: 3000,
     }
   end
-
-  def test_url_helper
-    T.assert_type!(test_index_path, String)
-    T.assert_type!(test_index_url, String)
-  end
 end
-TestHelper.new.test_url_helper
+T.assert_type!(TestHelper.new.test_index_url, String)

--- a/spec/support/v5.0/sorbet_test_cases.rb
+++ b/spec/support/v5.0/sorbet_test_cases.rb
@@ -377,8 +377,12 @@ Wizard.all.pluck_to_tstruct(TA[WizardStruct].new).each do |row|
   T.assert_type!(row, WizardStruct)
 end
 
-
 # -- GeneratedUrlHelpers
+class TestHelperWithoutUrlOptions
+  include GeneratedUrlHelpers
+end
+T.assert_type!(TestHelperWithoutUrlOptions.new.test_index_path, String)
+
 class TestHelper
   include GeneratedUrlHelpers
 
@@ -390,10 +394,5 @@ class TestHelper
       port: 3000,
     }
   end
-
-  def test_url_helper
-    T.assert_type!(test_index_path, String)
-    T.assert_type!(test_index_url, String)
-  end
 end
-TestHelper.new.test_url_helper
+T.assert_type!(TestHelper.new.test_index_url, String)

--- a/spec/support/v5.1/sorbet_test_cases.rb
+++ b/spec/support/v5.1/sorbet_test_cases.rb
@@ -377,8 +377,12 @@ Wizard.all.pluck_to_tstruct(TA[WizardStruct].new).each do |row|
   T.assert_type!(row, WizardStruct)
 end
 
-
 # -- GeneratedUrlHelpers
+class TestHelperWithoutUrlOptions
+  include GeneratedUrlHelpers
+end
+T.assert_type!(TestHelperWithoutUrlOptions.new.test_index_path, String)
+
 class TestHelper
   include GeneratedUrlHelpers
 
@@ -390,10 +394,5 @@ class TestHelper
       port: 3000,
     }
   end
-
-  def test_url_helper
-    T.assert_type!(test_index_path, String)
-    T.assert_type!(test_index_url, String)
-  end
 end
-TestHelper.new.test_url_helper
+T.assert_type!(TestHelper.new.test_index_url, String)

--- a/spec/support/v5.2/sorbet_test_cases.rb
+++ b/spec/support/v5.2/sorbet_test_cases.rb
@@ -377,8 +377,12 @@ Wizard.all.pluck_to_tstruct(TA[WizardStruct].new).each do |row|
   T.assert_type!(row, WizardStruct)
 end
 
-
 # -- GeneratedUrlHelpers
+class TestHelperWithoutUrlOptions
+  include GeneratedUrlHelpers
+end
+T.assert_type!(TestHelperWithoutUrlOptions.new.test_index_path, String)
+
 class TestHelper
   include GeneratedUrlHelpers
 
@@ -390,10 +394,5 @@ class TestHelper
       port: 3000,
     }
   end
-
-  def test_url_helper
-    T.assert_type!(test_index_path, String)
-    T.assert_type!(test_index_url, String)
-  end
 end
-TestHelper.new.test_url_helper
+T.assert_type!(TestHelper.new.test_index_url, String)

--- a/spec/support/v6.0/sorbet_test_cases.rb
+++ b/spec/support/v6.0/sorbet_test_cases.rb
@@ -377,8 +377,12 @@ Wizard.all.pluck_to_tstruct(TA[WizardStruct].new).each do |row|
   T.assert_type!(row, WizardStruct)
 end
 
-
 # -- GeneratedUrlHelpers
+class TestHelperWithoutUrlOptions
+  include GeneratedUrlHelpers
+end
+T.assert_type!(TestHelperWithoutUrlOptions.new.test_index_path, String)
+
 class TestHelper
   include GeneratedUrlHelpers
 
@@ -390,10 +394,5 @@ class TestHelper
       port: 3000,
     }
   end
-
-  def test_url_helper
-    T.assert_type!(test_index_path, String)
-    T.assert_type!(test_index_url, String)
-  end
 end
-TestHelper.new.test_url_helper
+T.assert_type!(TestHelper.new.test_index_url, String)


### PR DESCRIPTION
Turns out classes including `url_helpers` does not need `default_url_options` defined explicitly to work (See #335). This PR implements a `default_url_options` method that draw it from the Rails application config so that people don't have to implement it explicitly.

Note that the default for `Rails.application.config` is {} and usually applications will set it for their mailer etc. The `_path` methods will work empty options {} but the `_url` methods still require a valid set of options with a HOST.