### PR TITLE
release 0.7.0

### DIFF
--- a/sorbet-rails.gemspec
+++ b/sorbet-rails.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name          = %q{sorbet-rails}
-  s.version       = "0.6.5.1"
+  s.version       = "0.7.0"
   s.date          = %q{2019-04-18}
   s.summary       = %q{Set of tools to make Sorbet work with Rails seamlessly.}
   s.authors       = ["Chan Zuckerberg Initiative"]

--- a/spec/support/v5.0/Gemfile.lock
+++ b/spec/support/v5.0/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../..
   specs:
-    sorbet-rails (0.6.5.1)
+    sorbet-rails (0.7.0)
       method_source (>= 0.9.2)
       parlour (~> 2.0)
       parser (>= 2.7)

--- a/spec/support/v5.1/Gemfile.lock
+++ b/spec/support/v5.1/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../..
   specs:
-    sorbet-rails (0.6.5.1)
+    sorbet-rails (0.7.0)
       method_source (>= 0.9.2)
       parlour (~> 2.0)
       parser (>= 2.7)

--- a/spec/support/v5.2/Gemfile.lock
+++ b/spec/support/v5.2/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../..
   specs:
-    sorbet-rails (0.6.5.1)
+    sorbet-rails (0.7.0)
       method_source (>= 0.9.2)
       parlour (~> 2.0)
       parser (>= 2.7)

--- a/spec/support/v6.0/Gemfile.lock
+++ b/spec/support/v6.0/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../..
   specs:
-    sorbet-rails (0.6.5.1)
+    sorbet-rails (0.7.0)
       method_source (>= 0.9.2)
       parlour (~> 2.0)
       parser (>= 2.7)


### PR DESCRIPTION
- Drop "fetch_typed", "require_typed" in favor of TypedParams
- Drop "IntegerString", "BooleanString" because they are not needed with TypedParams. They also introduce unnecessary perf cost.
- Add a sig for typed_enum.
- Fix GeneratedUrlHelper working with _path method out of the box.