### PR TITLE
Generate`T::Enum`s as a nested class

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,12 +136,14 @@ ie.
 Will generate this enum:
 
 ```ruby
-class Wizard::House < T::Enum
-  enums do
-    Gryffindor = new('Gryffindor')
-    Hufflepuff = new('Hufflepuff')
-    Ravenclaw = new('Ravenclaw')
-    Slytherin = new('Slytherin')
+class Wizard
+  class House < T::Enum
+    enums do
+      Gryffindor = new('Gryffindor')
+      Hufflepuff = new('Hufflepuff')
+      Ravenclaw = new('Ravenclaw')
+      Slytherin = new('Slytherin')
+    end
   end
 end
 ```

--- a/lib/sorbet-rails/model_plugins/active_record_attribute.rb
+++ b/lib/sorbet-rails/model_plugins/active_record_attribute.rb
@@ -73,18 +73,18 @@ class SorbetRails::ModelPlugins::ActiveRecordAttribute < SorbetRails::ModelPlugi
         # do not generate the methods for enums in strict_mode
         should_skip_setter_getter = config.strict_mode
 
-        t_enum_type = "#{model_class_name}::#{config.class_name}"
-
-        # define T::Enum class & values
-        enum_values = T.must(model_defined_enums[column_name])
-        t_enum_values = @model_class.gen_typed_enum_values(enum_values.keys)
-        root.create_enum_class(
-          t_enum_type,
-          enums: t_enum_values.map { |k, v| [v, "%q{#{k}}"] },
-        )
+        root.create_class(model_class_name) do |model_class|
+          # define T::Enum class & values
+          enum_values = T.must(model_defined_enums[column_name])
+          t_enum_values = @model_class.gen_typed_enum_values(enum_values.keys)
+          model_class.create_enum_class(
+            config.class_name,
+            enums: t_enum_values.map { |k, v| [v, "%q{#{k}}"] },
+          )
+        end
 
         # define t_enum setter/getter
-        assignable_type = t_enum_type
+        assignable_type = "#{model_class_name}::#{config.class_name}"
         assignable_type = "T.nilable(#{assignable_type})" if nilable_column
         # add directly to model_class_rbi because they are included
         # by sorbet's hidden.rbi

--- a/spec/test_data/v5.0/expected_spell_book.rbi
+++ b/spec/test_data/v5.0/expected_spell_book.rbi
@@ -65,15 +65,6 @@ module SpellBook::GeneratedAttributeMethods
   def wizard_id?; end
 end
 
-class SpellBook::BookType < T::Enum
-  enums do
-    Unclassified = new(%q{unclassified})
-    Biology = new(%q{biology})
-    DarkArt = new(%q{dark_art})
-  end
-
-end
-
 module SpellBook::GeneratedAssociationMethods
   sig { returns(::Spell::ActiveRecord_Associations_CollectionProxy) }
   def spells; end
@@ -145,6 +136,15 @@ class SpellBook < ApplicationRecord
 
   sig { params(value: SpellBook::BookType).void }
   def typed_book_type=(value); end
+
+  class BookType < T::Enum
+    enums do
+      Unclassified = new(%q{unclassified})
+      Biology = new(%q{biology})
+      DarkArt = new(%q{dark_art})
+    end
+
+  end
 end
 
 class SpellBook::ActiveRecord_Relation < ActiveRecord::Relation

--- a/spec/test_data/v5.0/expected_wand.rbi
+++ b/spec/test_data/v5.0/expected_wand.rbi
@@ -152,16 +152,6 @@ module Wand::GeneratedAttributeMethods
   def wood_type?; end
 end
 
-class Wand::CoreType < T::Enum
-  enums do
-    PhoenixFeather = new(%q{phoenix_feather})
-    DragonHeartstring = new(%q{dragon_heartstring})
-    UnicornTailHair = new(%q{unicorn_tail_hair})
-    BasiliskHorn = new(%q{basilisk_horn})
-  end
-
-end
-
 module Wand::GeneratedAssociationMethods
   sig { returns(::Wizard) }
   def wizard; end
@@ -224,6 +214,16 @@ class Wand < ApplicationRecord
 
   sig { params(value: T.nilable(Wand::CoreType)).void }
   def typed_core_type=(value); end
+
+  class CoreType < T::Enum
+    enums do
+      PhoenixFeather = new(%q{phoenix_feather})
+      DragonHeartstring = new(%q{dragon_heartstring})
+      UnicornTailHair = new(%q{unicorn_tail_hair})
+      BasiliskHorn = new(%q{basilisk_horn})
+    end
+
+  end
 
   sig { returns(T::Array[Wand]) }
   def self.mythicals; end

--- a/spec/test_data/v5.0/expected_wizard.rbi
+++ b/spec/test_data/v5.0/expected_wizard.rbi
@@ -230,64 +230,6 @@ module Wizard::GeneratedAttributeMethods
   def updated_at?; end
 end
 
-class Wizard::Broom < T::Enum
-  enums do
-    Nimbus = new(%q{nimbus})
-    Firebolt = new(%q{firebolt})
-  end
-
-end
-
-class Wizard::EyeColor < T::Enum
-  enums do
-    Brown = new(%q{brown})
-    Green = new(%q{green})
-    Blue = new(%q{blue})
-  end
-
-end
-
-class Wizard::HairColor < T::Enum
-  enums do
-    Brown = new(%q{brown})
-    Black = new(%q{black})
-    Blonde = new(%q{blonde})
-  end
-
-end
-
-class Wizard::House < T::Enum
-  enums do
-    Gryffindor = new(%q{Gryffindor})
-    Hufflepuff = new(%q{Hufflepuff})
-    Ravenclaw = new(%q{Ravenclaw})
-    Slytherin = new(%q{Slytherin})
-  end
-
-end
-
-class Wizard::ProfessorEnum < T::Enum
-  enums do
-    SeverusSnape = new(%q{Severus Snape})
-    MinervaMcGonagall = new(%q{Minerva McGonagall})
-    PomonaSprout = new(%q{Pomona Sprout})
-    FiliusFlitwick = new(%q{Filius Flitwick})
-    Hagrid = new(%q{Hagrid})
-    AlastorMadEyeMoody = new(%q{Alastor 'Mad-Eye' Moody})
-  end
-
-end
-
-class Wizard::QuidditchPosition < T::Enum
-  enums do
-    Keeper = new(%q{keeper})
-    Seeker = new(%q{seeker})
-    Beater = new(%q{beater})
-    Chaser = new(%q{chaser})
-  end
-
-end
-
 module Wizard::GeneratedAssociationMethods
   sig { returns(T.nilable(::School)) }
   def school; end
@@ -470,6 +412,64 @@ class Wizard < ApplicationRecord
 
   sig { params(value: T.nilable(Wizard::QuidditchPosition)).void }
   def typed_quidditch_position=(value); end
+
+  class Broom < T::Enum
+    enums do
+      Nimbus = new(%q{nimbus})
+      Firebolt = new(%q{firebolt})
+    end
+
+  end
+
+  class EyeColor < T::Enum
+    enums do
+      Brown = new(%q{brown})
+      Green = new(%q{green})
+      Blue = new(%q{blue})
+    end
+
+  end
+
+  class HairColor < T::Enum
+    enums do
+      Brown = new(%q{brown})
+      Black = new(%q{black})
+      Blonde = new(%q{blonde})
+    end
+
+  end
+
+  class House < T::Enum
+    enums do
+      Gryffindor = new(%q{Gryffindor})
+      Hufflepuff = new(%q{Hufflepuff})
+      Ravenclaw = new(%q{Ravenclaw})
+      Slytherin = new(%q{Slytherin})
+    end
+
+  end
+
+  class ProfessorEnum < T::Enum
+    enums do
+      SeverusSnape = new(%q{Severus Snape})
+      MinervaMcGonagall = new(%q{Minerva McGonagall})
+      PomonaSprout = new(%q{Pomona Sprout})
+      FiliusFlitwick = new(%q{Filius Flitwick})
+      Hagrid = new(%q{Hagrid})
+      AlastorMadEyeMoody = new(%q{Alastor 'Mad-Eye' Moody})
+    end
+
+  end
+
+  class QuidditchPosition < T::Enum
+    enums do
+      Keeper = new(%q{keeper})
+      Seeker = new(%q{seeker})
+      Beater = new(%q{beater})
+      Chaser = new(%q{chaser})
+    end
+
+  end
 end
 
 class Wizard::ActiveRecord_Relation < ActiveRecord::Relation

--- a/spec/test_data/v5.0/expected_wizard_wo_spellbook.rbi
+++ b/spec/test_data/v5.0/expected_wizard_wo_spellbook.rbi
@@ -230,64 +230,6 @@ module Wizard::GeneratedAttributeMethods
   def updated_at?; end
 end
 
-class Wizard::Broom < T::Enum
-  enums do
-    Nimbus = new(%q{nimbus})
-    Firebolt = new(%q{firebolt})
-  end
-
-end
-
-class Wizard::EyeColor < T::Enum
-  enums do
-    Brown = new(%q{brown})
-    Green = new(%q{green})
-    Blue = new(%q{blue})
-  end
-
-end
-
-class Wizard::HairColor < T::Enum
-  enums do
-    Brown = new(%q{brown})
-    Black = new(%q{black})
-    Blonde = new(%q{blonde})
-  end
-
-end
-
-class Wizard::House < T::Enum
-  enums do
-    Gryffindor = new(%q{Gryffindor})
-    Hufflepuff = new(%q{Hufflepuff})
-    Ravenclaw = new(%q{Ravenclaw})
-    Slytherin = new(%q{Slytherin})
-  end
-
-end
-
-class Wizard::ProfessorEnum < T::Enum
-  enums do
-    SeverusSnape = new(%q{Severus Snape})
-    MinervaMcGonagall = new(%q{Minerva McGonagall})
-    PomonaSprout = new(%q{Pomona Sprout})
-    FiliusFlitwick = new(%q{Filius Flitwick})
-    Hagrid = new(%q{Hagrid})
-    AlastorMadEyeMoody = new(%q{Alastor 'Mad-Eye' Moody})
-  end
-
-end
-
-class Wizard::QuidditchPosition < T::Enum
-  enums do
-    Keeper = new(%q{keeper})
-    Seeker = new(%q{seeker})
-    Beater = new(%q{beater})
-    Chaser = new(%q{chaser})
-  end
-
-end
-
 module Wizard::GeneratedAssociationMethods
   sig { returns(T.nilable(T.untyped)) }
   def school; end
@@ -464,6 +406,64 @@ class Wizard < ApplicationRecord
 
   sig { params(value: T.nilable(Wizard::QuidditchPosition)).void }
   def typed_quidditch_position=(value); end
+
+  class Broom < T::Enum
+    enums do
+      Nimbus = new(%q{nimbus})
+      Firebolt = new(%q{firebolt})
+    end
+
+  end
+
+  class EyeColor < T::Enum
+    enums do
+      Brown = new(%q{brown})
+      Green = new(%q{green})
+      Blue = new(%q{blue})
+    end
+
+  end
+
+  class HairColor < T::Enum
+    enums do
+      Brown = new(%q{brown})
+      Black = new(%q{black})
+      Blonde = new(%q{blonde})
+    end
+
+  end
+
+  class House < T::Enum
+    enums do
+      Gryffindor = new(%q{Gryffindor})
+      Hufflepuff = new(%q{Hufflepuff})
+      Ravenclaw = new(%q{Ravenclaw})
+      Slytherin = new(%q{Slytherin})
+    end
+
+  end
+
+  class ProfessorEnum < T::Enum
+    enums do
+      SeverusSnape = new(%q{Severus Snape})
+      MinervaMcGonagall = new(%q{Minerva McGonagall})
+      PomonaSprout = new(%q{Pomona Sprout})
+      FiliusFlitwick = new(%q{Filius Flitwick})
+      Hagrid = new(%q{Hagrid})
+      AlastorMadEyeMoody = new(%q{Alastor 'Mad-Eye' Moody})
+    end
+
+  end
+
+  class QuidditchPosition < T::Enum
+    enums do
+      Keeper = new(%q{keeper})
+      Seeker = new(%q{seeker})
+      Beater = new(%q{beater})
+      Chaser = new(%q{chaser})
+    end
+
+  end
 end
 
 class Wizard::ActiveRecord_Relation < ActiveRecord::Relation

--- a/spec/test_data/v5.1/expected_spell_book.rbi
+++ b/spec/test_data/v5.1/expected_spell_book.rbi
@@ -65,15 +65,6 @@ module SpellBook::GeneratedAttributeMethods
   def wizard_id?; end
 end
 
-class SpellBook::BookType < T::Enum
-  enums do
-    Unclassified = new(%q{unclassified})
-    Biology = new(%q{biology})
-    DarkArt = new(%q{dark_art})
-  end
-
-end
-
 module SpellBook::GeneratedAssociationMethods
   sig { returns(::Spell::ActiveRecord_Associations_CollectionProxy) }
   def spells; end
@@ -145,6 +136,15 @@ class SpellBook < ApplicationRecord
 
   sig { params(value: SpellBook::BookType).void }
   def typed_book_type=(value); end
+
+  class BookType < T::Enum
+    enums do
+      Unclassified = new(%q{unclassified})
+      Biology = new(%q{biology})
+      DarkArt = new(%q{dark_art})
+    end
+
+  end
 end
 
 class SpellBook::ActiveRecord_Relation < ActiveRecord::Relation

--- a/spec/test_data/v5.1/expected_wand.rbi
+++ b/spec/test_data/v5.1/expected_wand.rbi
@@ -152,16 +152,6 @@ module Wand::GeneratedAttributeMethods
   def wood_type?; end
 end
 
-class Wand::CoreType < T::Enum
-  enums do
-    PhoenixFeather = new(%q{phoenix_feather})
-    DragonHeartstring = new(%q{dragon_heartstring})
-    UnicornTailHair = new(%q{unicorn_tail_hair})
-    BasiliskHorn = new(%q{basilisk_horn})
-  end
-
-end
-
 module Wand::GeneratedAssociationMethods
   sig { returns(::Wizard) }
   def wizard; end
@@ -224,6 +214,16 @@ class Wand < ApplicationRecord
 
   sig { params(value: T.nilable(Wand::CoreType)).void }
   def typed_core_type=(value); end
+
+  class CoreType < T::Enum
+    enums do
+      PhoenixFeather = new(%q{phoenix_feather})
+      DragonHeartstring = new(%q{dragon_heartstring})
+      UnicornTailHair = new(%q{unicorn_tail_hair})
+      BasiliskHorn = new(%q{basilisk_horn})
+    end
+
+  end
 
   sig { returns(T::Array[Wand]) }
   def self.mythicals; end

--- a/spec/test_data/v5.1/expected_wizard.rbi
+++ b/spec/test_data/v5.1/expected_wizard.rbi
@@ -230,64 +230,6 @@ module Wizard::GeneratedAttributeMethods
   def updated_at?; end
 end
 
-class Wizard::Broom < T::Enum
-  enums do
-    Nimbus = new(%q{nimbus})
-    Firebolt = new(%q{firebolt})
-  end
-
-end
-
-class Wizard::EyeColor < T::Enum
-  enums do
-    Brown = new(%q{brown})
-    Green = new(%q{green})
-    Blue = new(%q{blue})
-  end
-
-end
-
-class Wizard::HairColor < T::Enum
-  enums do
-    Brown = new(%q{brown})
-    Black = new(%q{black})
-    Blonde = new(%q{blonde})
-  end
-
-end
-
-class Wizard::House < T::Enum
-  enums do
-    Gryffindor = new(%q{Gryffindor})
-    Hufflepuff = new(%q{Hufflepuff})
-    Ravenclaw = new(%q{Ravenclaw})
-    Slytherin = new(%q{Slytherin})
-  end
-
-end
-
-class Wizard::ProfessorEnum < T::Enum
-  enums do
-    SeverusSnape = new(%q{Severus Snape})
-    MinervaMcGonagall = new(%q{Minerva McGonagall})
-    PomonaSprout = new(%q{Pomona Sprout})
-    FiliusFlitwick = new(%q{Filius Flitwick})
-    Hagrid = new(%q{Hagrid})
-    AlastorMadEyeMoody = new(%q{Alastor 'Mad-Eye' Moody})
-  end
-
-end
-
-class Wizard::QuidditchPosition < T::Enum
-  enums do
-    Keeper = new(%q{keeper})
-    Seeker = new(%q{seeker})
-    Beater = new(%q{beater})
-    Chaser = new(%q{chaser})
-  end
-
-end
-
 module Wizard::GeneratedAssociationMethods
   sig { returns(T.nilable(::School)) }
   def school; end
@@ -470,6 +412,64 @@ class Wizard < ApplicationRecord
 
   sig { params(value: T.nilable(Wizard::QuidditchPosition)).void }
   def typed_quidditch_position=(value); end
+
+  class Broom < T::Enum
+    enums do
+      Nimbus = new(%q{nimbus})
+      Firebolt = new(%q{firebolt})
+    end
+
+  end
+
+  class EyeColor < T::Enum
+    enums do
+      Brown = new(%q{brown})
+      Green = new(%q{green})
+      Blue = new(%q{blue})
+    end
+
+  end
+
+  class HairColor < T::Enum
+    enums do
+      Brown = new(%q{brown})
+      Black = new(%q{black})
+      Blonde = new(%q{blonde})
+    end
+
+  end
+
+  class House < T::Enum
+    enums do
+      Gryffindor = new(%q{Gryffindor})
+      Hufflepuff = new(%q{Hufflepuff})
+      Ravenclaw = new(%q{Ravenclaw})
+      Slytherin = new(%q{Slytherin})
+    end
+
+  end
+
+  class ProfessorEnum < T::Enum
+    enums do
+      SeverusSnape = new(%q{Severus Snape})
+      MinervaMcGonagall = new(%q{Minerva McGonagall})
+      PomonaSprout = new(%q{Pomona Sprout})
+      FiliusFlitwick = new(%q{Filius Flitwick})
+      Hagrid = new(%q{Hagrid})
+      AlastorMadEyeMoody = new(%q{Alastor 'Mad-Eye' Moody})
+    end
+
+  end
+
+  class QuidditchPosition < T::Enum
+    enums do
+      Keeper = new(%q{keeper})
+      Seeker = new(%q{seeker})
+      Beater = new(%q{beater})
+      Chaser = new(%q{chaser})
+    end
+
+  end
 end
 
 class Wizard::ActiveRecord_Relation < ActiveRecord::Relation

--- a/spec/test_data/v5.1/expected_wizard_wo_spellbook.rbi
+++ b/spec/test_data/v5.1/expected_wizard_wo_spellbook.rbi
@@ -230,64 +230,6 @@ module Wizard::GeneratedAttributeMethods
   def updated_at?; end
 end
 
-class Wizard::Broom < T::Enum
-  enums do
-    Nimbus = new(%q{nimbus})
-    Firebolt = new(%q{firebolt})
-  end
-
-end
-
-class Wizard::EyeColor < T::Enum
-  enums do
-    Brown = new(%q{brown})
-    Green = new(%q{green})
-    Blue = new(%q{blue})
-  end
-
-end
-
-class Wizard::HairColor < T::Enum
-  enums do
-    Brown = new(%q{brown})
-    Black = new(%q{black})
-    Blonde = new(%q{blonde})
-  end
-
-end
-
-class Wizard::House < T::Enum
-  enums do
-    Gryffindor = new(%q{Gryffindor})
-    Hufflepuff = new(%q{Hufflepuff})
-    Ravenclaw = new(%q{Ravenclaw})
-    Slytherin = new(%q{Slytherin})
-  end
-
-end
-
-class Wizard::ProfessorEnum < T::Enum
-  enums do
-    SeverusSnape = new(%q{Severus Snape})
-    MinervaMcGonagall = new(%q{Minerva McGonagall})
-    PomonaSprout = new(%q{Pomona Sprout})
-    FiliusFlitwick = new(%q{Filius Flitwick})
-    Hagrid = new(%q{Hagrid})
-    AlastorMadEyeMoody = new(%q{Alastor 'Mad-Eye' Moody})
-  end
-
-end
-
-class Wizard::QuidditchPosition < T::Enum
-  enums do
-    Keeper = new(%q{keeper})
-    Seeker = new(%q{seeker})
-    Beater = new(%q{beater})
-    Chaser = new(%q{chaser})
-  end
-
-end
-
 module Wizard::GeneratedAssociationMethods
   sig { returns(T.nilable(T.untyped)) }
   def school; end
@@ -464,6 +406,64 @@ class Wizard < ApplicationRecord
 
   sig { params(value: T.nilable(Wizard::QuidditchPosition)).void }
   def typed_quidditch_position=(value); end
+
+  class Broom < T::Enum
+    enums do
+      Nimbus = new(%q{nimbus})
+      Firebolt = new(%q{firebolt})
+    end
+
+  end
+
+  class EyeColor < T::Enum
+    enums do
+      Brown = new(%q{brown})
+      Green = new(%q{green})
+      Blue = new(%q{blue})
+    end
+
+  end
+
+  class HairColor < T::Enum
+    enums do
+      Brown = new(%q{brown})
+      Black = new(%q{black})
+      Blonde = new(%q{blonde})
+    end
+
+  end
+
+  class House < T::Enum
+    enums do
+      Gryffindor = new(%q{Gryffindor})
+      Hufflepuff = new(%q{Hufflepuff})
+      Ravenclaw = new(%q{Ravenclaw})
+      Slytherin = new(%q{Slytherin})
+    end
+
+  end
+
+  class ProfessorEnum < T::Enum
+    enums do
+      SeverusSnape = new(%q{Severus Snape})
+      MinervaMcGonagall = new(%q{Minerva McGonagall})
+      PomonaSprout = new(%q{Pomona Sprout})
+      FiliusFlitwick = new(%q{Filius Flitwick})
+      Hagrid = new(%q{Hagrid})
+      AlastorMadEyeMoody = new(%q{Alastor 'Mad-Eye' Moody})
+    end
+
+  end
+
+  class QuidditchPosition < T::Enum
+    enums do
+      Keeper = new(%q{keeper})
+      Seeker = new(%q{seeker})
+      Beater = new(%q{beater})
+      Chaser = new(%q{chaser})
+    end
+
+  end
 end
 
 class Wizard::ActiveRecord_Relation < ActiveRecord::Relation

--- a/spec/test_data/v5.2/expected_spell_book.rbi
+++ b/spec/test_data/v5.2/expected_spell_book.rbi
@@ -65,15 +65,6 @@ module SpellBook::GeneratedAttributeMethods
   def wizard_id?; end
 end
 
-class SpellBook::BookType < T::Enum
-  enums do
-    Unclassified = new(%q{unclassified})
-    Biology = new(%q{biology})
-    DarkArt = new(%q{dark_art})
-  end
-
-end
-
 module SpellBook::GeneratedAssociationMethods
   sig { returns(::Spell::ActiveRecord_Associations_CollectionProxy) }
   def spells; end
@@ -145,6 +136,15 @@ class SpellBook < ApplicationRecord
 
   sig { params(value: SpellBook::BookType).void }
   def typed_book_type=(value); end
+
+  class BookType < T::Enum
+    enums do
+      Unclassified = new(%q{unclassified})
+      Biology = new(%q{biology})
+      DarkArt = new(%q{dark_art})
+    end
+
+  end
 end
 
 class SpellBook::ActiveRecord_Relation < ActiveRecord::Relation

--- a/spec/test_data/v5.2/expected_wand.rbi
+++ b/spec/test_data/v5.2/expected_wand.rbi
@@ -170,16 +170,6 @@ module Wand::GeneratedAttributeMethods
   def wood_type?; end
 end
 
-class Wand::CoreType < T::Enum
-  enums do
-    PhoenixFeather = new(%q{phoenix_feather})
-    DragonHeartstring = new(%q{dragon_heartstring})
-    UnicornTailHair = new(%q{unicorn_tail_hair})
-    BasiliskHorn = new(%q{basilisk_horn})
-  end
-
-end
-
 module Wand::GeneratedAssociationMethods
   sig { returns(::Wizard) }
   def wizard; end
@@ -242,6 +232,16 @@ class Wand < ApplicationRecord
 
   sig { params(value: T.nilable(Wand::CoreType)).void }
   def typed_core_type=(value); end
+
+  class CoreType < T::Enum
+    enums do
+      PhoenixFeather = new(%q{phoenix_feather})
+      DragonHeartstring = new(%q{dragon_heartstring})
+      UnicornTailHair = new(%q{unicorn_tail_hair})
+      BasiliskHorn = new(%q{basilisk_horn})
+    end
+
+  end
 
   sig { returns(T::Array[Wand]) }
   def self.mythicals; end

--- a/spec/test_data/v5.2/expected_wizard.rbi
+++ b/spec/test_data/v5.2/expected_wizard.rbi
@@ -230,64 +230,6 @@ module Wizard::GeneratedAttributeMethods
   def updated_at?; end
 end
 
-class Wizard::Broom < T::Enum
-  enums do
-    Nimbus = new(%q{nimbus})
-    Firebolt = new(%q{firebolt})
-  end
-
-end
-
-class Wizard::EyeColor < T::Enum
-  enums do
-    Brown = new(%q{brown})
-    Green = new(%q{green})
-    Blue = new(%q{blue})
-  end
-
-end
-
-class Wizard::HairColor < T::Enum
-  enums do
-    Brown = new(%q{brown})
-    Black = new(%q{black})
-    Blonde = new(%q{blonde})
-  end
-
-end
-
-class Wizard::House < T::Enum
-  enums do
-    Gryffindor = new(%q{Gryffindor})
-    Hufflepuff = new(%q{Hufflepuff})
-    Ravenclaw = new(%q{Ravenclaw})
-    Slytherin = new(%q{Slytherin})
-  end
-
-end
-
-class Wizard::ProfessorEnum < T::Enum
-  enums do
-    SeverusSnape = new(%q{Severus Snape})
-    MinervaMcGonagall = new(%q{Minerva McGonagall})
-    PomonaSprout = new(%q{Pomona Sprout})
-    FiliusFlitwick = new(%q{Filius Flitwick})
-    Hagrid = new(%q{Hagrid})
-    AlastorMadEyeMoody = new(%q{Alastor 'Mad-Eye' Moody})
-  end
-
-end
-
-class Wizard::QuidditchPosition < T::Enum
-  enums do
-    Keeper = new(%q{keeper})
-    Seeker = new(%q{seeker})
-    Beater = new(%q{beater})
-    Chaser = new(%q{chaser})
-  end
-
-end
-
 module Wizard::GeneratedAssociationMethods
   sig { returns(::ActiveStorage::Attachment::ActiveRecord_Associations_CollectionProxy) }
   def hats_attachments; end
@@ -524,6 +466,64 @@ class Wizard < ApplicationRecord
 
   sig { params(value: T.nilable(Wizard::QuidditchPosition)).void }
   def typed_quidditch_position=(value); end
+
+  class Broom < T::Enum
+    enums do
+      Nimbus = new(%q{nimbus})
+      Firebolt = new(%q{firebolt})
+    end
+
+  end
+
+  class EyeColor < T::Enum
+    enums do
+      Brown = new(%q{brown})
+      Green = new(%q{green})
+      Blue = new(%q{blue})
+    end
+
+  end
+
+  class HairColor < T::Enum
+    enums do
+      Brown = new(%q{brown})
+      Black = new(%q{black})
+      Blonde = new(%q{blonde})
+    end
+
+  end
+
+  class House < T::Enum
+    enums do
+      Gryffindor = new(%q{Gryffindor})
+      Hufflepuff = new(%q{Hufflepuff})
+      Ravenclaw = new(%q{Ravenclaw})
+      Slytherin = new(%q{Slytherin})
+    end
+
+  end
+
+  class ProfessorEnum < T::Enum
+    enums do
+      SeverusSnape = new(%q{Severus Snape})
+      MinervaMcGonagall = new(%q{Minerva McGonagall})
+      PomonaSprout = new(%q{Pomona Sprout})
+      FiliusFlitwick = new(%q{Filius Flitwick})
+      Hagrid = new(%q{Hagrid})
+      AlastorMadEyeMoody = new(%q{Alastor 'Mad-Eye' Moody})
+    end
+
+  end
+
+  class QuidditchPosition < T::Enum
+    enums do
+      Keeper = new(%q{keeper})
+      Seeker = new(%q{seeker})
+      Beater = new(%q{beater})
+      Chaser = new(%q{chaser})
+    end
+
+  end
 end
 
 class Wizard::ActiveRecord_Relation < ActiveRecord::Relation

--- a/spec/test_data/v5.2/expected_wizard_wo_spellbook.rbi
+++ b/spec/test_data/v5.2/expected_wizard_wo_spellbook.rbi
@@ -230,64 +230,6 @@ module Wizard::GeneratedAttributeMethods
   def updated_at?; end
 end
 
-class Wizard::Broom < T::Enum
-  enums do
-    Nimbus = new(%q{nimbus})
-    Firebolt = new(%q{firebolt})
-  end
-
-end
-
-class Wizard::EyeColor < T::Enum
-  enums do
-    Brown = new(%q{brown})
-    Green = new(%q{green})
-    Blue = new(%q{blue})
-  end
-
-end
-
-class Wizard::HairColor < T::Enum
-  enums do
-    Brown = new(%q{brown})
-    Black = new(%q{black})
-    Blonde = new(%q{blonde})
-  end
-
-end
-
-class Wizard::House < T::Enum
-  enums do
-    Gryffindor = new(%q{Gryffindor})
-    Hufflepuff = new(%q{Hufflepuff})
-    Ravenclaw = new(%q{Ravenclaw})
-    Slytherin = new(%q{Slytherin})
-  end
-
-end
-
-class Wizard::ProfessorEnum < T::Enum
-  enums do
-    SeverusSnape = new(%q{Severus Snape})
-    MinervaMcGonagall = new(%q{Minerva McGonagall})
-    PomonaSprout = new(%q{Pomona Sprout})
-    FiliusFlitwick = new(%q{Filius Flitwick})
-    Hagrid = new(%q{Hagrid})
-    AlastorMadEyeMoody = new(%q{Alastor 'Mad-Eye' Moody})
-  end
-
-end
-
-class Wizard::QuidditchPosition < T::Enum
-  enums do
-    Keeper = new(%q{keeper})
-    Seeker = new(%q{seeker})
-    Beater = new(%q{beater})
-    Chaser = new(%q{chaser})
-  end
-
-end
-
 module Wizard::GeneratedAssociationMethods
   sig { returns(::ActiveStorage::Attachment::ActiveRecord_Associations_CollectionProxy) }
   def hats_attachments; end
@@ -518,6 +460,64 @@ class Wizard < ApplicationRecord
 
   sig { params(value: T.nilable(Wizard::QuidditchPosition)).void }
   def typed_quidditch_position=(value); end
+
+  class Broom < T::Enum
+    enums do
+      Nimbus = new(%q{nimbus})
+      Firebolt = new(%q{firebolt})
+    end
+
+  end
+
+  class EyeColor < T::Enum
+    enums do
+      Brown = new(%q{brown})
+      Green = new(%q{green})
+      Blue = new(%q{blue})
+    end
+
+  end
+
+  class HairColor < T::Enum
+    enums do
+      Brown = new(%q{brown})
+      Black = new(%q{black})
+      Blonde = new(%q{blonde})
+    end
+
+  end
+
+  class House < T::Enum
+    enums do
+      Gryffindor = new(%q{Gryffindor})
+      Hufflepuff = new(%q{Hufflepuff})
+      Ravenclaw = new(%q{Ravenclaw})
+      Slytherin = new(%q{Slytherin})
+    end
+
+  end
+
+  class ProfessorEnum < T::Enum
+    enums do
+      SeverusSnape = new(%q{Severus Snape})
+      MinervaMcGonagall = new(%q{Minerva McGonagall})
+      PomonaSprout = new(%q{Pomona Sprout})
+      FiliusFlitwick = new(%q{Filius Flitwick})
+      Hagrid = new(%q{Hagrid})
+      AlastorMadEyeMoody = new(%q{Alastor 'Mad-Eye' Moody})
+    end
+
+  end
+
+  class QuidditchPosition < T::Enum
+    enums do
+      Keeper = new(%q{keeper})
+      Seeker = new(%q{seeker})
+      Beater = new(%q{beater})
+      Chaser = new(%q{chaser})
+    end
+
+  end
 end
 
 class Wizard::ActiveRecord_Relation < ActiveRecord::Relation

--- a/spec/test_data/v6.0/expected_spell_book.rbi
+++ b/spec/test_data/v6.0/expected_spell_book.rbi
@@ -65,15 +65,6 @@ module SpellBook::GeneratedAttributeMethods
   def wizard_id?; end
 end
 
-class SpellBook::BookType < T::Enum
-  enums do
-    Unclassified = new(%q{unclassified})
-    Biology = new(%q{biology})
-    DarkArt = new(%q{dark_art})
-  end
-
-end
-
 module SpellBook::GeneratedAssociationMethods
   sig { returns(::Spell::ActiveRecord_Associations_CollectionProxy) }
   def spells; end
@@ -154,6 +145,15 @@ class SpellBook < ApplicationRecord
 
   sig { params(value: SpellBook::BookType).void }
   def typed_book_type=(value); end
+
+  class BookType < T::Enum
+    enums do
+      Unclassified = new(%q{unclassified})
+      Biology = new(%q{biology})
+      DarkArt = new(%q{dark_art})
+    end
+
+  end
 end
 
 class SpellBook::ActiveRecord_Relation < ActiveRecord::Relation

--- a/spec/test_data/v6.0/expected_wand.rbi
+++ b/spec/test_data/v6.0/expected_wand.rbi
@@ -170,16 +170,6 @@ module Wand::GeneratedAttributeMethods
   def wood_type?; end
 end
 
-class Wand::CoreType < T::Enum
-  enums do
-    PhoenixFeather = new(%q{phoenix_feather})
-    DragonHeartstring = new(%q{dragon_heartstring})
-    UnicornTailHair = new(%q{unicorn_tail_hair})
-    BasiliskHorn = new(%q{basilisk_horn})
-  end
-
-end
-
 module Wand::GeneratedAssociationMethods
   sig { returns(::Wizard) }
   def wizard; end
@@ -254,6 +244,16 @@ class Wand < ApplicationRecord
 
   sig { params(value: T.nilable(Wand::CoreType)).void }
   def typed_core_type=(value); end
+
+  class CoreType < T::Enum
+    enums do
+      PhoenixFeather = new(%q{phoenix_feather})
+      DragonHeartstring = new(%q{dragon_heartstring})
+      UnicornTailHair = new(%q{unicorn_tail_hair})
+      BasiliskHorn = new(%q{basilisk_horn})
+    end
+
+  end
 
   sig { returns(T::Array[Wand]) }
   def self.mythicals; end

--- a/spec/test_data/v6.0/expected_wizard.rbi
+++ b/spec/test_data/v6.0/expected_wizard.rbi
@@ -230,64 +230,6 @@ module Wizard::GeneratedAttributeMethods
   def updated_at?; end
 end
 
-class Wizard::Broom < T::Enum
-  enums do
-    Nimbus = new(%q{nimbus})
-    Firebolt = new(%q{firebolt})
-  end
-
-end
-
-class Wizard::EyeColor < T::Enum
-  enums do
-    Brown = new(%q{brown})
-    Green = new(%q{green})
-    Blue = new(%q{blue})
-  end
-
-end
-
-class Wizard::HairColor < T::Enum
-  enums do
-    Brown = new(%q{brown})
-    Black = new(%q{black})
-    Blonde = new(%q{blonde})
-  end
-
-end
-
-class Wizard::House < T::Enum
-  enums do
-    Gryffindor = new(%q{Gryffindor})
-    Hufflepuff = new(%q{Hufflepuff})
-    Ravenclaw = new(%q{Ravenclaw})
-    Slytherin = new(%q{Slytherin})
-  end
-
-end
-
-class Wizard::ProfessorEnum < T::Enum
-  enums do
-    SeverusSnape = new(%q{Severus Snape})
-    MinervaMcGonagall = new(%q{Minerva McGonagall})
-    PomonaSprout = new(%q{Pomona Sprout})
-    FiliusFlitwick = new(%q{Filius Flitwick})
-    Hagrid = new(%q{Hagrid})
-    AlastorMadEyeMoody = new(%q{Alastor 'Mad-Eye' Moody})
-  end
-
-end
-
-class Wizard::QuidditchPosition < T::Enum
-  enums do
-    Keeper = new(%q{keeper})
-    Seeker = new(%q{seeker})
-    Beater = new(%q{beater})
-    Chaser = new(%q{chaser})
-  end
-
-end
-
 module Wizard::CustomFinderMethods
   sig { params(limit: Integer).returns(T::Array[Wizard]) }
   def first_n(limit); end
@@ -477,6 +419,64 @@ class Wizard < ApplicationRecord
 
   sig { params(value: T.nilable(Wizard::QuidditchPosition)).void }
   def typed_quidditch_position=(value); end
+
+  class Broom < T::Enum
+    enums do
+      Nimbus = new(%q{nimbus})
+      Firebolt = new(%q{firebolt})
+    end
+
+  end
+
+  class EyeColor < T::Enum
+    enums do
+      Brown = new(%q{brown})
+      Green = new(%q{green})
+      Blue = new(%q{blue})
+    end
+
+  end
+
+  class HairColor < T::Enum
+    enums do
+      Brown = new(%q{brown})
+      Black = new(%q{black})
+      Blonde = new(%q{blonde})
+    end
+
+  end
+
+  class House < T::Enum
+    enums do
+      Gryffindor = new(%q{Gryffindor})
+      Hufflepuff = new(%q{Hufflepuff})
+      Ravenclaw = new(%q{Ravenclaw})
+      Slytherin = new(%q{Slytherin})
+    end
+
+  end
+
+  class ProfessorEnum < T::Enum
+    enums do
+      SeverusSnape = new(%q{Severus Snape})
+      MinervaMcGonagall = new(%q{Minerva McGonagall})
+      PomonaSprout = new(%q{Pomona Sprout})
+      FiliusFlitwick = new(%q{Filius Flitwick})
+      Hagrid = new(%q{Hagrid})
+      AlastorMadEyeMoody = new(%q{Alastor 'Mad-Eye' Moody})
+    end
+
+  end
+
+  class QuidditchPosition < T::Enum
+    enums do
+      Keeper = new(%q{keeper})
+      Seeker = new(%q{seeker})
+      Beater = new(%q{beater})
+      Chaser = new(%q{chaser})
+    end
+
+  end
 end
 
 class Wizard::ActiveRecord_Relation < ActiveRecord::Relation

--- a/spec/test_data/v6.0/expected_wizard_wo_spellbook.rbi
+++ b/spec/test_data/v6.0/expected_wizard_wo_spellbook.rbi
@@ -230,64 +230,6 @@ module Wizard::GeneratedAttributeMethods
   def updated_at?; end
 end
 
-class Wizard::Broom < T::Enum
-  enums do
-    Nimbus = new(%q{nimbus})
-    Firebolt = new(%q{firebolt})
-  end
-
-end
-
-class Wizard::EyeColor < T::Enum
-  enums do
-    Brown = new(%q{brown})
-    Green = new(%q{green})
-    Blue = new(%q{blue})
-  end
-
-end
-
-class Wizard::HairColor < T::Enum
-  enums do
-    Brown = new(%q{brown})
-    Black = new(%q{black})
-    Blonde = new(%q{blonde})
-  end
-
-end
-
-class Wizard::House < T::Enum
-  enums do
-    Gryffindor = new(%q{Gryffindor})
-    Hufflepuff = new(%q{Hufflepuff})
-    Ravenclaw = new(%q{Ravenclaw})
-    Slytherin = new(%q{Slytherin})
-  end
-
-end
-
-class Wizard::ProfessorEnum < T::Enum
-  enums do
-    SeverusSnape = new(%q{Severus Snape})
-    MinervaMcGonagall = new(%q{Minerva McGonagall})
-    PomonaSprout = new(%q{Pomona Sprout})
-    FiliusFlitwick = new(%q{Filius Flitwick})
-    Hagrid = new(%q{Hagrid})
-    AlastorMadEyeMoody = new(%q{Alastor 'Mad-Eye' Moody})
-  end
-
-end
-
-class Wizard::QuidditchPosition < T::Enum
-  enums do
-    Keeper = new(%q{keeper})
-    Seeker = new(%q{seeker})
-    Beater = new(%q{beater})
-    Chaser = new(%q{chaser})
-  end
-
-end
-
 module Wizard::CustomFinderMethods
   sig { params(limit: Integer).returns(T::Array[Wizard]) }
   def first_n(limit); end
@@ -477,6 +419,64 @@ class Wizard < ApplicationRecord
 
   sig { params(value: T.nilable(Wizard::QuidditchPosition)).void }
   def typed_quidditch_position=(value); end
+
+  class Broom < T::Enum
+    enums do
+      Nimbus = new(%q{nimbus})
+      Firebolt = new(%q{firebolt})
+    end
+
+  end
+
+  class EyeColor < T::Enum
+    enums do
+      Brown = new(%q{brown})
+      Green = new(%q{green})
+      Blue = new(%q{blue})
+    end
+
+  end
+
+  class HairColor < T::Enum
+    enums do
+      Brown = new(%q{brown})
+      Black = new(%q{black})
+      Blonde = new(%q{blonde})
+    end
+
+  end
+
+  class House < T::Enum
+    enums do
+      Gryffindor = new(%q{Gryffindor})
+      Hufflepuff = new(%q{Hufflepuff})
+      Ravenclaw = new(%q{Ravenclaw})
+      Slytherin = new(%q{Slytherin})
+    end
+
+  end
+
+  class ProfessorEnum < T::Enum
+    enums do
+      SeverusSnape = new(%q{Severus Snape})
+      MinervaMcGonagall = new(%q{Minerva McGonagall})
+      PomonaSprout = new(%q{Pomona Sprout})
+      FiliusFlitwick = new(%q{Filius Flitwick})
+      Hagrid = new(%q{Hagrid})
+      AlastorMadEyeMoody = new(%q{Alastor 'Mad-Eye' Moody})
+    end
+
+  end
+
+  class QuidditchPosition < T::Enum
+    enums do
+      Keeper = new(%q{keeper})
+      Seeker = new(%q{seeker})
+      Beater = new(%q{beater})
+      Chaser = new(%q{chaser})
+    end
+
+  end
 end
 
 class Wizard::ActiveRecord_Relation < ActiveRecord::Relation


### PR DESCRIPTION
In one of our apps, we have this ... unfortunate ... enum setup.

```ruby
class RosterTemplate < ApplicationRecord
  enum template_type: {
    "RosterTemplate": 0,
	# bunch of other options
  }
end
```

sorbet-rails generates this rbi:

```ruby
class RosterTemplate::TemplateType < T::Enum
  enums do
    RosterTemplate = new(%q{RosterTemplate})
	# other options
  end

end
```

sorbet doesn't like that:

```
sorbet/rails-rbi/models/roster_template.rbi:140: Unable to resolve constant TemplateType https://srb.help/5002
     140 |class RosterTemplate::TemplateType < T::Enum
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

The error message isn't very clear, but we are 99% sure it's because `RosterTemplate` is both the model class, _and_ one of the enum value types.

We've found that tweaking the sorbet-rails generated rbi to this fixes the issue:

```ruby
class RosterTemplate
  class TemplateType < T::Enum
    enums do
      RosterTemplate = new(%q{RosterTemplate})
	  # other options
    end
  end
end
```

This PR upstreams that logic. As far as I can tell it's functionally the same, and this is verified by the [`sorbet_test_cases`](https://github.com/chanzuckerberg/sorbet-rails/blob/master/spec/generators/sorbet_test_cases.rb#L298..L306) rbi test.

Thanks to @DanielGilchrist for helping me figure out the root cause.