### PR TITLE
fix: primary key is not always "id"

### DIFF
--- a/lib/sorbet-rails/model_plugins/active_record_assoc.rb
+++ b/lib/sorbet-rails/model_plugins/active_record_assoc.rb
@@ -137,7 +137,7 @@ class SorbetRails::ModelPlugins::ActiveRecordAssoc < SorbetRails::ModelPlugins::
       if reflection.klass.table_exists?
         # Normally the id_type is an Integer, but it could be a String if using
         # UUIDs.
-        id_type = type_for_column_def(reflection.klass.columns_hash["id"]).to_s
+        id_type = type_for_column_def(reflection.klass.columns_hash[reflection.klass.primary_key]).to_s
       else
         id_type = "T.untyped"
       end


### PR DESCRIPTION
Given the primary key for a table is not always "id", use reflection.class.primary_key instead.

I noticed this due to having two tables in my application with non-standard primary keys (Sadly they are very hard to change).

NOTE: I have not added a test for this since I'm not sure what would be most appropriate. I started changing "spell_books" to have a primary key of "spell_id" (in only rails v5.2 - and guessing you would want all versions changed). However, I figured it was better to ask for the preferences of the maintainers before continuing with more work.
