### PR TITLE
Add support for `serialized` attributes

### DIFF
--- a/lib/sorbet-rails/config.rb
+++ b/lib/sorbet-rails/config.rb
@@ -54,6 +54,7 @@ module SorbetRails
         :active_record_named_scope,
         :active_record_querying,
         :active_relation_where_not,
+        :active_record_serialization,
         :active_record_attribute,
         :active_record_assoc,
         :custom_finder_methods,

--- a/lib/sorbet-rails/config.rb
+++ b/lib/sorbet-rails/config.rb
@@ -54,7 +54,7 @@ module SorbetRails
         :active_record_named_scope,
         :active_record_querying,
         :active_relation_where_not,
-        :active_record_serialization,
+        :active_record_serialized_attribute,
         :active_record_attribute,
         :active_record_assoc,
         :custom_finder_methods,

--- a/lib/sorbet-rails/dependent_gem_rbis/activerecord.rbi
+++ b/lib/sorbet-rails/dependent_gem_rbis/activerecord.rbi
@@ -12,6 +12,9 @@ class ActiveRecord::Base < Object
   sig { returns(T::Hash[String, T.untyped]) }
   def self.columns_hash; end
 
+  sig { params(column_name: String).returns(T.nilable(T.any(ActiveModel::Type::Value, ActiveRecord::Type::Serialized))) }
+  def self.type_for_attribute(column_name); end
+
   sig { returns(T::Hash[String, T.untyped]) }
   def self.reflections; end
 

--- a/lib/sorbet-rails/model_plugins/active_record_attribute.rb
+++ b/lib/sorbet-rails/model_plugins/active_record_attribute.rb
@@ -25,7 +25,7 @@ class SorbetRails::ModelPlugins::ActiveRecordAttribute < SorbetRails::ModelPlugi
           column_def,
         )
       elsif serialization_coder_for_column(column_name)
-        next # handled by the ActiveRecordSerialization plugin
+        next # handled by the ActiveRecordSerializedAttribute plugin
       else
         column_type = type_for_column_def(column_def)
         attribute_module_rbi.create_method(

--- a/lib/sorbet-rails/model_plugins/active_record_attribute.rb
+++ b/lib/sorbet-rails/model_plugins/active_record_attribute.rb
@@ -24,6 +24,8 @@ class SorbetRails::ModelPlugins::ActiveRecordAttribute < SorbetRails::ModelPlugi
           column_name,
           column_def,
         )
+      elsif serialization_coder_for_column(column_name)
+        next # handled by the ActiveRecordSerialization plugin
       else
         column_type = type_for_column_def(column_def)
         attribute_module_rbi.create_method(

--- a/lib/sorbet-rails/model_plugins/active_record_serialization.rb
+++ b/lib/sorbet-rails/model_plugins/active_record_serialization.rb
@@ -1,0 +1,68 @@
+# typed: strict
+require ('sorbet-rails/model_plugins/base')
+class SorbetRails::ModelPlugins::ActiveRecordSerialization < SorbetRails::ModelPlugins::Base
+
+  sig { override.params(root: Parlour::RbiGenerator::Namespace).void }
+  def generate(root)
+    columns_hash = @model_class.table_exists? ? @model_class.columns_hash : {}
+    return unless any_serialized_columns?(columns_hash)
+
+    serialize_module_name = self.model_module_name('GeneratedSerializationMethods')
+    serialize_module_rbi = root.create_module(serialize_module_name)
+
+    model_class_rbi = root.create_class(self.model_class_name)
+    model_class_rbi.create_include(serialize_module_name)
+
+    columns_hash.sort.each do |column_name, column_def|
+      serialization_coder = serialization_coder_for_column(column_name)
+      next unless serialization_coder
+
+      nilable = nilable_column?(column_def)
+      attr_type = attr_types_for_coder(serialization_coder)
+
+      serialize_module_rbi.create_method(
+        column_name.to_s,
+        return_type: ColumnType.new(base_type: attr_type, nilable: nilable).to_s,
+      )
+
+      serialize_module_rbi.create_method(
+        "#{column_name}=",
+        parameters: [
+          Parameter.new('value', type: ColumnType.new(base_type: attr_type, nilable: nilable).to_s)
+        ],
+        return_type: nil,
+      )
+
+      serialize_module_rbi.create_method(
+        "#{column_name}?",
+        return_type: 'T::Boolean',
+      )
+    end
+  end
+
+  sig { params(columns_hash: T::Hash[String, ActiveRecord::ConnectionAdapters::Column]).returns(T::Boolean) }
+  def any_serialized_columns?(columns_hash)
+    columns_hash.keys.any? do |column_name|
+      !serialization_coder_for_column(column_name).nil?
+    end
+  end
+
+  sig { params(serialization_coder: T.nilable(Class)).returns(String) }
+  def attr_types_for_coder(serialization_coder)
+    case serialization_coder.to_s
+    when 'Hash'
+      # Hash uses YAML.load/YAML.dump, and permits pretty much any kind of Hash key
+      'T::Hash[T.untyped, T.untyped]'
+    when 'Array'
+      # YAML.load/YAML.dump
+      'T::Array[T.untyped]'
+    when 'JSON'
+      # ActiveSupport::JSON.encode/ActiveSupport::JSON.decode
+      # note that Hash keys are Strings since this is JSON
+      'T.any(T::Array[T.untyped], T::Boolean, Float, T::Hash[String, T.untyped], Integer, String)'
+    else
+      # unknown uses YAML.load/YAML.dump
+      'T.any(T::Array[T.untyped], T::Boolean, Float, T::Hash[T.untyped, T.untyped], Integer, String)'
+    end
+  end
+end

--- a/lib/sorbet-rails/model_plugins/active_record_serialized_attribute.rb
+++ b/lib/sorbet-rails/model_plugins/active_record_serialized_attribute.rb
@@ -1,13 +1,13 @@
 # typed: strict
 require ('sorbet-rails/model_plugins/base')
-class SorbetRails::ModelPlugins::ActiveRecordSerialization < SorbetRails::ModelPlugins::Base
+class SorbetRails::ModelPlugins::ActiveRecordSerializedAttribute < SorbetRails::ModelPlugins::Base
 
   sig { override.params(root: Parlour::RbiGenerator::Namespace).void }
   def generate(root)
     columns_hash = @model_class.table_exists? ? @model_class.columns_hash : {}
     return unless any_serialized_columns?(columns_hash)
 
-    serialize_module_name = self.model_module_name('GeneratedSerializationMethods')
+    serialize_module_name = self.model_module_name('GeneratedSerializedAttributeMethods')
     serialize_module_rbi = root.create_module(serialize_module_name)
 
     model_class_rbi = root.create_class(self.model_class_name)

--- a/lib/sorbet-rails/model_plugins/base.rb
+++ b/lib/sorbet-rails/model_plugins/base.rb
@@ -29,5 +29,13 @@ module SorbetRails::ModelPlugins
       @model_class = T.let(model_class, T.class_of(ActiveRecord::Base))
       @available_classes = T.let(available_classes, T::Set[String])
     end
+
+    sig { params(column_name: String).returns(T.nilable(Class)) }
+    def serialization_coder_for_column(column_name)
+      column_type = @model_class.type_for_attribute(column_name)
+      return unless column_type.is_a?(ActiveRecord::Type::Serialized)
+
+      column_type.coder.try(:object_class) || Object
+    end
   end
 end

--- a/lib/sorbet-rails/model_plugins/plugins.rb
+++ b/lib/sorbet-rails/model_plugins/plugins.rb
@@ -6,7 +6,7 @@ require('sorbet-rails/model_plugins/active_relation_where_not')
 require('sorbet-rails/model_plugins/active_record_named_scope')
 require('sorbet-rails/model_plugins/active_record_attribute')
 require('sorbet-rails/model_plugins/active_record_assoc')
-require('sorbet-rails/model_plugins/active_record_serialization')
+require('sorbet-rails/model_plugins/active_record_serialized_attribute')
 require('sorbet-rails/model_plugins/custom_finder_methods')
 require('sorbet-rails/model_plugins/enumerable_collections')
 require('sorbet-rails/model_plugins/active_storage_methods')
@@ -48,8 +48,8 @@ module SorbetRails::ModelPlugins
       ActiveRecordQuerying
     when :active_relation_where_not
       ActiveRelationWhereNot
-    when :active_record_serialization
-      ActiveRecordSerialization
+    when :active_record_serialized_attribute
+      ActiveRecordSerializedAttribute
     when :active_record_attribute
       ActiveRecordAttribute
     when :active_record_assoc

--- a/lib/sorbet-rails/model_plugins/plugins.rb
+++ b/lib/sorbet-rails/model_plugins/plugins.rb
@@ -6,6 +6,7 @@ require('sorbet-rails/model_plugins/active_relation_where_not')
 require('sorbet-rails/model_plugins/active_record_named_scope')
 require('sorbet-rails/model_plugins/active_record_attribute')
 require('sorbet-rails/model_plugins/active_record_assoc')
+require('sorbet-rails/model_plugins/active_record_serialization')
 require('sorbet-rails/model_plugins/custom_finder_methods')
 require('sorbet-rails/model_plugins/enumerable_collections')
 require('sorbet-rails/model_plugins/active_storage_methods')
@@ -47,6 +48,8 @@ module SorbetRails::ModelPlugins
       ActiveRecordQuerying
     when :active_relation_where_not
       ActiveRelationWhereNot
+    when :active_record_serialization
+      ActiveRecordSerialization
     when :active_record_attribute
       ActiveRecordAttribute
     when :active_record_assoc

--- a/spec/generators/rails-template.rb
+++ b/spec/generators/rails-template.rb
@@ -181,6 +181,7 @@ def create_models
       }, _prefix: :color, _suffix: :eyes
 
       serialize :owl_results, Hash
+      serialize :newt_subjects # no specific data type, uses the default YAML Object coder
       serialize :pets, Array
       serialize :patronus_characteristics, JSON
 
@@ -425,6 +426,7 @@ def create_migrations
     class AddSerializedToWizards < #{migration_superclass}
       def change
         add_column :wizards, :owl_results, :text # Hash
+        add_column :wizards, :newt_subjects, :text # generic
         add_column :wizards, :pets, :text # Array
         add_column :wizards, :patronus_characteristics, :text # serialized as JSON, but not a JSON column type
       end

--- a/spec/generators/rails-template.rb
+++ b/spec/generators/rails-template.rb
@@ -180,6 +180,10 @@ def create_models
         blue: 2,
       }, _prefix: :color, _suffix: :eyes
 
+      serialize :owl_results, Hash
+      serialize :pets, Array
+      serialize :patronus_characteristics, JSON
+
       has_one :wand
       has_many :spell_books
       # habtm which is optional at the db level
@@ -413,6 +417,16 @@ def create_migrations
           t.references :school
           t.references :wizard
         end
+      end
+    end
+  RUBY
+
+  file "db/migrate/20190620000015_add_serialized_to_wizards.rb", <<~RUBY
+    class AddSerializedToWizards < #{migration_superclass}
+      def change
+        add_column :wizards, :owl_results, :text # Hash
+        add_column :wizards, :pets, :text # Array
+        add_column :wizards, :patronus_characteristics, :text # serialized as JSON, but not a JSON column type
       end
     end
   RUBY

--- a/spec/generators/sorbet_test_cases.rb
+++ b/spec/generators/sorbet_test_cases.rb
@@ -305,6 +305,17 @@ T.assert_type!(Wizard::House::Hufflepuff, Wizard::House)
 T.assert_type!(Wizard::House::Ravenclaw, Wizard::House)
 T.assert_type!(Wizard::House::Slytherin, Wizard::House)
 
+# Serialization
+T.assert_type!(
+  wizard.owl_results,
+  T.any(T::Array[T.untyped], T::Boolean, Float, T::Hash[T.untyped, T.untyped], Integer, String)
+)
+T.assert_type!(
+  wizard.patronus_characteristics,
+  T.any(T::Array[T.untyped], T::Boolean, Float, T::Hash[String, T.untyped], Integer, String)
+)
+T.assert_type!(wizard.pets, T::Array[T.untyped])
+
 # Mythical plugin
 T.assert_type!(Wand.mythicals, T::Array[Wand])
 

--- a/spec/generators/sorbet_test_cases.rb
+++ b/spec/generators/sorbet_test_cases.rb
@@ -308,13 +308,17 @@ T.assert_type!(Wizard::House::Slytherin, Wizard::House)
 # Serialization
 T.assert_type!(
   wizard.owl_results,
-  T.any(T::Array[T.untyped], T::Boolean, Float, T::Hash[T.untyped, T.untyped], Integer, String)
+  T.nilable(T.any(T::Hash[T.untyped, T.untyped]))
+)
+T.assert_type!(
+  wizard.newt_subjects,
+  T.nilable(T.any(T::Array[T.untyped], T::Boolean, Float, T::Hash[T.untyped, T.untyped], Integer, String))
 )
 T.assert_type!(
   wizard.patronus_characteristics,
-  T.any(T::Array[T.untyped], T::Boolean, Float, T::Hash[String, T.untyped], Integer, String)
+  T.nilable(T.any(T::Array[T.untyped], T::Boolean, Float, T::Hash[String, T.untyped], Integer, String))
 )
-T.assert_type!(wizard.pets, T::Array[T.untyped])
+T.assert_type!(wizard.pets, T.nilable(T::Array[T.untyped]))
 
 # Mythical plugin
 T.assert_type!(Wand.mythicals, T::Array[Wand])

--- a/spec/generators/sorbet_test_cases.rb
+++ b/spec/generators/sorbet_test_cases.rb
@@ -308,7 +308,7 @@ T.assert_type!(Wizard::House::Slytherin, Wizard::House)
 # Serialization
 T.assert_type!(
   wizard.owl_results,
-  T.nilable(T.any(T::Hash[T.untyped, T.untyped]))
+  T.nilable(T::Hash[T.untyped, T.untyped])
 )
 T.assert_type!(
   wizard.newt_subjects,

--- a/spec/support/v5.0/app/models/wizard.rb
+++ b/spec/support/v5.0/app/models/wizard.rb
@@ -48,6 +48,7 @@ class Wizard < ApplicationRecord
   }, _prefix: :color, _suffix: :eyes
 
   serialize :owl_results, Hash
+  serialize :newt_subjects # no specific data type, uses the default YAML Object coder
   serialize :pets, Array
   serialize :patronus_characteristics, JSON
 

--- a/spec/support/v5.0/app/models/wizard.rb
+++ b/spec/support/v5.0/app/models/wizard.rb
@@ -47,6 +47,10 @@ class Wizard < ApplicationRecord
     blue: 2,
   }, _prefix: :color, _suffix: :eyes
 
+  serialize :owl_results, Hash
+  serialize :pets, Array
+  serialize :patronus_characteristics, JSON
+
   has_one :wand
   has_many :spell_books
   # habtm which is optional at the db level

--- a/spec/support/v5.0/db/migrate/20190620000015_add_serialized_to_wizards.rb
+++ b/spec/support/v5.0/db/migrate/20190620000015_add_serialized_to_wizards.rb
@@ -1,6 +1,8 @@
 class AddSerializedToWizards < ActiveRecord::Migration[5.0]
   def change
     add_column :wizards, :owl_results, :text # Hash
+    add_column :wizards, :newt_subjects, :text # generic
     add_column :wizards, :pets, :text # Array
+    add_column :wizards, :patronus_characteristics, :text # serialized as JSON, but not a JSON column type
   end
 end

--- a/spec/support/v5.0/db/migrate/20190620000015_add_serialized_to_wizards.rb
+++ b/spec/support/v5.0/db/migrate/20190620000015_add_serialized_to_wizards.rb
@@ -1,0 +1,6 @@
+class AddSerializedToWizards < ActiveRecord::Migration[5.0]
+  def change
+    add_column :wizards, :owl_results, :text # Hash
+    add_column :wizards, :pets, :text # Array
+  end
+end

--- a/spec/support/v5.0/db/schema.rb
+++ b/spec/support/v5.0/db/schema.rb
@@ -87,6 +87,9 @@ ActiveRecord::Schema.define(version: 20190620000014) do
     t.integer  "hair_length"
     t.string   "type",               default: "Wizard", null: false
     t.integer  "school_id"
+    t.text "owl_results"
+    t.text "pets"
+    t.text "patronus_characteristics"
   end
 
 end

--- a/spec/support/v5.0/db/schema.rb
+++ b/spec/support/v5.0/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190620000014) do
+ActiveRecord::Schema.define(version: 20190620000015) do
 
   create_table "headmasters", force: :cascade do |t|
     t.integer "school_id"
@@ -78,18 +78,19 @@ ActiveRecord::Schema.define(version: 20190620000014) do
     t.integer  "professor"
     t.string   "parent_email"
     t.text     "notes"
-    t.datetime "created_at",                            null: false
-    t.datetime "updated_at",                            null: false
+    t.datetime "created_at",                                  null: false
+    t.datetime "updated_at",                                  null: false
     t.string   "broom"
     t.integer  "quidditch_position"
     t.integer  "hair_color"
     t.integer  "eye_color"
     t.integer  "hair_length"
-    t.string   "type",               default: "Wizard", null: false
+    t.string   "type",                     default: "Wizard", null: false
     t.integer  "school_id"
-    t.text "owl_results"
-    t.text "pets"
-    t.text "patronus_characteristics"
+    t.text     "owl_results"
+    t.text     "newt_subjects"
+    t.text     "pets"
+    t.text     "patronus_characteristics"
   end
 
 end

--- a/spec/support/v5.0/sorbet_test_cases.rb
+++ b/spec/support/v5.0/sorbet_test_cases.rb
@@ -305,6 +305,17 @@ T.assert_type!(Wizard::House::Hufflepuff, Wizard::House)
 T.assert_type!(Wizard::House::Ravenclaw, Wizard::House)
 T.assert_type!(Wizard::House::Slytherin, Wizard::House)
 
+# Serialization
+T.assert_type!(
+  wizard.owl_results,
+  T.any(T::Array[T.untyped], T::Boolean, Float, T::Hash[T.untyped, T.untyped], Integer, String)
+)
+T.assert_type!(
+  wizard.patronus_characteristics,
+  T.any(T::Array[T.untyped], T::Boolean, Float, T::Hash[String, T.untyped], Integer, String)
+)
+T.assert_type!(wizard.pets, T::Array[T.untyped])
+
 # Mythical plugin
 T.assert_type!(Wand.mythicals, T::Array[Wand])
 

--- a/spec/support/v5.0/sorbet_test_cases.rb
+++ b/spec/support/v5.0/sorbet_test_cases.rb
@@ -308,13 +308,17 @@ T.assert_type!(Wizard::House::Slytherin, Wizard::House)
 # Serialization
 T.assert_type!(
   wizard.owl_results,
-  T.any(T::Array[T.untyped], T::Boolean, Float, T::Hash[T.untyped, T.untyped], Integer, String)
+  T.nilable(T.any(T::Hash[T.untyped, T.untyped]))
+)
+T.assert_type!(
+  wizard.newt_subjects,
+  T.nilable(T.any(T::Array[T.untyped], T::Boolean, Float, T::Hash[T.untyped, T.untyped], Integer, String))
 )
 T.assert_type!(
   wizard.patronus_characteristics,
-  T.any(T::Array[T.untyped], T::Boolean, Float, T::Hash[String, T.untyped], Integer, String)
+  T.nilable(T.any(T::Array[T.untyped], T::Boolean, Float, T::Hash[String, T.untyped], Integer, String))
 )
-T.assert_type!(wizard.pets, T::Array[T.untyped])
+T.assert_type!(wizard.pets, T.nilable(T::Array[T.untyped]))
 
 # Mythical plugin
 T.assert_type!(Wand.mythicals, T::Array[Wand])

--- a/spec/support/v5.0/sorbet_test_cases.rb
+++ b/spec/support/v5.0/sorbet_test_cases.rb
@@ -308,7 +308,7 @@ T.assert_type!(Wizard::House::Slytherin, Wizard::House)
 # Serialization
 T.assert_type!(
   wizard.owl_results,
-  T.nilable(T.any(T::Hash[T.untyped, T.untyped]))
+  T.nilable(T::Hash[T.untyped, T.untyped])
 )
 T.assert_type!(
   wizard.newt_subjects,

--- a/spec/support/v5.1/app/models/wizard.rb
+++ b/spec/support/v5.1/app/models/wizard.rb
@@ -48,6 +48,7 @@ class Wizard < ApplicationRecord
   }, _prefix: :color, _suffix: :eyes
 
   serialize :owl_results, Hash
+  serialize :newt_subjects # no specific data type, uses the default YAML Object coder
   serialize :pets, Array
   serialize :patronus_characteristics, JSON
 

--- a/spec/support/v5.1/app/models/wizard.rb
+++ b/spec/support/v5.1/app/models/wizard.rb
@@ -47,6 +47,10 @@ class Wizard < ApplicationRecord
     blue: 2,
   }, _prefix: :color, _suffix: :eyes
 
+  serialize :owl_results, Hash
+  serialize :pets, Array
+  serialize :patronus_characteristics, JSON
+
   has_one :wand
   has_many :spell_books
   # habtm which is optional at the db level

--- a/spec/support/v5.1/db/migrate/20190620000015_add_serialized_to_wizards.rb
+++ b/spec/support/v5.1/db/migrate/20190620000015_add_serialized_to_wizards.rb
@@ -1,6 +1,8 @@
 class AddSerializedToWizards < ActiveRecord::Migration[5.1]
   def change
     add_column :wizards, :owl_results, :text # Hash
+    add_column :wizards, :newt_subjects, :text # generic
     add_column :wizards, :pets, :text # Array
+    add_column :wizards, :patronus_characteristics, :text # serialized as JSON, but not a JSON column type
   end
 end

--- a/spec/support/v5.1/db/migrate/20190620000015_add_serialized_to_wizards.rb
+++ b/spec/support/v5.1/db/migrate/20190620000015_add_serialized_to_wizards.rb
@@ -1,0 +1,6 @@
+class AddSerializedToWizards < ActiveRecord::Migration[5.1]
+  def change
+    add_column :wizards, :owl_results, :text # Hash
+    add_column :wizards, :pets, :text # Array
+  end
+end

--- a/spec/support/v5.1/db/schema.rb
+++ b/spec/support/v5.1/db/schema.rb
@@ -87,6 +87,9 @@ ActiveRecord::Schema.define(version: 20190620000014) do
     t.integer "hair_length"
     t.string "type", default: "Wizard", null: false
     t.integer "school_id"
+    t.text "owl_results"
+    t.text "pets"
+    t.text "patronus_characteristics"
   end
 
 end

--- a/spec/support/v5.1/db/schema.rb
+++ b/spec/support/v5.1/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190620000014) do
+ActiveRecord::Schema.define(version: 20190620000015) do
 
   create_table "headmasters", force: :cascade do |t|
     t.integer "school_id"
@@ -88,6 +88,7 @@ ActiveRecord::Schema.define(version: 20190620000014) do
     t.string "type", default: "Wizard", null: false
     t.integer "school_id"
     t.text "owl_results"
+    t.text "newt_subjects"
     t.text "pets"
     t.text "patronus_characteristics"
   end

--- a/spec/support/v5.1/sorbet_test_cases.rb
+++ b/spec/support/v5.1/sorbet_test_cases.rb
@@ -305,6 +305,17 @@ T.assert_type!(Wizard::House::Hufflepuff, Wizard::House)
 T.assert_type!(Wizard::House::Ravenclaw, Wizard::House)
 T.assert_type!(Wizard::House::Slytherin, Wizard::House)
 
+# Serialization
+T.assert_type!(
+  wizard.owl_results,
+  T.any(T::Array[T.untyped], T::Boolean, Float, T::Hash[T.untyped, T.untyped], Integer, String)
+)
+T.assert_type!(
+  wizard.patronus_characteristics,
+  T.any(T::Array[T.untyped], T::Boolean, Float, T::Hash[String, T.untyped], Integer, String)
+)
+T.assert_type!(wizard.pets, T::Array[T.untyped])
+
 # Mythical plugin
 T.assert_type!(Wand.mythicals, T::Array[Wand])
 

--- a/spec/support/v5.1/sorbet_test_cases.rb
+++ b/spec/support/v5.1/sorbet_test_cases.rb
@@ -308,13 +308,17 @@ T.assert_type!(Wizard::House::Slytherin, Wizard::House)
 # Serialization
 T.assert_type!(
   wizard.owl_results,
-  T.any(T::Array[T.untyped], T::Boolean, Float, T::Hash[T.untyped, T.untyped], Integer, String)
+  T.nilable(T.any(T::Hash[T.untyped, T.untyped]))
+)
+T.assert_type!(
+  wizard.newt_subjects,
+  T.nilable(T.any(T::Array[T.untyped], T::Boolean, Float, T::Hash[T.untyped, T.untyped], Integer, String))
 )
 T.assert_type!(
   wizard.patronus_characteristics,
-  T.any(T::Array[T.untyped], T::Boolean, Float, T::Hash[String, T.untyped], Integer, String)
+  T.nilable(T.any(T::Array[T.untyped], T::Boolean, Float, T::Hash[String, T.untyped], Integer, String))
 )
-T.assert_type!(wizard.pets, T::Array[T.untyped])
+T.assert_type!(wizard.pets, T.nilable(T::Array[T.untyped]))
 
 # Mythical plugin
 T.assert_type!(Wand.mythicals, T::Array[Wand])

--- a/spec/support/v5.1/sorbet_test_cases.rb
+++ b/spec/support/v5.1/sorbet_test_cases.rb
@@ -308,7 +308,7 @@ T.assert_type!(Wizard::House::Slytherin, Wizard::House)
 # Serialization
 T.assert_type!(
   wizard.owl_results,
-  T.nilable(T.any(T::Hash[T.untyped, T.untyped]))
+  T.nilable(T::Hash[T.untyped, T.untyped])
 )
 T.assert_type!(
   wizard.newt_subjects,

--- a/spec/support/v5.2/app/models/wizard.rb
+++ b/spec/support/v5.2/app/models/wizard.rb
@@ -48,6 +48,7 @@ class Wizard < ApplicationRecord
   }, _prefix: :color, _suffix: :eyes
 
   serialize :owl_results, Hash
+  serialize :newt_subjects # no specific data type, uses the default YAML Object coder
   serialize :pets, Array
   serialize :patronus_characteristics, JSON
 

--- a/spec/support/v5.2/app/models/wizard.rb
+++ b/spec/support/v5.2/app/models/wizard.rb
@@ -47,6 +47,10 @@ class Wizard < ApplicationRecord
     blue: 2,
   }, _prefix: :color, _suffix: :eyes
 
+  serialize :owl_results, Hash
+  serialize :pets, Array
+  serialize :patronus_characteristics, JSON
+
   has_one :wand
   has_many :spell_books
   # habtm which is optional at the db level

--- a/spec/support/v5.2/db/migrate/20190620000015_add_serialized_to_wizards.rb
+++ b/spec/support/v5.2/db/migrate/20190620000015_add_serialized_to_wizards.rb
@@ -1,0 +1,7 @@
+class AddSerializedToWizards < ActiveRecord::Migration[5.2]
+  def change
+    add_column :wizards, :owl_results, :text # Hash
+    add_column :wizards, :pets, :text # Array
+    add_column :wizards, :patronus_characteristics, :text # serialized as JSON, but not a JSON column type
+  end
+end

--- a/spec/support/v5.2/db/migrate/20190620000015_add_serialized_to_wizards.rb
+++ b/spec/support/v5.2/db/migrate/20190620000015_add_serialized_to_wizards.rb
@@ -1,6 +1,7 @@
 class AddSerializedToWizards < ActiveRecord::Migration[5.2]
   def change
     add_column :wizards, :owl_results, :text # Hash
+    add_column :wizards, :newt_subjects, :text # generic
     add_column :wizards, :pets, :text # Array
     add_column :wizards, :patronus_characteristics, :text # serialized as JSON, but not a JSON column type
   end

--- a/spec/support/v5.2/db/schema.rb
+++ b/spec/support/v5.2/db/schema.rb
@@ -90,6 +90,7 @@ ActiveRecord::Schema.define(version: 2019_06_20_000015) do
     t.string "type", default: "Wizard", null: false
     t.integer "school_id"
     t.text "owl_results"
+    t.text "newt_subjects"
     t.text "pets"
     t.text "patronus_characteristics"
   end

--- a/spec/support/v5.2/db/schema.rb
+++ b/spec/support/v5.2/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_06_20_000014) do
+ActiveRecord::Schema.define(version: 2019_06_20_000015) do
 
   create_table "headmasters", force: :cascade do |t|
     t.integer "school_id"
@@ -89,6 +89,9 @@ ActiveRecord::Schema.define(version: 2019_06_20_000014) do
     t.integer "hair_length"
     t.string "type", default: "Wizard", null: false
     t.integer "school_id"
+    t.text "owl_results"
+    t.text "pets"
+    t.text "patronus_characteristics"
   end
 
 end

--- a/spec/support/v5.2/sorbet_test_cases.rb
+++ b/spec/support/v5.2/sorbet_test_cases.rb
@@ -305,6 +305,17 @@ T.assert_type!(Wizard::House::Hufflepuff, Wizard::House)
 T.assert_type!(Wizard::House::Ravenclaw, Wizard::House)
 T.assert_type!(Wizard::House::Slytherin, Wizard::House)
 
+# Serialization
+T.assert_type!(
+  wizard.owl_results,
+  T.any(T::Array[T.untyped], T::Boolean, Float, T::Hash[T.untyped, T.untyped], Integer, String)
+)
+T.assert_type!(
+  wizard.patronus_characteristics,
+  T.any(T::Array[T.untyped], T::Boolean, Float, T::Hash[String, T.untyped], Integer, String)
+)
+T.assert_type!(wizard.pets, T::Array[T.untyped])
+
 # Mythical plugin
 T.assert_type!(Wand.mythicals, T::Array[Wand])
 

--- a/spec/support/v5.2/sorbet_test_cases.rb
+++ b/spec/support/v5.2/sorbet_test_cases.rb
@@ -308,13 +308,17 @@ T.assert_type!(Wizard::House::Slytherin, Wizard::House)
 # Serialization
 T.assert_type!(
   wizard.owl_results,
-  T.any(T::Array[T.untyped], T::Boolean, Float, T::Hash[T.untyped, T.untyped], Integer, String)
+  T.nilable(T.any(T::Hash[T.untyped, T.untyped]))
+)
+T.assert_type!(
+  wizard.newt_subjects,
+  T.nilable(T.any(T::Array[T.untyped], T::Boolean, Float, T::Hash[T.untyped, T.untyped], Integer, String))
 )
 T.assert_type!(
   wizard.patronus_characteristics,
-  T.any(T::Array[T.untyped], T::Boolean, Float, T::Hash[String, T.untyped], Integer, String)
+  T.nilable(T.any(T::Array[T.untyped], T::Boolean, Float, T::Hash[String, T.untyped], Integer, String))
 )
-T.assert_type!(wizard.pets, T::Array[T.untyped])
+T.assert_type!(wizard.pets, T.nilable(T::Array[T.untyped]))
 
 # Mythical plugin
 T.assert_type!(Wand.mythicals, T::Array[Wand])

--- a/spec/support/v5.2/sorbet_test_cases.rb
+++ b/spec/support/v5.2/sorbet_test_cases.rb
@@ -308,7 +308,7 @@ T.assert_type!(Wizard::House::Slytherin, Wizard::House)
 # Serialization
 T.assert_type!(
   wizard.owl_results,
-  T.nilable(T.any(T::Hash[T.untyped, T.untyped]))
+  T.nilable(T::Hash[T.untyped, T.untyped])
 )
 T.assert_type!(
   wizard.newt_subjects,

--- a/spec/support/v6.0/app/models/wizard.rb
+++ b/spec/support/v6.0/app/models/wizard.rb
@@ -48,6 +48,7 @@ class Wizard < ApplicationRecord
   }, _prefix: :color, _suffix: :eyes
 
   serialize :owl_results, Hash
+  serialize :newt_subjects # no specific data type, uses the default YAML Object coder
   serialize :pets, Array
   serialize :patronus_characteristics, JSON
 

--- a/spec/support/v6.0/app/models/wizard.rb
+++ b/spec/support/v6.0/app/models/wizard.rb
@@ -47,6 +47,10 @@ class Wizard < ApplicationRecord
     blue: 2,
   }, _prefix: :color, _suffix: :eyes
 
+  serialize :owl_results, Hash
+  serialize :pets, Array
+  serialize :patronus_characteristics, JSON
+
   has_one :wand
   has_many :spell_books
   # habtm which is optional at the db level

--- a/spec/support/v6.0/db/migrate/20190620000015_add_serialized_to_wizards.rb
+++ b/spec/support/v6.0/db/migrate/20190620000015_add_serialized_to_wizards.rb
@@ -2,6 +2,8 @@
 class AddSerializedToWizards < ActiveRecord::Migration[6.0]
   def change
     add_column :wizards, :owl_results, :text # Hash
+    add_column :wizards, :newt_subjects, :text # generic
     add_column :wizards, :pets, :text # Array
+    add_column :wizards, :patronus_characteristics, :text # serialized as JSON, but not a JSON column type
   end
 end

--- a/spec/support/v6.0/db/migrate/20190620000015_add_serialized_to_wizards.rb
+++ b/spec/support/v6.0/db/migrate/20190620000015_add_serialized_to_wizards.rb
@@ -1,0 +1,7 @@
+# typed: true
+class AddSerializedToWizards < ActiveRecord::Migration[6.0]
+  def change
+    add_column :wizards, :owl_results, :text # Hash
+    add_column :wizards, :pets, :text # Array
+  end
+end

--- a/spec/support/v6.0/db/schema.rb
+++ b/spec/support/v6.0/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_06_20_000014) do
+ActiveRecord::Schema.define(version: 2019_06_20_000015) do
 
   create_table "headmasters", force: :cascade do |t|
     t.integer "school_id"
@@ -90,6 +90,7 @@ ActiveRecord::Schema.define(version: 2019_06_20_000014) do
     t.string "type", default: "Wizard", null: false
     t.integer "school_id"
     t.text "owl_results"
+    t.text "newt_subjects"
     t.text "pets"
     t.text "patronus_characteristics"
   end

--- a/spec/support/v6.0/db/schema.rb
+++ b/spec/support/v6.0/db/schema.rb
@@ -89,6 +89,9 @@ ActiveRecord::Schema.define(version: 2019_06_20_000014) do
     t.integer "hair_length"
     t.string "type", default: "Wizard", null: false
     t.integer "school_id"
+    t.text "owl_results"
+    t.text "pets"
+    t.text "patronus_characteristics"
   end
 
   add_foreign_key "wizards", "schools"

--- a/spec/support/v6.0/sorbet_test_cases.rb
+++ b/spec/support/v6.0/sorbet_test_cases.rb
@@ -305,6 +305,17 @@ T.assert_type!(Wizard::House::Hufflepuff, Wizard::House)
 T.assert_type!(Wizard::House::Ravenclaw, Wizard::House)
 T.assert_type!(Wizard::House::Slytherin, Wizard::House)
 
+# Serialization
+T.assert_type!(
+  wizard.owl_results,
+  T.any(T::Array[T.untyped], T::Boolean, Float, T::Hash[T.untyped, T.untyped], Integer, String)
+)
+T.assert_type!(
+  wizard.patronus_characteristics,
+  T.any(T::Array[T.untyped], T::Boolean, Float, T::Hash[String, T.untyped], Integer, String)
+)
+T.assert_type!(wizard.pets, T::Array[T.untyped])
+
 # Mythical plugin
 T.assert_type!(Wand.mythicals, T::Array[Wand])
 

--- a/spec/support/v6.0/sorbet_test_cases.rb
+++ b/spec/support/v6.0/sorbet_test_cases.rb
@@ -308,13 +308,17 @@ T.assert_type!(Wizard::House::Slytherin, Wizard::House)
 # Serialization
 T.assert_type!(
   wizard.owl_results,
-  T.any(T::Array[T.untyped], T::Boolean, Float, T::Hash[T.untyped, T.untyped], Integer, String)
+  T.nilable(T.any(T::Hash[T.untyped, T.untyped]))
+)
+T.assert_type!(
+  wizard.newt_subjects,
+  T.nilable(T.any(T::Array[T.untyped], T::Boolean, Float, T::Hash[T.untyped, T.untyped], Integer, String))
 )
 T.assert_type!(
   wizard.patronus_characteristics,
-  T.any(T::Array[T.untyped], T::Boolean, Float, T::Hash[String, T.untyped], Integer, String)
+  T.nilable(T.any(T::Array[T.untyped], T::Boolean, Float, T::Hash[String, T.untyped], Integer, String))
 )
-T.assert_type!(wizard.pets, T::Array[T.untyped])
+T.assert_type!(wizard.pets, T.nilable(T::Array[T.untyped]))
 
 # Mythical plugin
 T.assert_type!(Wand.mythicals, T::Array[Wand])

--- a/spec/support/v6.0/sorbet_test_cases.rb
+++ b/spec/support/v6.0/sorbet_test_cases.rb
@@ -308,7 +308,7 @@ T.assert_type!(Wizard::House::Slytherin, Wizard::House)
 # Serialization
 T.assert_type!(
   wizard.owl_results,
-  T.nilable(T.any(T::Hash[T.untyped, T.untyped]))
+  T.nilable(T::Hash[T.untyped, T.untyped])
 )
 T.assert_type!(
   wizard.newt_subjects,

--- a/spec/test_data/v5.0/expected_squib.rbi
+++ b/spec/test_data/v5.0/expected_squib.rbi
@@ -111,7 +111,7 @@ module Squib::ActiveRelation_WhereNot
   def not(opts, *rest); end
 end
 
-module Squib::GeneratedSerializationMethods
+module Squib::GeneratedSerializedAttributeMethods
   sig { returns(T.nilable(T.any(T::Array[T.untyped], T::Boolean, Float, T::Hash[T.untyped, T.untyped], Integer, String))) }
   def newt_subjects; end
 
@@ -361,7 +361,7 @@ end
 
 class Squib < Wizard
   include Squib::EnumInstanceMethods
-  include Squib::GeneratedSerializationMethods
+  include Squib::GeneratedSerializedAttributeMethods
   include Squib::GeneratedAttributeMethods
   include Squib::GeneratedAssociationMethods
   extend Squib::CustomFinderMethods

--- a/spec/test_data/v5.0/expected_squib.rbi
+++ b/spec/test_data/v5.0/expected_squib.rbi
@@ -112,6 +112,15 @@ module Squib::ActiveRelation_WhereNot
 end
 
 module Squib::GeneratedSerializationMethods
+  sig { returns(T.nilable(T.any(T::Array[T.untyped], T::Boolean, Float, T::Hash[T.untyped, T.untyped], Integer, String))) }
+  def newt_subjects; end
+
+  sig { params(value: T.nilable(T.any(T::Array[T.untyped], T::Boolean, Float, T::Hash[T.untyped, T.untyped], Integer, String))).void }
+  def newt_subjects=(value); end
+
+  sig { returns(T::Boolean) }
+  def newt_subjects?; end
+
   sig { returns(T.nilable(T::Hash[T.untyped, T.untyped])) }
   def owl_results; end
 

--- a/spec/test_data/v5.0/expected_squib.rbi
+++ b/spec/test_data/v5.0/expected_squib.rbi
@@ -111,6 +111,35 @@ module Squib::ActiveRelation_WhereNot
   def not(opts, *rest); end
 end
 
+module Squib::GeneratedSerializationMethods
+  sig { returns(T.nilable(T::Hash[T.untyped, T.untyped])) }
+  def owl_results; end
+
+  sig { params(value: T.nilable(T::Hash[T.untyped, T.untyped])).void }
+  def owl_results=(value); end
+
+  sig { returns(T::Boolean) }
+  def owl_results?; end
+
+  sig { returns(T.nilable(T.any(T::Array[T.untyped], T::Boolean, Float, T::Hash[T.untyped, T.untyped], Integer, String))) }
+  def patronus_characteristics; end
+
+  sig { params(value: T.nilable(T.any(T::Array[T.untyped], T::Boolean, Float, T::Hash[T.untyped, T.untyped], Integer, String))).void }
+  def patronus_characteristics=(value); end
+
+  sig { returns(T::Boolean) }
+  def patronus_characteristics?; end
+
+  sig { returns(T.nilable(T::Array[T.untyped])) }
+  def pets; end
+
+  sig { params(value: T.nilable(T::Array[T.untyped])).void }
+  def pets=(value); end
+
+  sig { returns(T::Boolean) }
+  def pets?; end
+end
+
 module Squib::GeneratedAttributeMethods
   sig { returns(T.nilable(String)) }
   def broom; end
@@ -317,6 +346,7 @@ end
 
 class Squib < Wizard
   include Squib::EnumInstanceMethods
+  include Squib::GeneratedSerializationMethods
   include Squib::GeneratedAttributeMethods
   include Squib::GeneratedAssociationMethods
   extend Squib::CustomFinderMethods

--- a/spec/test_data/v5.0/expected_wizard.rbi
+++ b/spec/test_data/v5.0/expected_wizard.rbi
@@ -111,7 +111,7 @@ module Wizard::ActiveRelation_WhereNot
   def not(opts, *rest); end
 end
 
-module Wizard::GeneratedSerializationMethods
+module Wizard::GeneratedSerializedAttributeMethods
   sig { returns(T.nilable(T.any(T::Array[T.untyped], T::Boolean, Float, T::Hash[T.untyped, T.untyped], Integer, String))) }
   def newt_subjects; end
 
@@ -343,7 +343,7 @@ end
 
 class Wizard < ApplicationRecord
   include Wizard::EnumInstanceMethods
-  include Wizard::GeneratedSerializationMethods
+  include Wizard::GeneratedSerializedAttributeMethods
   include Wizard::GeneratedAttributeMethods
   include Wizard::GeneratedAssociationMethods
   extend Wizard::CustomFinderMethods

--- a/spec/test_data/v5.0/expected_wizard.rbi
+++ b/spec/test_data/v5.0/expected_wizard.rbi
@@ -112,6 +112,15 @@ module Wizard::ActiveRelation_WhereNot
 end
 
 module Wizard::GeneratedSerializationMethods
+  sig { returns(T.nilable(T.any(T::Array[T.untyped], T::Boolean, Float, T::Hash[T.untyped, T.untyped], Integer, String))) }
+  def newt_subjects; end
+
+  sig { params(value: T.nilable(T.any(T::Array[T.untyped], T::Boolean, Float, T::Hash[T.untyped, T.untyped], Integer, String))).void }
+  def newt_subjects=(value); end
+
+  sig { returns(T::Boolean) }
+  def newt_subjects?; end
+
   sig { returns(T.nilable(T::Hash[T.untyped, T.untyped])) }
   def owl_results; end
 

--- a/spec/test_data/v5.0/expected_wizard.rbi
+++ b/spec/test_data/v5.0/expected_wizard.rbi
@@ -111,6 +111,35 @@ module Wizard::ActiveRelation_WhereNot
   def not(opts, *rest); end
 end
 
+module Wizard::GeneratedSerializationMethods
+  sig { returns(T.nilable(T::Hash[T.untyped, T.untyped])) }
+  def owl_results; end
+
+  sig { params(value: T.nilable(T::Hash[T.untyped, T.untyped])).void }
+  def owl_results=(value); end
+
+  sig { returns(T::Boolean) }
+  def owl_results?; end
+
+  sig { returns(T.nilable(T.any(T::Array[T.untyped], T::Boolean, Float, T::Hash[T.untyped, T.untyped], Integer, String))) }
+  def patronus_characteristics; end
+
+  sig { params(value: T.nilable(T.any(T::Array[T.untyped], T::Boolean, Float, T::Hash[T.untyped, T.untyped], Integer, String))).void }
+  def patronus_characteristics=(value); end
+
+  sig { returns(T::Boolean) }
+  def patronus_characteristics?; end
+
+  sig { returns(T.nilable(T::Array[T.untyped])) }
+  def pets; end
+
+  sig { params(value: T.nilable(T::Array[T.untyped])).void }
+  def pets=(value); end
+
+  sig { returns(T::Boolean) }
+  def pets?; end
+end
+
 module Wizard::GeneratedAttributeMethods
   sig { returns(T::Boolean) }
   def broom?; end
@@ -299,6 +328,7 @@ end
 
 class Wizard < ApplicationRecord
   include Wizard::EnumInstanceMethods
+  include Wizard::GeneratedSerializationMethods
   include Wizard::GeneratedAttributeMethods
   include Wizard::GeneratedAssociationMethods
   extend Wizard::CustomFinderMethods

--- a/spec/test_data/v5.0/expected_wizard_wo_spellbook.rbi
+++ b/spec/test_data/v5.0/expected_wizard_wo_spellbook.rbi
@@ -111,7 +111,7 @@ module Wizard::ActiveRelation_WhereNot
   def not(opts, *rest); end
 end
 
-module Wizard::GeneratedSerializationMethods
+module Wizard::GeneratedSerializedAttributeMethods
   sig { returns(T.nilable(T.any(T::Array[T.untyped], T::Boolean, Float, T::Hash[T.untyped, T.untyped], Integer, String))) }
   def newt_subjects; end
 
@@ -337,7 +337,7 @@ end
 
 class Wizard < ApplicationRecord
   include Wizard::EnumInstanceMethods
-  include Wizard::GeneratedSerializationMethods
+  include Wizard::GeneratedSerializedAttributeMethods
   include Wizard::GeneratedAttributeMethods
   include Wizard::GeneratedAssociationMethods
   extend Wizard::CustomFinderMethods

--- a/spec/test_data/v5.0/expected_wizard_wo_spellbook.rbi
+++ b/spec/test_data/v5.0/expected_wizard_wo_spellbook.rbi
@@ -112,6 +112,15 @@ module Wizard::ActiveRelation_WhereNot
 end
 
 module Wizard::GeneratedSerializationMethods
+  sig { returns(T.nilable(T.any(T::Array[T.untyped], T::Boolean, Float, T::Hash[T.untyped, T.untyped], Integer, String))) }
+  def newt_subjects; end
+
+  sig { params(value: T.nilable(T.any(T::Array[T.untyped], T::Boolean, Float, T::Hash[T.untyped, T.untyped], Integer, String))).void }
+  def newt_subjects=(value); end
+
+  sig { returns(T::Boolean) }
+  def newt_subjects?; end
+
   sig { returns(T.nilable(T::Hash[T.untyped, T.untyped])) }
   def owl_results; end
 

--- a/spec/test_data/v5.0/expected_wizard_wo_spellbook.rbi
+++ b/spec/test_data/v5.0/expected_wizard_wo_spellbook.rbi
@@ -111,6 +111,35 @@ module Wizard::ActiveRelation_WhereNot
   def not(opts, *rest); end
 end
 
+module Wizard::GeneratedSerializationMethods
+  sig { returns(T.nilable(T::Hash[T.untyped, T.untyped])) }
+  def owl_results; end
+
+  sig { params(value: T.nilable(T::Hash[T.untyped, T.untyped])).void }
+  def owl_results=(value); end
+
+  sig { returns(T::Boolean) }
+  def owl_results?; end
+
+  sig { returns(T.nilable(T.any(T::Array[T.untyped], T::Boolean, Float, T::Hash[T.untyped, T.untyped], Integer, String))) }
+  def patronus_characteristics; end
+
+  sig { params(value: T.nilable(T.any(T::Array[T.untyped], T::Boolean, Float, T::Hash[T.untyped, T.untyped], Integer, String))).void }
+  def patronus_characteristics=(value); end
+
+  sig { returns(T::Boolean) }
+  def patronus_characteristics?; end
+
+  sig { returns(T.nilable(T::Array[T.untyped])) }
+  def pets; end
+
+  sig { params(value: T.nilable(T::Array[T.untyped])).void }
+  def pets=(value); end
+
+  sig { returns(T::Boolean) }
+  def pets?; end
+end
+
 module Wizard::GeneratedAttributeMethods
   sig { returns(T::Boolean) }
   def broom?; end
@@ -293,6 +322,7 @@ end
 
 class Wizard < ApplicationRecord
   include Wizard::EnumInstanceMethods
+  include Wizard::GeneratedSerializationMethods
   include Wizard::GeneratedAttributeMethods
   include Wizard::GeneratedAssociationMethods
   extend Wizard::CustomFinderMethods

--- a/spec/test_data/v5.1/expected_squib.rbi
+++ b/spec/test_data/v5.1/expected_squib.rbi
@@ -111,7 +111,7 @@ module Squib::ActiveRelation_WhereNot
   def not(opts, *rest); end
 end
 
-module Squib::GeneratedSerializationMethods
+module Squib::GeneratedSerializedAttributeMethods
   sig { returns(T.nilable(T.any(T::Array[T.untyped], T::Boolean, Float, T::Hash[T.untyped, T.untyped], Integer, String))) }
   def newt_subjects; end
 
@@ -361,7 +361,7 @@ end
 
 class Squib < Wizard
   include Squib::EnumInstanceMethods
-  include Squib::GeneratedSerializationMethods
+  include Squib::GeneratedSerializedAttributeMethods
   include Squib::GeneratedAttributeMethods
   include Squib::GeneratedAssociationMethods
   extend Squib::CustomFinderMethods

--- a/spec/test_data/v5.1/expected_squib.rbi
+++ b/spec/test_data/v5.1/expected_squib.rbi
@@ -112,6 +112,15 @@ module Squib::ActiveRelation_WhereNot
 end
 
 module Squib::GeneratedSerializationMethods
+  sig { returns(T.nilable(T.any(T::Array[T.untyped], T::Boolean, Float, T::Hash[T.untyped, T.untyped], Integer, String))) }
+  def newt_subjects; end
+
+  sig { params(value: T.nilable(T.any(T::Array[T.untyped], T::Boolean, Float, T::Hash[T.untyped, T.untyped], Integer, String))).void }
+  def newt_subjects=(value); end
+
+  sig { returns(T::Boolean) }
+  def newt_subjects?; end
+
   sig { returns(T.nilable(T::Hash[T.untyped, T.untyped])) }
   def owl_results; end
 

--- a/spec/test_data/v5.1/expected_squib.rbi
+++ b/spec/test_data/v5.1/expected_squib.rbi
@@ -111,6 +111,35 @@ module Squib::ActiveRelation_WhereNot
   def not(opts, *rest); end
 end
 
+module Squib::GeneratedSerializationMethods
+  sig { returns(T.nilable(T::Hash[T.untyped, T.untyped])) }
+  def owl_results; end
+
+  sig { params(value: T.nilable(T::Hash[T.untyped, T.untyped])).void }
+  def owl_results=(value); end
+
+  sig { returns(T::Boolean) }
+  def owl_results?; end
+
+  sig { returns(T.nilable(T.any(T::Array[T.untyped], T::Boolean, Float, T::Hash[T.untyped, T.untyped], Integer, String))) }
+  def patronus_characteristics; end
+
+  sig { params(value: T.nilable(T.any(T::Array[T.untyped], T::Boolean, Float, T::Hash[T.untyped, T.untyped], Integer, String))).void }
+  def patronus_characteristics=(value); end
+
+  sig { returns(T::Boolean) }
+  def patronus_characteristics?; end
+
+  sig { returns(T.nilable(T::Array[T.untyped])) }
+  def pets; end
+
+  sig { params(value: T.nilable(T::Array[T.untyped])).void }
+  def pets=(value); end
+
+  sig { returns(T::Boolean) }
+  def pets?; end
+end
+
 module Squib::GeneratedAttributeMethods
   sig { returns(T.nilable(String)) }
   def broom; end
@@ -317,6 +346,7 @@ end
 
 class Squib < Wizard
   include Squib::EnumInstanceMethods
+  include Squib::GeneratedSerializationMethods
   include Squib::GeneratedAttributeMethods
   include Squib::GeneratedAssociationMethods
   extend Squib::CustomFinderMethods

--- a/spec/test_data/v5.1/expected_wizard.rbi
+++ b/spec/test_data/v5.1/expected_wizard.rbi
@@ -111,7 +111,7 @@ module Wizard::ActiveRelation_WhereNot
   def not(opts, *rest); end
 end
 
-module Wizard::GeneratedSerializationMethods
+module Wizard::GeneratedSerializedAttributeMethods
   sig { returns(T.nilable(T.any(T::Array[T.untyped], T::Boolean, Float, T::Hash[T.untyped, T.untyped], Integer, String))) }
   def newt_subjects; end
 
@@ -343,7 +343,7 @@ end
 
 class Wizard < ApplicationRecord
   include Wizard::EnumInstanceMethods
-  include Wizard::GeneratedSerializationMethods
+  include Wizard::GeneratedSerializedAttributeMethods
   include Wizard::GeneratedAttributeMethods
   include Wizard::GeneratedAssociationMethods
   extend Wizard::CustomFinderMethods

--- a/spec/test_data/v5.1/expected_wizard.rbi
+++ b/spec/test_data/v5.1/expected_wizard.rbi
@@ -112,6 +112,15 @@ module Wizard::ActiveRelation_WhereNot
 end
 
 module Wizard::GeneratedSerializationMethods
+  sig { returns(T.nilable(T.any(T::Array[T.untyped], T::Boolean, Float, T::Hash[T.untyped, T.untyped], Integer, String))) }
+  def newt_subjects; end
+
+  sig { params(value: T.nilable(T.any(T::Array[T.untyped], T::Boolean, Float, T::Hash[T.untyped, T.untyped], Integer, String))).void }
+  def newt_subjects=(value); end
+
+  sig { returns(T::Boolean) }
+  def newt_subjects?; end
+
   sig { returns(T.nilable(T::Hash[T.untyped, T.untyped])) }
   def owl_results; end
 

--- a/spec/test_data/v5.1/expected_wizard.rbi
+++ b/spec/test_data/v5.1/expected_wizard.rbi
@@ -111,6 +111,35 @@ module Wizard::ActiveRelation_WhereNot
   def not(opts, *rest); end
 end
 
+module Wizard::GeneratedSerializationMethods
+  sig { returns(T.nilable(T::Hash[T.untyped, T.untyped])) }
+  def owl_results; end
+
+  sig { params(value: T.nilable(T::Hash[T.untyped, T.untyped])).void }
+  def owl_results=(value); end
+
+  sig { returns(T::Boolean) }
+  def owl_results?; end
+
+  sig { returns(T.nilable(T.any(T::Array[T.untyped], T::Boolean, Float, T::Hash[T.untyped, T.untyped], Integer, String))) }
+  def patronus_characteristics; end
+
+  sig { params(value: T.nilable(T.any(T::Array[T.untyped], T::Boolean, Float, T::Hash[T.untyped, T.untyped], Integer, String))).void }
+  def patronus_characteristics=(value); end
+
+  sig { returns(T::Boolean) }
+  def patronus_characteristics?; end
+
+  sig { returns(T.nilable(T::Array[T.untyped])) }
+  def pets; end
+
+  sig { params(value: T.nilable(T::Array[T.untyped])).void }
+  def pets=(value); end
+
+  sig { returns(T::Boolean) }
+  def pets?; end
+end
+
 module Wizard::GeneratedAttributeMethods
   sig { returns(T::Boolean) }
   def broom?; end
@@ -299,6 +328,7 @@ end
 
 class Wizard < ApplicationRecord
   include Wizard::EnumInstanceMethods
+  include Wizard::GeneratedSerializationMethods
   include Wizard::GeneratedAttributeMethods
   include Wizard::GeneratedAssociationMethods
   extend Wizard::CustomFinderMethods

--- a/spec/test_data/v5.1/expected_wizard_wo_spellbook.rbi
+++ b/spec/test_data/v5.1/expected_wizard_wo_spellbook.rbi
@@ -111,7 +111,7 @@ module Wizard::ActiveRelation_WhereNot
   def not(opts, *rest); end
 end
 
-module Wizard::GeneratedSerializationMethods
+module Wizard::GeneratedSerializedAttributeMethods
   sig { returns(T.nilable(T.any(T::Array[T.untyped], T::Boolean, Float, T::Hash[T.untyped, T.untyped], Integer, String))) }
   def newt_subjects; end
 
@@ -337,7 +337,7 @@ end
 
 class Wizard < ApplicationRecord
   include Wizard::EnumInstanceMethods
-  include Wizard::GeneratedSerializationMethods
+  include Wizard::GeneratedSerializedAttributeMethods
   include Wizard::GeneratedAttributeMethods
   include Wizard::GeneratedAssociationMethods
   extend Wizard::CustomFinderMethods

--- a/spec/test_data/v5.1/expected_wizard_wo_spellbook.rbi
+++ b/spec/test_data/v5.1/expected_wizard_wo_spellbook.rbi
@@ -112,6 +112,15 @@ module Wizard::ActiveRelation_WhereNot
 end
 
 module Wizard::GeneratedSerializationMethods
+  sig { returns(T.nilable(T.any(T::Array[T.untyped], T::Boolean, Float, T::Hash[T.untyped, T.untyped], Integer, String))) }
+  def newt_subjects; end
+
+  sig { params(value: T.nilable(T.any(T::Array[T.untyped], T::Boolean, Float, T::Hash[T.untyped, T.untyped], Integer, String))).void }
+  def newt_subjects=(value); end
+
+  sig { returns(T::Boolean) }
+  def newt_subjects?; end
+
   sig { returns(T.nilable(T::Hash[T.untyped, T.untyped])) }
   def owl_results; end
 

--- a/spec/test_data/v5.1/expected_wizard_wo_spellbook.rbi
+++ b/spec/test_data/v5.1/expected_wizard_wo_spellbook.rbi
@@ -111,6 +111,35 @@ module Wizard::ActiveRelation_WhereNot
   def not(opts, *rest); end
 end
 
+module Wizard::GeneratedSerializationMethods
+  sig { returns(T.nilable(T::Hash[T.untyped, T.untyped])) }
+  def owl_results; end
+
+  sig { params(value: T.nilable(T::Hash[T.untyped, T.untyped])).void }
+  def owl_results=(value); end
+
+  sig { returns(T::Boolean) }
+  def owl_results?; end
+
+  sig { returns(T.nilable(T.any(T::Array[T.untyped], T::Boolean, Float, T::Hash[T.untyped, T.untyped], Integer, String))) }
+  def patronus_characteristics; end
+
+  sig { params(value: T.nilable(T.any(T::Array[T.untyped], T::Boolean, Float, T::Hash[T.untyped, T.untyped], Integer, String))).void }
+  def patronus_characteristics=(value); end
+
+  sig { returns(T::Boolean) }
+  def patronus_characteristics?; end
+
+  sig { returns(T.nilable(T::Array[T.untyped])) }
+  def pets; end
+
+  sig { params(value: T.nilable(T::Array[T.untyped])).void }
+  def pets=(value); end
+
+  sig { returns(T::Boolean) }
+  def pets?; end
+end
+
 module Wizard::GeneratedAttributeMethods
   sig { returns(T::Boolean) }
   def broom?; end
@@ -293,6 +322,7 @@ end
 
 class Wizard < ApplicationRecord
   include Wizard::EnumInstanceMethods
+  include Wizard::GeneratedSerializationMethods
   include Wizard::GeneratedAttributeMethods
   include Wizard::GeneratedAssociationMethods
   extend Wizard::CustomFinderMethods

--- a/spec/test_data/v5.2/expected_squib.rbi
+++ b/spec/test_data/v5.2/expected_squib.rbi
@@ -111,6 +111,35 @@ module Squib::ActiveRelation_WhereNot
   def not(opts, *rest); end
 end
 
+module Squib::GeneratedSerializationMethods
+  sig { returns(T.nilable(T::Hash[T.untyped, T.untyped])) }
+  def owl_results; end
+
+  sig { params(value: T.nilable(T::Hash[T.untyped, T.untyped])).void }
+  def owl_results=(value); end
+
+  sig { returns(T::Boolean) }
+  def owl_results?; end
+
+  sig { returns(T.nilable(T.any(T::Array[T.untyped], T::Boolean, Float, T::Hash[T.untyped, T.untyped], Integer, String))) }
+  def patronus_characteristics; end
+
+  sig { params(value: T.nilable(T.any(T::Array[T.untyped], T::Boolean, Float, T::Hash[T.untyped, T.untyped], Integer, String))).void }
+  def patronus_characteristics=(value); end
+
+  sig { returns(T::Boolean) }
+  def patronus_characteristics?; end
+
+  sig { returns(T.nilable(T::Array[T.untyped])) }
+  def pets; end
+
+  sig { params(value: T.nilable(T::Array[T.untyped])).void }
+  def pets=(value); end
+
+  sig { returns(T::Boolean) }
+  def pets?; end
+end
+
 module Squib::GeneratedAttributeMethods
   sig { returns(T.nilable(String)) }
   def broom; end
@@ -365,6 +394,7 @@ end
 
 class Squib < Wizard
   include Squib::EnumInstanceMethods
+  include Squib::GeneratedSerializationMethods
   include Squib::GeneratedAttributeMethods
   include Squib::GeneratedAssociationMethods
   extend Squib::CustomFinderMethods

--- a/spec/test_data/v5.2/expected_squib.rbi
+++ b/spec/test_data/v5.2/expected_squib.rbi
@@ -112,6 +112,15 @@ module Squib::ActiveRelation_WhereNot
 end
 
 module Squib::GeneratedSerializationMethods
+  sig { returns(T.nilable(T.any(T::Array[T.untyped], T::Boolean, Float, T::Hash[T.untyped, T.untyped], Integer, String))) }
+  def newt_subjects; end
+
+  sig { params(value: T.nilable(T.any(T::Array[T.untyped], T::Boolean, Float, T::Hash[T.untyped, T.untyped], Integer, String))).void }
+  def newt_subjects=(value); end
+
+  sig { returns(T::Boolean) }
+  def newt_subjects?; end
+
   sig { returns(T.nilable(T::Hash[T.untyped, T.untyped])) }
   def owl_results; end
 

--- a/spec/test_data/v5.2/expected_squib.rbi
+++ b/spec/test_data/v5.2/expected_squib.rbi
@@ -111,7 +111,7 @@ module Squib::ActiveRelation_WhereNot
   def not(opts, *rest); end
 end
 
-module Squib::GeneratedSerializationMethods
+module Squib::GeneratedSerializedAttributeMethods
   sig { returns(T.nilable(T.any(T::Array[T.untyped], T::Boolean, Float, T::Hash[T.untyped, T.untyped], Integer, String))) }
   def newt_subjects; end
 
@@ -415,7 +415,7 @@ end
 
 class Squib < Wizard
   include Squib::EnumInstanceMethods
-  include Squib::GeneratedSerializationMethods
+  include Squib::GeneratedSerializedAttributeMethods
   include Squib::GeneratedAttributeMethods
   include Squib::GeneratedAssociationMethods
   extend Squib::CustomFinderMethods

--- a/spec/test_data/v5.2/expected_wizard.rbi
+++ b/spec/test_data/v5.2/expected_wizard.rbi
@@ -111,7 +111,7 @@ module Wizard::ActiveRelation_WhereNot
   def not(opts, *rest); end
 end
 
-module Wizard::GeneratedSerializationMethods
+module Wizard::GeneratedSerializedAttributeMethods
   sig { returns(T.nilable(T.any(T::Array[T.untyped], T::Boolean, Float, T::Hash[T.untyped, T.untyped], Integer, String))) }
   def newt_subjects; end
 
@@ -397,7 +397,7 @@ end
 
 class Wizard < ApplicationRecord
   include Wizard::EnumInstanceMethods
-  include Wizard::GeneratedSerializationMethods
+  include Wizard::GeneratedSerializedAttributeMethods
   include Wizard::GeneratedAttributeMethods
   include Wizard::GeneratedAssociationMethods
   extend Wizard::CustomFinderMethods

--- a/spec/test_data/v5.2/expected_wizard.rbi
+++ b/spec/test_data/v5.2/expected_wizard.rbi
@@ -112,6 +112,15 @@ module Wizard::ActiveRelation_WhereNot
 end
 
 module Wizard::GeneratedSerializationMethods
+  sig { returns(T.nilable(T.any(T::Array[T.untyped], T::Boolean, Float, T::Hash[T.untyped, T.untyped], Integer, String))) }
+  def newt_subjects; end
+
+  sig { params(value: T.nilable(T.any(T::Array[T.untyped], T::Boolean, Float, T::Hash[T.untyped, T.untyped], Integer, String))).void }
+  def newt_subjects=(value); end
+
+  sig { returns(T::Boolean) }
+  def newt_subjects?; end
+
   sig { returns(T.nilable(T::Hash[T.untyped, T.untyped])) }
   def owl_results; end
 

--- a/spec/test_data/v5.2/expected_wizard.rbi
+++ b/spec/test_data/v5.2/expected_wizard.rbi
@@ -111,6 +111,35 @@ module Wizard::ActiveRelation_WhereNot
   def not(opts, *rest); end
 end
 
+module Wizard::GeneratedSerializationMethods
+  sig { returns(T.nilable(T::Hash[T.untyped, T.untyped])) }
+  def owl_results; end
+
+  sig { params(value: T.nilable(T::Hash[T.untyped, T.untyped])).void }
+  def owl_results=(value); end
+
+  sig { returns(T::Boolean) }
+  def owl_results?; end
+
+  sig { returns(T.nilable(T.any(T::Array[T.untyped], T::Boolean, Float, T::Hash[T.untyped, T.untyped], Integer, String))) }
+  def patronus_characteristics; end
+
+  sig { params(value: T.nilable(T.any(T::Array[T.untyped], T::Boolean, Float, T::Hash[T.untyped, T.untyped], Integer, String))).void }
+  def patronus_characteristics=(value); end
+
+  sig { returns(T::Boolean) }
+  def patronus_characteristics?; end
+
+  sig { returns(T.nilable(T::Array[T.untyped])) }
+  def pets; end
+
+  sig { params(value: T.nilable(T::Array[T.untyped])).void }
+  def pets=(value); end
+
+  sig { returns(T::Boolean) }
+  def pets?; end
+end
+
 module Wizard::GeneratedAttributeMethods
   sig { returns(T::Boolean) }
   def broom?; end
@@ -347,6 +376,7 @@ end
 
 class Wizard < ApplicationRecord
   include Wizard::EnumInstanceMethods
+  include Wizard::GeneratedSerializationMethods
   include Wizard::GeneratedAttributeMethods
   include Wizard::GeneratedAssociationMethods
   extend Wizard::CustomFinderMethods

--- a/spec/test_data/v5.2/expected_wizard_wo_spellbook.rbi
+++ b/spec/test_data/v5.2/expected_wizard_wo_spellbook.rbi
@@ -111,7 +111,7 @@ module Wizard::ActiveRelation_WhereNot
   def not(opts, *rest); end
 end
 
-module Wizard::GeneratedSerializationMethods
+module Wizard::GeneratedSerializedAttributeMethods
   sig { returns(T.nilable(T.any(T::Array[T.untyped], T::Boolean, Float, T::Hash[T.untyped, T.untyped], Integer, String))) }
   def newt_subjects; end
 
@@ -391,7 +391,7 @@ end
 
 class Wizard < ApplicationRecord
   include Wizard::EnumInstanceMethods
-  include Wizard::GeneratedSerializationMethods
+  include Wizard::GeneratedSerializedAttributeMethods
   include Wizard::GeneratedAttributeMethods
   include Wizard::GeneratedAssociationMethods
   extend Wizard::CustomFinderMethods

--- a/spec/test_data/v5.2/expected_wizard_wo_spellbook.rbi
+++ b/spec/test_data/v5.2/expected_wizard_wo_spellbook.rbi
@@ -111,6 +111,35 @@ module Wizard::ActiveRelation_WhereNot
   def not(opts, *rest); end
 end
 
+module Wizard::GeneratedSerializationMethods
+  sig { returns(T.nilable(T::Hash[T.untyped, T.untyped])) }
+  def owl_results; end
+
+  sig { params(value: T.nilable(T::Hash[T.untyped, T.untyped])).void }
+  def owl_results=(value); end
+
+  sig { returns(T::Boolean) }
+  def owl_results?; end
+
+  sig { returns(T.nilable(T.any(T::Array[T.untyped], T::Boolean, Float, T::Hash[T.untyped, T.untyped], Integer, String))) }
+  def patronus_characteristics; end
+
+  sig { params(value: T.nilable(T.any(T::Array[T.untyped], T::Boolean, Float, T::Hash[T.untyped, T.untyped], Integer, String))).void }
+  def patronus_characteristics=(value); end
+
+  sig { returns(T::Boolean) }
+  def patronus_characteristics?; end
+
+  sig { returns(T.nilable(T::Array[T.untyped])) }
+  def pets; end
+
+  sig { params(value: T.nilable(T::Array[T.untyped])).void }
+  def pets=(value); end
+
+  sig { returns(T::Boolean) }
+  def pets?; end
+end
+
 module Wizard::GeneratedAttributeMethods
   sig { returns(T::Boolean) }
   def broom?; end
@@ -341,6 +370,7 @@ end
 
 class Wizard < ApplicationRecord
   include Wizard::EnumInstanceMethods
+  include Wizard::GeneratedSerializationMethods
   include Wizard::GeneratedAttributeMethods
   include Wizard::GeneratedAssociationMethods
   extend Wizard::CustomFinderMethods

--- a/spec/test_data/v5.2/expected_wizard_wo_spellbook.rbi
+++ b/spec/test_data/v5.2/expected_wizard_wo_spellbook.rbi
@@ -112,6 +112,15 @@ module Wizard::ActiveRelation_WhereNot
 end
 
 module Wizard::GeneratedSerializationMethods
+  sig { returns(T.nilable(T.any(T::Array[T.untyped], T::Boolean, Float, T::Hash[T.untyped, T.untyped], Integer, String))) }
+  def newt_subjects; end
+
+  sig { params(value: T.nilable(T.any(T::Array[T.untyped], T::Boolean, Float, T::Hash[T.untyped, T.untyped], Integer, String))).void }
+  def newt_subjects=(value); end
+
+  sig { returns(T::Boolean) }
+  def newt_subjects?; end
+
   sig { returns(T.nilable(T::Hash[T.untyped, T.untyped])) }
   def owl_results; end
 

--- a/spec/test_data/v6.0/expected_squib.rbi
+++ b/spec/test_data/v6.0/expected_squib.rbi
@@ -111,6 +111,35 @@ module Squib::ActiveRelation_WhereNot
   def not(opts, *rest); end
 end
 
+module Squib::GeneratedSerializationMethods
+  sig { returns(T.nilable(T::Hash[T.untyped, T.untyped])) }
+  def owl_results; end
+
+  sig { params(value: T.nilable(T::Hash[T.untyped, T.untyped])).void }
+  def owl_results=(value); end
+
+  sig { returns(T::Boolean) }
+  def owl_results?; end
+
+  sig { returns(T.nilable(T.any(T::Array[T.untyped], T::Boolean, Float, T::Hash[T.untyped, T.untyped], Integer, String))) }
+  def patronus_characteristics; end
+
+  sig { params(value: T.nilable(T.any(T::Array[T.untyped], T::Boolean, Float, T::Hash[T.untyped, T.untyped], Integer, String))).void }
+  def patronus_characteristics=(value); end
+
+  sig { returns(T::Boolean) }
+  def patronus_characteristics?; end
+
+  sig { returns(T.nilable(T::Array[T.untyped])) }
+  def pets; end
+
+  sig { params(value: T.nilable(T::Array[T.untyped])).void }
+  def pets=(value); end
+
+  sig { returns(T::Boolean) }
+  def pets?; end
+end
+
 module Squib::GeneratedAttributeMethods
   sig { returns(T.nilable(String)) }
   def broom; end
@@ -267,6 +296,7 @@ end
 
 class Squib < Wizard
   include Squib::EnumInstanceMethods
+  include Squib::GeneratedSerializationMethods
   include Squib::GeneratedAttributeMethods
   include Squib::GeneratedAssociationMethods
   extend Squib::CustomFinderMethods

--- a/spec/test_data/v6.0/expected_squib.rbi
+++ b/spec/test_data/v6.0/expected_squib.rbi
@@ -112,6 +112,15 @@ module Squib::ActiveRelation_WhereNot
 end
 
 module Squib::GeneratedSerializationMethods
+  sig { returns(T.nilable(T.any(T::Array[T.untyped], T::Boolean, Float, T::Hash[T.untyped, T.untyped], Integer, String))) }
+  def newt_subjects; end
+
+  sig { params(value: T.nilable(T.any(T::Array[T.untyped], T::Boolean, Float, T::Hash[T.untyped, T.untyped], Integer, String))).void }
+  def newt_subjects=(value); end
+
+  sig { returns(T::Boolean) }
+  def newt_subjects?; end
+
   sig { returns(T.nilable(T::Hash[T.untyped, T.untyped])) }
   def owl_results; end
 

--- a/spec/test_data/v6.0/expected_squib.rbi
+++ b/spec/test_data/v6.0/expected_squib.rbi
@@ -111,7 +111,7 @@ module Squib::ActiveRelation_WhereNot
   def not(opts, *rest); end
 end
 
-module Squib::GeneratedSerializationMethods
+module Squib::GeneratedSerializedAttributeMethods
   sig { returns(T.nilable(T.any(T::Array[T.untyped], T::Boolean, Float, T::Hash[T.untyped, T.untyped], Integer, String))) }
   def newt_subjects; end
 
@@ -305,7 +305,7 @@ end
 
 class Squib < Wizard
   include Squib::EnumInstanceMethods
-  include Squib::GeneratedSerializationMethods
+  include Squib::GeneratedSerializedAttributeMethods
   include Squib::GeneratedAttributeMethods
   include Squib::GeneratedAssociationMethods
   extend Squib::CustomFinderMethods

--- a/spec/test_data/v6.0/expected_wizard.rbi
+++ b/spec/test_data/v6.0/expected_wizard.rbi
@@ -112,6 +112,15 @@ module Wizard::ActiveRelation_WhereNot
 end
 
 module Wizard::GeneratedSerializationMethods
+  sig { returns(T.nilable(T.any(T::Array[T.untyped], T::Boolean, Float, T::Hash[T.untyped, T.untyped], Integer, String))) }
+  def newt_subjects; end
+
+  sig { params(value: T.nilable(T.any(T::Array[T.untyped], T::Boolean, Float, T::Hash[T.untyped, T.untyped], Integer, String))).void }
+  def newt_subjects=(value); end
+
+  sig { returns(T::Boolean) }
+  def newt_subjects?; end
+
   sig { returns(T.nilable(T::Hash[T.untyped, T.untyped])) }
   def owl_results; end
 

--- a/spec/test_data/v6.0/expected_wizard.rbi
+++ b/spec/test_data/v6.0/expected_wizard.rbi
@@ -111,6 +111,35 @@ module Wizard::ActiveRelation_WhereNot
   def not(opts, *rest); end
 end
 
+module Wizard::GeneratedSerializationMethods
+  sig { returns(T.nilable(T::Hash[T.untyped, T.untyped])) }
+  def owl_results; end
+
+  sig { params(value: T.nilable(T::Hash[T.untyped, T.untyped])).void }
+  def owl_results=(value); end
+
+  sig { returns(T::Boolean) }
+  def owl_results?; end
+
+  sig { returns(T.nilable(T.any(T::Array[T.untyped], T::Boolean, Float, T::Hash[T.untyped, T.untyped], Integer, String))) }
+  def patronus_characteristics; end
+
+  sig { params(value: T.nilable(T.any(T::Array[T.untyped], T::Boolean, Float, T::Hash[T.untyped, T.untyped], Integer, String))).void }
+  def patronus_characteristics=(value); end
+
+  sig { returns(T::Boolean) }
+  def patronus_characteristics?; end
+
+  sig { returns(T.nilable(T::Array[T.untyped])) }
+  def pets; end
+
+  sig { params(value: T.nilable(T::Array[T.untyped])).void }
+  def pets=(value); end
+
+  sig { returns(T::Boolean) }
+  def pets?; end
+end
+
 module Wizard::GeneratedAttributeMethods
   sig { returns(T::Boolean) }
   def broom?; end
@@ -249,6 +278,7 @@ end
 
 class Wizard < ApplicationRecord
   include Wizard::EnumInstanceMethods
+  include Wizard::GeneratedSerializationMethods
   include Wizard::GeneratedAttributeMethods
   include Wizard::GeneratedAssociationMethods
   extend Wizard::CustomFinderMethods

--- a/spec/test_data/v6.0/expected_wizard.rbi
+++ b/spec/test_data/v6.0/expected_wizard.rbi
@@ -111,7 +111,7 @@ module Wizard::ActiveRelation_WhereNot
   def not(opts, *rest); end
 end
 
-module Wizard::GeneratedSerializationMethods
+module Wizard::GeneratedSerializedAttributeMethods
   sig { returns(T.nilable(T.any(T::Array[T.untyped], T::Boolean, Float, T::Hash[T.untyped, T.untyped], Integer, String))) }
   def newt_subjects; end
 
@@ -287,7 +287,7 @@ end
 
 class Wizard < ApplicationRecord
   include Wizard::EnumInstanceMethods
-  include Wizard::GeneratedSerializationMethods
+  include Wizard::GeneratedSerializedAttributeMethods
   include Wizard::GeneratedAttributeMethods
   include Wizard::GeneratedAssociationMethods
   extend Wizard::CustomFinderMethods

--- a/spec/test_data/v6.0/expected_wizard_wo_spellbook.rbi
+++ b/spec/test_data/v6.0/expected_wizard_wo_spellbook.rbi
@@ -112,6 +112,15 @@ module Wizard::ActiveRelation_WhereNot
 end
 
 module Wizard::GeneratedSerializationMethods
+  sig { returns(T.nilable(T.any(T::Array[T.untyped], T::Boolean, Float, T::Hash[T.untyped, T.untyped], Integer, String))) }
+  def newt_subjects; end
+
+  sig { params(value: T.nilable(T.any(T::Array[T.untyped], T::Boolean, Float, T::Hash[T.untyped, T.untyped], Integer, String))).void }
+  def newt_subjects=(value); end
+
+  sig { returns(T::Boolean) }
+  def newt_subjects?; end
+
   sig { returns(T.nilable(T::Hash[T.untyped, T.untyped])) }
   def owl_results; end
 

--- a/spec/test_data/v6.0/expected_wizard_wo_spellbook.rbi
+++ b/spec/test_data/v6.0/expected_wizard_wo_spellbook.rbi
@@ -111,6 +111,35 @@ module Wizard::ActiveRelation_WhereNot
   def not(opts, *rest); end
 end
 
+module Wizard::GeneratedSerializationMethods
+  sig { returns(T.nilable(T::Hash[T.untyped, T.untyped])) }
+  def owl_results; end
+
+  sig { params(value: T.nilable(T::Hash[T.untyped, T.untyped])).void }
+  def owl_results=(value); end
+
+  sig { returns(T::Boolean) }
+  def owl_results?; end
+
+  sig { returns(T.nilable(T.any(T::Array[T.untyped], T::Boolean, Float, T::Hash[T.untyped, T.untyped], Integer, String))) }
+  def patronus_characteristics; end
+
+  sig { params(value: T.nilable(T.any(T::Array[T.untyped], T::Boolean, Float, T::Hash[T.untyped, T.untyped], Integer, String))).void }
+  def patronus_characteristics=(value); end
+
+  sig { returns(T::Boolean) }
+  def patronus_characteristics?; end
+
+  sig { returns(T.nilable(T::Array[T.untyped])) }
+  def pets; end
+
+  sig { params(value: T.nilable(T::Array[T.untyped])).void }
+  def pets=(value); end
+
+  sig { returns(T::Boolean) }
+  def pets?; end
+end
+
 module Wizard::GeneratedAttributeMethods
   sig { returns(T::Boolean) }
   def broom?; end
@@ -249,6 +278,7 @@ end
 
 class Wizard < ApplicationRecord
   include Wizard::EnumInstanceMethods
+  include Wizard::GeneratedSerializationMethods
   include Wizard::GeneratedAttributeMethods
   include Wizard::GeneratedAssociationMethods
   extend Wizard::CustomFinderMethods

--- a/spec/test_data/v6.0/expected_wizard_wo_spellbook.rbi
+++ b/spec/test_data/v6.0/expected_wizard_wo_spellbook.rbi
@@ -111,7 +111,7 @@ module Wizard::ActiveRelation_WhereNot
   def not(opts, *rest); end
 end
 
-module Wizard::GeneratedSerializationMethods
+module Wizard::GeneratedSerializedAttributeMethods
   sig { returns(T.nilable(T.any(T::Array[T.untyped], T::Boolean, Float, T::Hash[T.untyped, T.untyped], Integer, String))) }
   def newt_subjects; end
 
@@ -287,7 +287,7 @@ end
 
 class Wizard < ApplicationRecord
   include Wizard::EnumInstanceMethods
-  include Wizard::GeneratedSerializationMethods
+  include Wizard::GeneratedSerializedAttributeMethods
   include Wizard::GeneratedAttributeMethods
   include Wizard::GeneratedAssociationMethods
   extend Wizard::CustomFinderMethods


### PR DESCRIPTION
This PR adds support for `serialize` to ActiveRecord models.  

There are various "coders" (Hash, JSON) that have different type signatures which I've captured.  

I've got this running happily in production in our Rails app and I think I did everything right for the test suite, but please let me know if I've missed something.  I ran Ruby 2.6 locally and things were working.

```
./spec/bin/run_all_specs.sh
bundle exec srb tc
```
are both good.

An aside: whenever I'd regenerate the test Rails apps from the template (e.g. `bundle exec rake update_spec:v6_0`) I would get a ton of changes to the `typed` sigils in pretty much every Ruby file.  Is there another way that I'm missing?