### PR TITLE
pluck_to_tstruct - Use tstruct prop's default value if type isn't nilable and the plucked value is nil

### DIFF
--- a/lib/sorbet-rails/rails_mixins/pluck_to_tstruct.rb
+++ b/lib/sorbet-rails/rails_mixins/pluck_to_tstruct.rb
@@ -59,8 +59,9 @@ module SorbetRails::PluckToTStruct
   private def map_nil_values_to_default(tstruct_props, zipped_rows)
     # we use the default value defined on a prop if
     # 1. the plucked value is nil
-    # 2. the props type isn't nilable
-    # 3. the prop has a default
+    # 2. the prop has a default
+    # 3. the prop's type isn't nilable
+
     zipped_rows.map do |key, value|
       next [key, value] unless value.nil?
 

--- a/lib/sorbet-rails/rails_mixins/pluck_to_tstruct.rb
+++ b/lib/sorbet-rails/rails_mixins/pluck_to_tstruct.rb
@@ -64,11 +64,11 @@ module SorbetRails::PluckToTStruct
     zipped_rows.map do |key, value|
       next [key, value] unless value.nil?
 
-      type_object = tstruct_props.dig(key, :type_object)
-      next [key, value] if nilable?(type_object)
-
       default = tstruct_props.dig(key, :default)
       next [key, value] unless default
+
+      type_object = tstruct_props.dig(key, :type_object)
+      next [key, value] if nilable?(type_object)
 
       [key, default]
     end

--- a/spec/pluck_to_tstruct_spec.rb
+++ b/spec/pluck_to_tstruct_spec.rb
@@ -82,6 +82,18 @@ RSpec.describe SorbetRails::PluckToTStruct do
     end
   end
 
+  class WizardWithDefaultParentEmailT < T::Struct
+    const :name, String
+    const :house, String
+    const :parent_email, String, default: "hagrid@hogwarts.com"
+  end
+
+  class WizardWithDefaultNilableParentEmailT < T::Struct
+    const :name, String
+    const :house, String
+    const :parent_email, T.nilable(String), default: "hagrid@hogwarts.com"
+  end
+
   shared_examples 'pluck_to_tstruct' do |struct_type, expected_values|
     it 'plucks correctly from ActiveRecord model' do
       plucked = Wizard.pluck_to_tstruct(TA[struct_type].new)
@@ -148,5 +160,35 @@ RSpec.describe SorbetRails::PluckToTStruct do
     ]
 
     it_should_behave_like 'pluck_to_tstruct with associations', WizardWithWandT, associations, expected
+  end
+
+  context 'uses default value if prop type is not nilable and has default value' do
+    it_should_behave_like 'pluck_to_tstruct', WizardWithDefaultParentEmailT, [
+      WizardWithDefaultParentEmailT.new(
+        name: "Harry Potter",
+        house: "Gryffindor",
+        parent_email: "hagrid@hogwarts.com"
+      ),
+      WizardWithDefaultParentEmailT.new(
+        name: "Hermione Granger",
+        house: "Gryffindor",
+        parent_email: "hagrid@hogwarts.com"
+      ),
+    ]
+  end
+
+  context 'doesnt use default value if prop type is nilable even with a default value' do
+    it_should_behave_like 'pluck_to_tstruct', WizardWithDefaultNilableParentEmailT, [
+      WizardWithDefaultNilableParentEmailT.new(
+        name: "Harry Potter",
+        house: "Gryffindor",
+        parent_email: nil
+      ),
+      WizardWithDefaultNilableParentEmailT.new(
+        name: "Hermione Granger",
+        house: "Gryffindor",
+        parent_email: nil
+      ),
+    ]
   end
 end

--- a/spec/pluck_to_tstruct_spec.rb
+++ b/spec/pluck_to_tstruct_spec.rb
@@ -1,5 +1,6 @@
 require 'rails_helper'
 require 'sorbet-rails/model_rbi_formatter'
+require "tstruct_comparable"
 
 RSpec.describe SorbetRails::PluckToTStruct do
   let!(:harry) do
@@ -41,75 +42,40 @@ RSpec.describe SorbetRails::PluckToTStruct do
   end
 
   class WizardName < T::Struct
+    include TStructComparable
+
     const :name, String
-
-    def ==(other)
-      return false unless other.is_a?(self.class)
-      name == other.name
-    end
-
-    def eql?(other)
-      self == other
-    end
   end
 
   class WizardT < T::Struct
+    include TStructComparable
+
     const :name, String
     const :house, String
-
-    def ==(other)
-      return false unless other.is_a?(self.class)
-      name == other.name && house == other.house
-    end
-
-    def eql?(other)
-      self == other
-    end
   end
 
   class WizardWithWandT < T::Struct
+    include TStructComparable
+
     const :name, String
     const :house, String
     const :wand_wood_type, String
-
-    def ==(other)
-      return false unless other.is_a?(self.class)
-      name == other.name && house == other.house && wand_wood_type == other.wand_wood_type
-    end
-
-    def eql?(other)
-      self == other
-    end
   end
 
   class WizardWithDefaultParentEmailT < T::Struct
+    include TStructComparable
+
     const :name, String
     const :house, String
     const :parent_email, String, default: "hagrid@hogwarts.com"
-
-    def ==(other)
-      return false unless other.is_a?(self.class)
-      name == other.name && house == other.house && parent_email == other.parent_email
-    end
-
-    def eql?(other)
-      self == other
-    end
   end
 
   class WizardWithDefaultNilableParentEmailT < T::Struct
+    include TStructComparable
+
     const :name, String
     const :house, String
     const :parent_email, T.nilable(String), default: "hagrid@hogwarts.com"
-
-    def ==(other)
-      return false unless other.is_a?(self.class)
-      name == other.name && house == other.house && parent_email == other.parent_email
-    end
-
-    def eql?(other)
-      self == other
-    end
   end
 
   shared_examples 'pluck_to_tstruct' do |struct_type, expected_values|

--- a/spec/pluck_to_tstruct_spec.rb
+++ b/spec/pluck_to_tstruct_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe SorbetRails::PluckToTStruct do
 
     def ==(other)
       return false unless other.is_a?(self.class)
-      name == other.name && house == other.house
+      name == other.name && house == other.house && wand_wood_type == other.wand_wood_type
     end
 
     def eql?(other)
@@ -86,12 +86,30 @@ RSpec.describe SorbetRails::PluckToTStruct do
     const :name, String
     const :house, String
     const :parent_email, String, default: "hagrid@hogwarts.com"
+
+    def ==(other)
+      return false unless other.is_a?(self.class)
+      name == other.name && house == other.house && parent_email == other.parent_email
+    end
+
+    def eql?(other)
+      self == other
+    end
   end
 
   class WizardWithDefaultNilableParentEmailT < T::Struct
     const :name, String
     const :house, String
     const :parent_email, T.nilable(String), default: "hagrid@hogwarts.com"
+
+    def ==(other)
+      return false unless other.is_a?(self.class)
+      name == other.name && house == other.house && parent_email == other.parent_email
+    end
+
+    def eql?(other)
+      self == other
+    end
   end
 
   shared_examples 'pluck_to_tstruct' do |struct_type, expected_values|

--- a/spec/pluck_to_tstruct_spec.rb
+++ b/spec/pluck_to_tstruct_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 require 'sorbet-rails/model_rbi_formatter'
-require "tstruct_comparable"
+require 'tstruct_comparable'
 
 RSpec.describe SorbetRails::PluckToTStruct do
   let!(:harry) do

--- a/spec/tstruct_comparable.rb
+++ b/spec/tstruct_comparable.rb
@@ -1,0 +1,13 @@
+module TStructComparable
+  def ==(other)
+    return false unless other.is_a?(self.class)
+
+    self.class.props.keys.each do |prop|
+      self.send(prop) == other.send(prop)
+    end
+  end
+
+  def eql?(other)
+    self == other
+  end
+end

--- a/spec/tstruct_comparable.rb
+++ b/spec/tstruct_comparable.rb
@@ -2,7 +2,7 @@ module TStructComparable
   def ==(other)
     return false unless other.is_a?(self.class)
 
-    self.class.props.keys.each do |prop|
+    self.class.props.keys.all? do |prop|
       self.send(prop) == other.send(prop)
     end
   end


### PR DESCRIPTION
Consider this scenario
```ruby
class TUserStruct < T::Struct
  const :id, Integer
  const :name, String, default: "Unknown"
end

User.create!(name: nil)

# Below would throw a runtime type error because `nil` would be passed to `name` when the type is `String`
User.all.pluck_to_tstruct(TA[TUserStruct].new)
```

This PR makes it so that in this case `pluck_to_tstruct` will use the default value for the `name` prop ("Unknown") instead of throwing a type error

I decided to only allow this behaviour if the type isn't nilable because if the type is nilable then I assume we'd be explicitly saying we don't want to use the default in that case I guess? Keen for thoughts