### PR TITLE
Add reload_<assoc> methods for single associations to model assoc plugin

### DIFF
--- a/lib/sorbet-rails/model_plugins/active_record_assoc.rb
+++ b/lib/sorbet-rails/model_plugins/active_record_assoc.rb
@@ -67,6 +67,10 @@ class SorbetRails::ModelPlugins::ActiveRecordAssoc < SorbetRails::ModelPlugins::
       ],
       return_type: nil,
     )
+    assoc_module_rbi.create_method(
+      "reload_#{assoc_name}",
+      return_type: assoc_type,
+    )
   end
 
   sig { params(reflection: T.untyped).returns(T::Boolean) }

--- a/spec/test_data/v5.0/expected_headmaster.rbi
+++ b/spec/test_data/v5.0/expected_headmaster.rbi
@@ -52,6 +52,9 @@ module Headmaster::GeneratedAssociationMethods
   sig { params(value: ::School).void }
   def school=(value); end
 
+  sig { returns(::School) }
+  def reload_school; end
+
   sig { returns(::Wizard) }
   def wizard; end
 
@@ -66,6 +69,9 @@ module Headmaster::GeneratedAssociationMethods
 
   sig { params(value: ::Wizard).void }
   def wizard=(value); end
+
+  sig { returns(::Wizard) }
+  def reload_wizard; end
 end
 
 module Headmaster::CustomFinderMethods

--- a/spec/test_data/v5.0/expected_potion.rbi
+++ b/spec/test_data/v5.0/expected_potion.rbi
@@ -22,6 +22,9 @@ module Potion::GeneratedAssociationMethods
 
   sig { params(value: T.nilable(::Wizard)).void }
   def wizard=(value); end
+
+  sig { returns(T.nilable(::Wizard)) }
+  def reload_wizard; end
 end
 
 module Potion::CustomFinderMethods

--- a/spec/test_data/v5.0/expected_robe.rbi
+++ b/spec/test_data/v5.0/expected_robe.rbi
@@ -42,6 +42,9 @@ module Robe::GeneratedAssociationMethods
 
   sig { params(value: T.nilable(::Wizard)).void }
   def wizard=(value); end
+
+  sig { returns(T.nilable(::Wizard)) }
+  def reload_wizard; end
 end
 
 module Robe::CustomFinderMethods

--- a/spec/test_data/v5.0/expected_school.rbi
+++ b/spec/test_data/v5.0/expected_school.rbi
@@ -42,6 +42,9 @@ module School::GeneratedAssociationMethods
 
   sig { params(value: ::Headmaster).void }
   def headmaster=(value); end
+
+  sig { returns(::Headmaster) }
+  def reload_headmaster; end
 end
 
 module School::CustomFinderMethods

--- a/spec/test_data/v5.0/expected_spell/habtm_spell_books.rbi
+++ b/spec/test_data/v5.0/expected_spell/habtm_spell_books.rbi
@@ -43,6 +43,9 @@ module Spell::HABTM_SpellBooks::GeneratedAssociationMethods
   sig { params(value: T.nilable(::Spell)).void }
   def left_side=(value); end
 
+  sig { returns(T.nilable(::Spell)) }
+  def reload_left_side; end
+
   sig { returns(::SpellBook) }
   def spell_book; end
 
@@ -57,6 +60,9 @@ module Spell::HABTM_SpellBooks::GeneratedAssociationMethods
 
   sig { params(value: ::SpellBook).void }
   def spell_book=(value); end
+
+  sig { returns(::SpellBook) }
+  def reload_spell_book; end
 end
 
 module Spell::HABTM_SpellBooks::CustomFinderMethods

--- a/spec/test_data/v5.0/expected_spell_book.rbi
+++ b/spec/test_data/v5.0/expected_spell_book.rbi
@@ -89,6 +89,9 @@ module SpellBook::GeneratedAssociationMethods
 
   sig { params(value: ::Wizard).void }
   def wizard=(value); end
+
+  sig { returns(::Wizard) }
+  def reload_wizard; end
 end
 
 module SpellBook::CustomFinderMethods

--- a/spec/test_data/v5.0/expected_spell_book/habtm_spells.rbi
+++ b/spec/test_data/v5.0/expected_spell_book/habtm_spells.rbi
@@ -43,6 +43,9 @@ module SpellBook::HABTM_Spells::GeneratedAssociationMethods
   sig { params(value: T.nilable(::SpellBook)).void }
   def left_side=(value); end
 
+  sig { returns(T.nilable(::SpellBook)) }
+  def reload_left_side; end
+
   sig { returns(::Spell) }
   def spell; end
 
@@ -57,6 +60,9 @@ module SpellBook::HABTM_Spells::GeneratedAssociationMethods
 
   sig { params(value: ::Spell).void }
   def spell=(value); end
+
+  sig { returns(::Spell) }
+  def reload_spell; end
 end
 
 module SpellBook::HABTM_Spells::CustomFinderMethods

--- a/spec/test_data/v5.0/expected_squib.rbi
+++ b/spec/test_data/v5.0/expected_squib.rbi
@@ -264,6 +264,9 @@ module Squib::GeneratedAssociationMethods
   sig { params(value: T.nilable(::School)).void }
   def school=(value); end
 
+  sig { returns(T.nilable(::School)) }
+  def reload_school; end
+
   sig { returns(::SpellBook::ActiveRecord_Associations_CollectionProxy) }
   def spell_books; end
 
@@ -296,6 +299,9 @@ module Squib::GeneratedAssociationMethods
 
   sig { params(value: T.nilable(::Wand)).void }
   def wand=(value); end
+
+  sig { returns(T.nilable(::Wand)) }
+  def reload_wand; end
 end
 
 module Squib::CustomFinderMethods

--- a/spec/test_data/v5.0/expected_subject/habtm_wizards.rbi
+++ b/spec/test_data/v5.0/expected_subject/habtm_wizards.rbi
@@ -43,6 +43,9 @@ module Subject::HABTM_Wizards::GeneratedAssociationMethods
   sig { params(value: T.nilable(::Subject)).void }
   def left_side=(value); end
 
+  sig { returns(T.nilable(::Subject)) }
+  def reload_left_side; end
+
   sig { returns(T.nilable(::Wizard)) }
   def wizard; end
 
@@ -57,6 +60,9 @@ module Subject::HABTM_Wizards::GeneratedAssociationMethods
 
   sig { params(value: T.nilable(::Wizard)).void }
   def wizard=(value); end
+
+  sig { returns(T.nilable(::Wizard)) }
+  def reload_wizard; end
 end
 
 module Subject::HABTM_Wizards::CustomFinderMethods

--- a/spec/test_data/v5.0/expected_wand.rbi
+++ b/spec/test_data/v5.0/expected_wand.rbi
@@ -167,6 +167,9 @@ module Wand::GeneratedAssociationMethods
 
   sig { params(value: ::Wizard).void }
   def wizard=(value); end
+
+  sig { returns(::Wizard) }
+  def reload_wizard; end
 end
 
 module Wand::CustomFinderMethods

--- a/spec/test_data/v5.0/expected_wizard.rbi
+++ b/spec/test_data/v5.0/expected_wizard.rbi
@@ -246,6 +246,9 @@ module Wizard::GeneratedAssociationMethods
   sig { params(value: T.nilable(::School)).void }
   def school=(value); end
 
+  sig { returns(T.nilable(::School)) }
+  def reload_school; end
+
   sig { returns(::SpellBook::ActiveRecord_Associations_CollectionProxy) }
   def spell_books; end
 
@@ -278,6 +281,9 @@ module Wizard::GeneratedAssociationMethods
 
   sig { params(value: T.nilable(::Wand)).void }
   def wand=(value); end
+
+  sig { returns(T.nilable(::Wand)) }
+  def reload_wand; end
 end
 
 module Wizard::CustomFinderMethods

--- a/spec/test_data/v5.0/expected_wizard/habtm_subjects.rbi
+++ b/spec/test_data/v5.0/expected_wizard/habtm_subjects.rbi
@@ -43,6 +43,9 @@ module Wizard::HABTM_Subjects::GeneratedAssociationMethods
   sig { params(value: T.nilable(::Wizard)).void }
   def left_side=(value); end
 
+  sig { returns(T.nilable(::Wizard)) }
+  def reload_left_side; end
+
   sig { returns(T.nilable(::Subject)) }
   def subject; end
 
@@ -57,6 +60,9 @@ module Wizard::HABTM_Subjects::GeneratedAssociationMethods
 
   sig { params(value: T.nilable(::Subject)).void }
   def subject=(value); end
+
+  sig { returns(T.nilable(::Subject)) }
+  def reload_subject; end
 end
 
 module Wizard::HABTM_Subjects::CustomFinderMethods

--- a/spec/test_data/v5.0/expected_wizard_wo_spellbook.rbi
+++ b/spec/test_data/v5.0/expected_wizard_wo_spellbook.rbi
@@ -246,6 +246,9 @@ module Wizard::GeneratedAssociationMethods
   sig { params(value: T.nilable(T.untyped)).void }
   def school=(value); end
 
+  sig { returns(T.nilable(T.untyped)) }
+  def reload_school; end
+
   sig { returns(ActiveRecord::Associations::CollectionProxy) }
   def spell_books; end
 
@@ -272,6 +275,9 @@ module Wizard::GeneratedAssociationMethods
 
   sig { params(value: T.nilable(::Wand)).void }
   def wand=(value); end
+
+  sig { returns(T.nilable(::Wand)) }
+  def reload_wand; end
 end
 
 module Wizard::CustomFinderMethods

--- a/spec/test_data/v5.1/expected_headmaster.rbi
+++ b/spec/test_data/v5.1/expected_headmaster.rbi
@@ -52,6 +52,9 @@ module Headmaster::GeneratedAssociationMethods
   sig { params(value: ::School).void }
   def school=(value); end
 
+  sig { returns(::School) }
+  def reload_school; end
+
   sig { returns(::Wizard) }
   def wizard; end
 
@@ -66,6 +69,9 @@ module Headmaster::GeneratedAssociationMethods
 
   sig { params(value: ::Wizard).void }
   def wizard=(value); end
+
+  sig { returns(::Wizard) }
+  def reload_wizard; end
 end
 
 module Headmaster::CustomFinderMethods

--- a/spec/test_data/v5.1/expected_potion.rbi
+++ b/spec/test_data/v5.1/expected_potion.rbi
@@ -22,6 +22,9 @@ module Potion::GeneratedAssociationMethods
 
   sig { params(value: T.nilable(::Wizard)).void }
   def wizard=(value); end
+
+  sig { returns(T.nilable(::Wizard)) }
+  def reload_wizard; end
 end
 
 module Potion::CustomFinderMethods

--- a/spec/test_data/v5.1/expected_robe.rbi
+++ b/spec/test_data/v5.1/expected_robe.rbi
@@ -42,6 +42,9 @@ module Robe::GeneratedAssociationMethods
 
   sig { params(value: T.nilable(::Wizard)).void }
   def wizard=(value); end
+
+  sig { returns(T.nilable(::Wizard)) }
+  def reload_wizard; end
 end
 
 module Robe::CustomFinderMethods

--- a/spec/test_data/v5.1/expected_school.rbi
+++ b/spec/test_data/v5.1/expected_school.rbi
@@ -42,6 +42,9 @@ module School::GeneratedAssociationMethods
 
   sig { params(value: ::Headmaster).void }
   def headmaster=(value); end
+
+  sig { returns(::Headmaster) }
+  def reload_headmaster; end
 end
 
 module School::CustomFinderMethods

--- a/spec/test_data/v5.1/expected_spell/habtm_spell_books.rbi
+++ b/spec/test_data/v5.1/expected_spell/habtm_spell_books.rbi
@@ -43,6 +43,9 @@ module Spell::HABTM_SpellBooks::GeneratedAssociationMethods
   sig { params(value: T.nilable(::Spell)).void }
   def left_side=(value); end
 
+  sig { returns(T.nilable(::Spell)) }
+  def reload_left_side; end
+
   sig { returns(::SpellBook) }
   def spell_book; end
 
@@ -57,6 +60,9 @@ module Spell::HABTM_SpellBooks::GeneratedAssociationMethods
 
   sig { params(value: ::SpellBook).void }
   def spell_book=(value); end
+
+  sig { returns(::SpellBook) }
+  def reload_spell_book; end
 end
 
 module Spell::HABTM_SpellBooks::CustomFinderMethods

--- a/spec/test_data/v5.1/expected_spell_book.rbi
+++ b/spec/test_data/v5.1/expected_spell_book.rbi
@@ -89,6 +89,9 @@ module SpellBook::GeneratedAssociationMethods
 
   sig { params(value: ::Wizard).void }
   def wizard=(value); end
+
+  sig { returns(::Wizard) }
+  def reload_wizard; end
 end
 
 module SpellBook::CustomFinderMethods

--- a/spec/test_data/v5.1/expected_spell_book/habtm_spells.rbi
+++ b/spec/test_data/v5.1/expected_spell_book/habtm_spells.rbi
@@ -43,6 +43,9 @@ module SpellBook::HABTM_Spells::GeneratedAssociationMethods
   sig { params(value: T.nilable(::SpellBook)).void }
   def left_side=(value); end
 
+  sig { returns(T.nilable(::SpellBook)) }
+  def reload_left_side; end
+
   sig { returns(::Spell) }
   def spell; end
 
@@ -57,6 +60,9 @@ module SpellBook::HABTM_Spells::GeneratedAssociationMethods
 
   sig { params(value: ::Spell).void }
   def spell=(value); end
+
+  sig { returns(::Spell) }
+  def reload_spell; end
 end
 
 module SpellBook::HABTM_Spells::CustomFinderMethods

--- a/spec/test_data/v5.1/expected_squib.rbi
+++ b/spec/test_data/v5.1/expected_squib.rbi
@@ -264,6 +264,9 @@ module Squib::GeneratedAssociationMethods
   sig { params(value: T.nilable(::School)).void }
   def school=(value); end
 
+  sig { returns(T.nilable(::School)) }
+  def reload_school; end
+
   sig { returns(::SpellBook::ActiveRecord_Associations_CollectionProxy) }
   def spell_books; end
 
@@ -296,6 +299,9 @@ module Squib::GeneratedAssociationMethods
 
   sig { params(value: T.nilable(::Wand)).void }
   def wand=(value); end
+
+  sig { returns(T.nilable(::Wand)) }
+  def reload_wand; end
 end
 
 module Squib::CustomFinderMethods

--- a/spec/test_data/v5.1/expected_subject/habtm_wizards.rbi
+++ b/spec/test_data/v5.1/expected_subject/habtm_wizards.rbi
@@ -43,6 +43,9 @@ module Subject::HABTM_Wizards::GeneratedAssociationMethods
   sig { params(value: T.nilable(::Subject)).void }
   def left_side=(value); end
 
+  sig { returns(T.nilable(::Subject)) }
+  def reload_left_side; end
+
   sig { returns(T.nilable(::Wizard)) }
   def wizard; end
 
@@ -57,6 +60,9 @@ module Subject::HABTM_Wizards::GeneratedAssociationMethods
 
   sig { params(value: T.nilable(::Wizard)).void }
   def wizard=(value); end
+
+  sig { returns(T.nilable(::Wizard)) }
+  def reload_wizard; end
 end
 
 module Subject::HABTM_Wizards::CustomFinderMethods

--- a/spec/test_data/v5.1/expected_wand.rbi
+++ b/spec/test_data/v5.1/expected_wand.rbi
@@ -167,6 +167,9 @@ module Wand::GeneratedAssociationMethods
 
   sig { params(value: ::Wizard).void }
   def wizard=(value); end
+
+  sig { returns(::Wizard) }
+  def reload_wizard; end
 end
 
 module Wand::CustomFinderMethods

--- a/spec/test_data/v5.1/expected_wizard.rbi
+++ b/spec/test_data/v5.1/expected_wizard.rbi
@@ -246,6 +246,9 @@ module Wizard::GeneratedAssociationMethods
   sig { params(value: T.nilable(::School)).void }
   def school=(value); end
 
+  sig { returns(T.nilable(::School)) }
+  def reload_school; end
+
   sig { returns(::SpellBook::ActiveRecord_Associations_CollectionProxy) }
   def spell_books; end
 
@@ -278,6 +281,9 @@ module Wizard::GeneratedAssociationMethods
 
   sig { params(value: T.nilable(::Wand)).void }
   def wand=(value); end
+
+  sig { returns(T.nilable(::Wand)) }
+  def reload_wand; end
 end
 
 module Wizard::CustomFinderMethods

--- a/spec/test_data/v5.1/expected_wizard/habtm_subjects.rbi
+++ b/spec/test_data/v5.1/expected_wizard/habtm_subjects.rbi
@@ -43,6 +43,9 @@ module Wizard::HABTM_Subjects::GeneratedAssociationMethods
   sig { params(value: T.nilable(::Wizard)).void }
   def left_side=(value); end
 
+  sig { returns(T.nilable(::Wizard)) }
+  def reload_left_side; end
+
   sig { returns(T.nilable(::Subject)) }
   def subject; end
 
@@ -57,6 +60,9 @@ module Wizard::HABTM_Subjects::GeneratedAssociationMethods
 
   sig { params(value: T.nilable(::Subject)).void }
   def subject=(value); end
+
+  sig { returns(T.nilable(::Subject)) }
+  def reload_subject; end
 end
 
 module Wizard::HABTM_Subjects::CustomFinderMethods

--- a/spec/test_data/v5.1/expected_wizard_wo_spellbook.rbi
+++ b/spec/test_data/v5.1/expected_wizard_wo_spellbook.rbi
@@ -246,6 +246,9 @@ module Wizard::GeneratedAssociationMethods
   sig { params(value: T.nilable(T.untyped)).void }
   def school=(value); end
 
+  sig { returns(T.nilable(T.untyped)) }
+  def reload_school; end
+
   sig { returns(ActiveRecord::Associations::CollectionProxy) }
   def spell_books; end
 
@@ -272,6 +275,9 @@ module Wizard::GeneratedAssociationMethods
 
   sig { params(value: T.nilable(::Wand)).void }
   def wand=(value); end
+
+  sig { returns(T.nilable(::Wand)) }
+  def reload_wand; end
 end
 
 module Wizard::CustomFinderMethods

--- a/spec/test_data/v5.2/expected_attachment.rbi
+++ b/spec/test_data/v5.2/expected_attachment.rbi
@@ -23,6 +23,9 @@ module ActiveStorage::Attachment::GeneratedAssociationMethods
   sig { params(value: ::ActiveStorage::Blob).void }
   def blob=(value); end
 
+  sig { returns(::ActiveStorage::Blob) }
+  def reload_blob; end
+
   sig { returns(T.untyped) }
   def record; end
 
@@ -37,6 +40,9 @@ module ActiveStorage::Attachment::GeneratedAssociationMethods
 
   sig { params(value: T.untyped).void }
   def record=(value); end
+
+  sig { returns(T.untyped) }
+  def reload_record; end
 end
 
 module ActiveStorage::Attachment::CustomFinderMethods

--- a/spec/test_data/v5.2/expected_blob.rbi
+++ b/spec/test_data/v5.2/expected_blob.rbi
@@ -32,6 +32,9 @@ module ActiveStorage::Blob::GeneratedAssociationMethods
   sig { params(value: T.nilable(::ActiveStorage::Attachment)).void }
   def preview_image_attachment=(value); end
 
+  sig { returns(T.nilable(::ActiveStorage::Attachment)) }
+  def reload_preview_image_attachment; end
+
   sig { returns(T.nilable(::ActiveStorage::Blob)) }
   def preview_image_blob; end
 
@@ -46,6 +49,9 @@ module ActiveStorage::Blob::GeneratedAssociationMethods
 
   sig { params(value: T.nilable(::ActiveStorage::Blob)).void }
   def preview_image_blob=(value); end
+
+  sig { returns(T.nilable(::ActiveStorage::Blob)) }
+  def reload_preview_image_blob; end
 end
 
 module ActiveStorage::Blob::CustomFinderMethods

--- a/spec/test_data/v5.2/expected_headmaster.rbi
+++ b/spec/test_data/v5.2/expected_headmaster.rbi
@@ -52,6 +52,9 @@ module Headmaster::GeneratedAssociationMethods
   sig { params(value: ::School).void }
   def school=(value); end
 
+  sig { returns(::School) }
+  def reload_school; end
+
   sig { returns(::Wizard) }
   def wizard; end
 
@@ -66,6 +69,9 @@ module Headmaster::GeneratedAssociationMethods
 
   sig { params(value: ::Wizard).void }
   def wizard=(value); end
+
+  sig { returns(::Wizard) }
+  def reload_wizard; end
 end
 
 module Headmaster::CustomFinderMethods

--- a/spec/test_data/v5.2/expected_potion.rbi
+++ b/spec/test_data/v5.2/expected_potion.rbi
@@ -22,6 +22,9 @@ module Potion::GeneratedAssociationMethods
 
   sig { params(value: T.nilable(::Wizard)).void }
   def wizard=(value); end
+
+  sig { returns(T.nilable(::Wizard)) }
+  def reload_wizard; end
 end
 
 module Potion::CustomFinderMethods

--- a/spec/test_data/v5.2/expected_robe.rbi
+++ b/spec/test_data/v5.2/expected_robe.rbi
@@ -42,6 +42,9 @@ module Robe::GeneratedAssociationMethods
 
   sig { params(value: T.nilable(::Wizard)).void }
   def wizard=(value); end
+
+  sig { returns(T.nilable(::Wizard)) }
+  def reload_wizard; end
 end
 
 module Robe::CustomFinderMethods

--- a/spec/test_data/v5.2/expected_school.rbi
+++ b/spec/test_data/v5.2/expected_school.rbi
@@ -42,6 +42,9 @@ module School::GeneratedAssociationMethods
 
   sig { params(value: ::Headmaster).void }
   def headmaster=(value); end
+
+  sig { returns(::Headmaster) }
+  def reload_headmaster; end
 end
 
 module School::CustomFinderMethods

--- a/spec/test_data/v5.2/expected_spell/habtm_spell_books.rbi
+++ b/spec/test_data/v5.2/expected_spell/habtm_spell_books.rbi
@@ -43,6 +43,9 @@ module Spell::HABTM_SpellBooks::GeneratedAssociationMethods
   sig { params(value: T.nilable(::Spell)).void }
   def left_side=(value); end
 
+  sig { returns(T.nilable(::Spell)) }
+  def reload_left_side; end
+
   sig { returns(::SpellBook) }
   def spell_book; end
 
@@ -57,6 +60,9 @@ module Spell::HABTM_SpellBooks::GeneratedAssociationMethods
 
   sig { params(value: ::SpellBook).void }
   def spell_book=(value); end
+
+  sig { returns(::SpellBook) }
+  def reload_spell_book; end
 end
 
 module Spell::HABTM_SpellBooks::CustomFinderMethods

--- a/spec/test_data/v5.2/expected_spell_book.rbi
+++ b/spec/test_data/v5.2/expected_spell_book.rbi
@@ -89,6 +89,9 @@ module SpellBook::GeneratedAssociationMethods
 
   sig { params(value: ::Wizard).void }
   def wizard=(value); end
+
+  sig { returns(::Wizard) }
+  def reload_wizard; end
 end
 
 module SpellBook::CustomFinderMethods

--- a/spec/test_data/v5.2/expected_spell_book/habtm_spells.rbi
+++ b/spec/test_data/v5.2/expected_spell_book/habtm_spells.rbi
@@ -43,6 +43,9 @@ module SpellBook::HABTM_Spells::GeneratedAssociationMethods
   sig { params(value: T.nilable(::SpellBook)).void }
   def left_side=(value); end
 
+  sig { returns(T.nilable(::SpellBook)) }
+  def reload_left_side; end
+
   sig { returns(::Spell) }
   def spell; end
 
@@ -57,6 +60,9 @@ module SpellBook::HABTM_Spells::GeneratedAssociationMethods
 
   sig { params(value: ::Spell).void }
   def spell=(value); end
+
+  sig { returns(::Spell) }
+  def reload_spell; end
 end
 
 module SpellBook::HABTM_Spells::CustomFinderMethods

--- a/spec/test_data/v5.2/expected_squib.rbi
+++ b/spec/test_data/v5.2/expected_squib.rbi
@@ -282,6 +282,9 @@ module Squib::GeneratedAssociationMethods
   sig { params(value: T.nilable(::School)).void }
   def school=(value); end
 
+  sig { returns(T.nilable(::School)) }
+  def reload_school; end
+
   sig { returns(T.nilable(::ActiveStorage::Attachment)) }
   def school_photo_attachment; end
 
@@ -297,6 +300,9 @@ module Squib::GeneratedAssociationMethods
   sig { params(value: T.nilable(::ActiveStorage::Attachment)).void }
   def school_photo_attachment=(value); end
 
+  sig { returns(T.nilable(::ActiveStorage::Attachment)) }
+  def reload_school_photo_attachment; end
+
   sig { returns(T.nilable(::ActiveStorage::Blob)) }
   def school_photo_blob; end
 
@@ -311,6 +317,9 @@ module Squib::GeneratedAssociationMethods
 
   sig { params(value: T.nilable(::ActiveStorage::Blob)).void }
   def school_photo_blob=(value); end
+
+  sig { returns(T.nilable(::ActiveStorage::Blob)) }
+  def reload_school_photo_blob; end
 
   sig { returns(::SpellBook::ActiveRecord_Associations_CollectionProxy) }
   def spell_books; end
@@ -344,6 +353,9 @@ module Squib::GeneratedAssociationMethods
 
   sig { params(value: T.nilable(::Wand)).void }
   def wand=(value); end
+
+  sig { returns(T.nilable(::Wand)) }
+  def reload_wand; end
 end
 
 module Squib::CustomFinderMethods

--- a/spec/test_data/v5.2/expected_subject/habtm_wizards.rbi
+++ b/spec/test_data/v5.2/expected_subject/habtm_wizards.rbi
@@ -43,6 +43,9 @@ module Subject::HABTM_Wizards::GeneratedAssociationMethods
   sig { params(value: T.nilable(::Subject)).void }
   def left_side=(value); end
 
+  sig { returns(T.nilable(::Subject)) }
+  def reload_left_side; end
+
   sig { returns(T.nilable(::Wizard)) }
   def wizard; end
 
@@ -57,6 +60,9 @@ module Subject::HABTM_Wizards::GeneratedAssociationMethods
 
   sig { params(value: T.nilable(::Wizard)).void }
   def wizard=(value); end
+
+  sig { returns(T.nilable(::Wizard)) }
+  def reload_wizard; end
 end
 
 module Subject::HABTM_Wizards::CustomFinderMethods

--- a/spec/test_data/v5.2/expected_wand.rbi
+++ b/spec/test_data/v5.2/expected_wand.rbi
@@ -185,6 +185,9 @@ module Wand::GeneratedAssociationMethods
 
   sig { params(value: ::Wizard).void }
   def wizard=(value); end
+
+  sig { returns(::Wizard) }
+  def reload_wizard; end
 end
 
 module Wand::CustomFinderMethods

--- a/spec/test_data/v5.2/expected_wizard.rbi
+++ b/spec/test_data/v5.2/expected_wizard.rbi
@@ -264,6 +264,9 @@ module Wizard::GeneratedAssociationMethods
   sig { params(value: T.nilable(::School)).void }
   def school=(value); end
 
+  sig { returns(T.nilable(::School)) }
+  def reload_school; end
+
   sig { returns(T.nilable(::ActiveStorage::Attachment)) }
   def school_photo_attachment; end
 
@@ -279,6 +282,9 @@ module Wizard::GeneratedAssociationMethods
   sig { params(value: T.nilable(::ActiveStorage::Attachment)).void }
   def school_photo_attachment=(value); end
 
+  sig { returns(T.nilable(::ActiveStorage::Attachment)) }
+  def reload_school_photo_attachment; end
+
   sig { returns(T.nilable(::ActiveStorage::Blob)) }
   def school_photo_blob; end
 
@@ -293,6 +299,9 @@ module Wizard::GeneratedAssociationMethods
 
   sig { params(value: T.nilable(::ActiveStorage::Blob)).void }
   def school_photo_blob=(value); end
+
+  sig { returns(T.nilable(::ActiveStorage::Blob)) }
+  def reload_school_photo_blob; end
 
   sig { returns(::SpellBook::ActiveRecord_Associations_CollectionProxy) }
   def spell_books; end
@@ -326,6 +335,9 @@ module Wizard::GeneratedAssociationMethods
 
   sig { params(value: T.nilable(::Wand)).void }
   def wand=(value); end
+
+  sig { returns(T.nilable(::Wand)) }
+  def reload_wand; end
 end
 
 module Wizard::CustomFinderMethods

--- a/spec/test_data/v5.2/expected_wizard/habtm_subjects.rbi
+++ b/spec/test_data/v5.2/expected_wizard/habtm_subjects.rbi
@@ -43,6 +43,9 @@ module Wizard::HABTM_Subjects::GeneratedAssociationMethods
   sig { params(value: T.nilable(::Wizard)).void }
   def left_side=(value); end
 
+  sig { returns(T.nilable(::Wizard)) }
+  def reload_left_side; end
+
   sig { returns(T.nilable(::Subject)) }
   def subject; end
 
@@ -57,6 +60,9 @@ module Wizard::HABTM_Subjects::GeneratedAssociationMethods
 
   sig { params(value: T.nilable(::Subject)).void }
   def subject=(value); end
+
+  sig { returns(T.nilable(::Subject)) }
+  def reload_subject; end
 end
 
 module Wizard::HABTM_Subjects::CustomFinderMethods

--- a/spec/test_data/v5.2/expected_wizard_wo_spellbook.rbi
+++ b/spec/test_data/v5.2/expected_wizard_wo_spellbook.rbi
@@ -264,6 +264,9 @@ module Wizard::GeneratedAssociationMethods
   sig { params(value: T.nilable(T.untyped)).void }
   def school=(value); end
 
+  sig { returns(T.nilable(T.untyped)) }
+  def reload_school; end
+
   sig { returns(T.nilable(::ActiveStorage::Attachment)) }
   def school_photo_attachment; end
 
@@ -279,6 +282,9 @@ module Wizard::GeneratedAssociationMethods
   sig { params(value: T.nilable(::ActiveStorage::Attachment)).void }
   def school_photo_attachment=(value); end
 
+  sig { returns(T.nilable(::ActiveStorage::Attachment)) }
+  def reload_school_photo_attachment; end
+
   sig { returns(T.nilable(::ActiveStorage::Blob)) }
   def school_photo_blob; end
 
@@ -293,6 +299,9 @@ module Wizard::GeneratedAssociationMethods
 
   sig { params(value: T.nilable(::ActiveStorage::Blob)).void }
   def school_photo_blob=(value); end
+
+  sig { returns(T.nilable(::ActiveStorage::Blob)) }
+  def reload_school_photo_blob; end
 
   sig { returns(ActiveRecord::Associations::CollectionProxy) }
   def spell_books; end
@@ -320,6 +329,9 @@ module Wizard::GeneratedAssociationMethods
 
   sig { params(value: T.nilable(::Wand)).void }
   def wand=(value); end
+
+  sig { returns(T.nilable(::Wand)) }
+  def reload_wand; end
 end
 
 module Wizard::CustomFinderMethods

--- a/spec/test_data/v6.0/expected_attachment.rbi
+++ b/spec/test_data/v6.0/expected_attachment.rbi
@@ -23,6 +23,9 @@ module ActiveStorage::Attachment::GeneratedAssociationMethods
   sig { params(value: ::ActiveStorage::Blob).void }
   def blob=(value); end
 
+  sig { returns(::ActiveStorage::Blob) }
+  def reload_blob; end
+
   sig { returns(T.untyped) }
   def record; end
 
@@ -37,6 +40,9 @@ module ActiveStorage::Attachment::GeneratedAssociationMethods
 
   sig { params(value: T.untyped).void }
   def record=(value); end
+
+  sig { returns(T.untyped) }
+  def reload_record; end
 end
 
 module ActiveStorage::Attachment::CustomFinderMethods

--- a/spec/test_data/v6.0/expected_blob.rbi
+++ b/spec/test_data/v6.0/expected_blob.rbi
@@ -338,6 +338,9 @@ module ActiveStorage::Blob::GeneratedAssociationMethods
   sig { params(value: T.nilable(::ActiveStorage::Attachment)).void }
   def preview_image_attachment=(value); end
 
+  sig { returns(T.nilable(::ActiveStorage::Attachment)) }
+  def reload_preview_image_attachment; end
+
   sig { returns(T.nilable(::ActiveStorage::Blob)) }
   def preview_image_blob; end
 
@@ -352,6 +355,9 @@ module ActiveStorage::Blob::GeneratedAssociationMethods
 
   sig { params(value: T.nilable(::ActiveStorage::Blob)).void }
   def preview_image_blob=(value); end
+
+  sig { returns(T.nilable(::ActiveStorage::Blob)) }
+  def reload_preview_image_blob; end
 
   sig { returns(T.nilable(ActiveStorage::Attached::One)) }
   def preview_image; end

--- a/spec/test_data/v6.0/expected_headmaster.rbi
+++ b/spec/test_data/v6.0/expected_headmaster.rbi
@@ -52,6 +52,9 @@ module Headmaster::GeneratedAssociationMethods
   sig { params(value: ::School).void }
   def school=(value); end
 
+  sig { returns(::School) }
+  def reload_school; end
+
   sig { returns(::Wizard) }
   def wizard; end
 
@@ -66,6 +69,9 @@ module Headmaster::GeneratedAssociationMethods
 
   sig { params(value: ::Wizard).void }
   def wizard=(value); end
+
+  sig { returns(::Wizard) }
+  def reload_wizard; end
 end
 
 module Headmaster::CustomFinderMethods

--- a/spec/test_data/v6.0/expected_potion.rbi
+++ b/spec/test_data/v6.0/expected_potion.rbi
@@ -22,6 +22,9 @@ module Potion::GeneratedAssociationMethods
 
   sig { params(value: T.nilable(::Wizard)).void }
   def wizard=(value); end
+
+  sig { returns(T.nilable(::Wizard)) }
+  def reload_wizard; end
 end
 
 module Potion::CustomFinderMethods

--- a/spec/test_data/v6.0/expected_robe.rbi
+++ b/spec/test_data/v6.0/expected_robe.rbi
@@ -42,6 +42,9 @@ module Robe::GeneratedAssociationMethods
 
   sig { params(value: T.nilable(::Wizard)).void }
   def wizard=(value); end
+
+  sig { returns(T.nilable(::Wizard)) }
+  def reload_wizard; end
 end
 
 module Robe::CustomFinderMethods

--- a/spec/test_data/v6.0/expected_school.rbi
+++ b/spec/test_data/v6.0/expected_school.rbi
@@ -42,6 +42,9 @@ module School::GeneratedAssociationMethods
 
   sig { params(value: ::Headmaster).void }
   def headmaster=(value); end
+
+  sig { returns(::Headmaster) }
+  def reload_headmaster; end
 end
 
 module School::CustomFinderMethods

--- a/spec/test_data/v6.0/expected_spell/habtm_spell_books.rbi
+++ b/spec/test_data/v6.0/expected_spell/habtm_spell_books.rbi
@@ -43,6 +43,9 @@ module Spell::HABTM_SpellBooks::GeneratedAssociationMethods
   sig { params(value: T.nilable(::Spell)).void }
   def left_side=(value); end
 
+  sig { returns(T.nilable(::Spell)) }
+  def reload_left_side; end
+
   sig { returns(::SpellBook) }
   def spell_book; end
 
@@ -57,6 +60,9 @@ module Spell::HABTM_SpellBooks::GeneratedAssociationMethods
 
   sig { params(value: ::SpellBook).void }
   def spell_book=(value); end
+
+  sig { returns(::SpellBook) }
+  def reload_spell_book; end
 end
 
 module Spell::HABTM_SpellBooks::CustomFinderMethods

--- a/spec/test_data/v6.0/expected_spell_book.rbi
+++ b/spec/test_data/v6.0/expected_spell_book.rbi
@@ -89,6 +89,9 @@ module SpellBook::GeneratedAssociationMethods
 
   sig { params(value: ::Wizard).void }
   def wizard=(value); end
+
+  sig { returns(::Wizard) }
+  def reload_wizard; end
 end
 
 module SpellBook::CustomFinderMethods

--- a/spec/test_data/v6.0/expected_spell_book/habtm_spells.rbi
+++ b/spec/test_data/v6.0/expected_spell_book/habtm_spells.rbi
@@ -43,6 +43,9 @@ module SpellBook::HABTM_Spells::GeneratedAssociationMethods
   sig { params(value: T.nilable(::SpellBook)).void }
   def left_side=(value); end
 
+  sig { returns(T.nilable(::SpellBook)) }
+  def reload_left_side; end
+
   sig { returns(::Spell) }
   def spell; end
 
@@ -57,6 +60,9 @@ module SpellBook::HABTM_Spells::GeneratedAssociationMethods
 
   sig { params(value: ::Spell).void }
   def spell=(value); end
+
+  sig { returns(::Spell) }
+  def reload_spell; end
 end
 
 module SpellBook::HABTM_Spells::CustomFinderMethods

--- a/spec/test_data/v6.0/expected_squib.rbi
+++ b/spec/test_data/v6.0/expected_squib.rbi
@@ -1028,6 +1028,9 @@ module Squib::GeneratedAssociationMethods
   sig { params(value: T.nilable(::School)).void }
   def school=(value); end
 
+  sig { returns(T.nilable(::School)) }
+  def reload_school; end
+
   sig { returns(T.nilable(::ActiveStorage::Attachment)) }
   def school_photo_attachment; end
 
@@ -1043,6 +1046,9 @@ module Squib::GeneratedAssociationMethods
   sig { params(value: T.nilable(::ActiveStorage::Attachment)).void }
   def school_photo_attachment=(value); end
 
+  sig { returns(T.nilable(::ActiveStorage::Attachment)) }
+  def reload_school_photo_attachment; end
+
   sig { returns(T.nilable(::ActiveStorage::Blob)) }
   def school_photo_blob; end
 
@@ -1057,6 +1063,9 @@ module Squib::GeneratedAssociationMethods
 
   sig { params(value: T.nilable(::ActiveStorage::Blob)).void }
   def school_photo_blob=(value); end
+
+  sig { returns(T.nilable(::ActiveStorage::Blob)) }
+  def reload_school_photo_blob; end
 
   sig { returns(::SpellBook::ActiveRecord_Associations_CollectionProxy) }
   def spell_books; end
@@ -1090,6 +1099,9 @@ module Squib::GeneratedAssociationMethods
 
   sig { params(value: T.nilable(::Wand)).void }
   def wand=(value); end
+
+  sig { returns(T.nilable(::Wand)) }
+  def reload_wand; end
 
   sig { returns(T.nilable(ActiveStorage::Attached::One)) }
   def school_photo; end

--- a/spec/test_data/v6.0/expected_subject/habtm_wizards.rbi
+++ b/spec/test_data/v6.0/expected_subject/habtm_wizards.rbi
@@ -43,6 +43,9 @@ module Subject::HABTM_Wizards::GeneratedAssociationMethods
   sig { params(value: T.nilable(::Subject)).void }
   def left_side=(value); end
 
+  sig { returns(T.nilable(::Subject)) }
+  def reload_left_side; end
+
   sig { returns(T.nilable(::Wizard)) }
   def wizard; end
 
@@ -57,6 +60,9 @@ module Subject::HABTM_Wizards::GeneratedAssociationMethods
 
   sig { params(value: T.nilable(::Wizard)).void }
   def wizard=(value); end
+
+  sig { returns(T.nilable(::Wizard)) }
+  def reload_wizard; end
 end
 
 module Subject::HABTM_Wizards::CustomFinderMethods

--- a/spec/test_data/v6.0/expected_wand.rbi
+++ b/spec/test_data/v6.0/expected_wand.rbi
@@ -185,6 +185,9 @@ module Wand::GeneratedAssociationMethods
 
   sig { params(value: ::Wizard).void }
   def wizard=(value); end
+
+  sig { returns(::Wizard) }
+  def reload_wizard; end
 end
 
 module Wand::CustomFinderMethods

--- a/spec/test_data/v6.0/expected_wizard.rbi
+++ b/spec/test_data/v6.0/expected_wizard.rbi
@@ -1104,6 +1104,9 @@ module Wizard::GeneratedAssociationMethods
   sig { params(value: T.nilable(::School)).void }
   def school=(value); end
 
+  sig { returns(T.nilable(::School)) }
+  def reload_school; end
+
   sig { returns(T.nilable(::ActiveStorage::Attachment)) }
   def school_photo_attachment; end
 
@@ -1119,6 +1122,9 @@ module Wizard::GeneratedAssociationMethods
   sig { params(value: T.nilable(::ActiveStorage::Attachment)).void }
   def school_photo_attachment=(value); end
 
+  sig { returns(T.nilable(::ActiveStorage::Attachment)) }
+  def reload_school_photo_attachment; end
+
   sig { returns(T.nilable(::ActiveStorage::Blob)) }
   def school_photo_blob; end
 
@@ -1133,6 +1139,9 @@ module Wizard::GeneratedAssociationMethods
 
   sig { params(value: T.nilable(::ActiveStorage::Blob)).void }
   def school_photo_blob=(value); end
+
+  sig { returns(T.nilable(::ActiveStorage::Blob)) }
+  def reload_school_photo_blob; end
 
   sig { returns(::SpellBook::ActiveRecord_Associations_CollectionProxy) }
   def spell_books; end
@@ -1166,6 +1175,9 @@ module Wizard::GeneratedAssociationMethods
 
   sig { params(value: T.nilable(::Wand)).void }
   def wand=(value); end
+
+  sig { returns(T.nilable(::Wand)) }
+  def reload_wand; end
 
   sig { returns(T.nilable(ActiveStorage::Attached::One)) }
   def school_photo; end

--- a/spec/test_data/v6.0/expected_wizard/habtm_subjects.rbi
+++ b/spec/test_data/v6.0/expected_wizard/habtm_subjects.rbi
@@ -43,6 +43,9 @@ module Wizard::HABTM_Subjects::GeneratedAssociationMethods
   sig { params(value: T.nilable(::Wizard)).void }
   def left_side=(value); end
 
+  sig { returns(T.nilable(::Wizard)) }
+  def reload_left_side; end
+
   sig { returns(T.nilable(::Subject)) }
   def subject; end
 
@@ -57,6 +60,9 @@ module Wizard::HABTM_Subjects::GeneratedAssociationMethods
 
   sig { params(value: T.nilable(::Subject)).void }
   def subject=(value); end
+
+  sig { returns(T.nilable(::Subject)) }
+  def reload_subject; end
 end
 
 module Wizard::HABTM_Subjects::CustomFinderMethods

--- a/spec/test_data/v6.0/expected_wizard_wo_spellbook.rbi
+++ b/spec/test_data/v6.0/expected_wizard_wo_spellbook.rbi
@@ -1104,6 +1104,9 @@ module Wizard::GeneratedAssociationMethods
   sig { params(value: T.nilable(T.untyped)).void }
   def school=(value); end
 
+  sig { returns(T.nilable(T.untyped)) }
+  def reload_school; end
+
   sig { returns(T.nilable(::ActiveStorage::Attachment)) }
   def school_photo_attachment; end
 
@@ -1119,6 +1122,9 @@ module Wizard::GeneratedAssociationMethods
   sig { params(value: T.nilable(::ActiveStorage::Attachment)).void }
   def school_photo_attachment=(value); end
 
+  sig { returns(T.nilable(::ActiveStorage::Attachment)) }
+  def reload_school_photo_attachment; end
+
   sig { returns(T.nilable(::ActiveStorage::Blob)) }
   def school_photo_blob; end
 
@@ -1133,6 +1139,9 @@ module Wizard::GeneratedAssociationMethods
 
   sig { params(value: T.nilable(::ActiveStorage::Blob)).void }
   def school_photo_blob=(value); end
+
+  sig { returns(T.nilable(::ActiveStorage::Blob)) }
+  def reload_school_photo_blob; end
 
   sig { returns(ActiveRecord::Associations::CollectionProxy) }
   def spell_books; end
@@ -1160,6 +1169,9 @@ module Wizard::GeneratedAssociationMethods
 
   sig { params(value: T.nilable(::Wand)).void }
   def wand=(value); end
+
+  sig { returns(T.nilable(::Wand)) }
+  def reload_wand; end
 
   sig { returns(T.nilable(ActiveStorage::Attached::One)) }
   def school_photo; end


### PR DESCRIPTION
Rails provides `reload_<association>` methods for single associations (has_one/belongs_to)

Example:
```ruby
user = User.first
user.reload_organisation
# => #<Organisation:0x0000000011279708> {
#      "id" => 123,
#      "name" => "Hogwarts",
#      ...
# }
```

From docs:
#### belongs_to
![image](https://user-images.githubusercontent.com/13454550/104034095-59648100-51c8-11eb-8917-9d98e0f34377.png)

#### has_one
![image](https://user-images.githubusercontent.com/13454550/104034141-697c6080-51c8-11eb-8110-e6ba732867ac.png)