### PR TITLE
check ApplicationController include ActionController::Helpers explicitly

### DIFF
--- a/lib/sorbet-rails/tasks/rails_rbi.rake
+++ b/lib/sorbet-rails/tasks/rails_rbi.rake
@@ -97,17 +97,18 @@ namespace :rails_rbi do
   task helpers: :environment do |t, args|
     SorbetRails::Utils.rails_eager_load_all!
 
-    if ApplicationController.methods.include?(:modules_for_helpers)
+    # API controller does not include ActionController::Helpers
+    if ApplicationController < ActionController::Helpers
       helpers = ApplicationController.modules_for_helpers([:all])
     end
 
     # If ApplicationController doesn't work or doesn't return any helpers,
     # try using ActionController::Base.
-    if ActionController::Base.methods.include?(:modules_for_helpers) && (helpers.nil? || helpers.length == 0)
+    if ApplicationController < ActionController::Helpers && helpers.blank?
       helpers = ActionController::Base.modules_for_helpers([:all])
     end
 
-    if helpers.nil? || helpers.length == 0
+    if helpers.blank?
       puts 'No helpers found.'
     else
       formatter = SorbetRails::HelperRbiFormatter.new(helpers)


### PR DESCRIPTION
One of my teammate found that `modules_for_helpers` is actually defined twice: one in 
`AbstractControler::Helpers` and override in `ActionController::Helpers`. The behavior
we rely on, `modules_for_helpers[:all]` is only defined in `ActionController::Helpers`.
We should check explicitly that this override is supported by checking that ApplicationController
includes ActionController::Helpers