### PR TITLE
add `last_page?` method to kaminari plugin

### DIFF
--- a/lib/sorbet-rails/gem_plugins/kaminari_plugin.rb
+++ b/lib/sorbet-rails/gem_plugins/kaminari_plugin.rb
@@ -43,5 +43,25 @@ class KaminariPlugin < SorbetRails::ModelPlugins::Base
       return_type: "Integer",
       class_method: true,
     )
+
+    # https://github.com/kaminari/kaminari/blob/c5186f5d9b7f23299d115408e62047447fd3189d/kaminari-core/lib/kaminari/models/page_scope_methods.rb#L82
+    model_relation_rbi = root.create_class(self.model_relation_class_name)
+    model_relation_rbi.create_method(
+      'last_page?',
+      parameters: nil,
+      return_type: 'T::Boolean',
+    )
+    model_assoc_relation_rbi = root.create_class(self.model_assoc_relation_class_name)
+    model_assoc_relation_rbi.create_method(
+      'last_page?',
+      parameters: nil,
+      return_type: 'T::Boolean',
+    )
+    collection_proxy_rbi = root.create_class(self.model_assoc_proxy_class_name)
+    collection_proxy_rbi.create_method(
+      'last_page?',
+      parameters: nil,
+      return_type: 'T::Boolean',
+    )
   end
 end


### PR DESCRIPTION
This PR adds the [`last_page?`](https://github.com/kaminari/kaminari/blob/c5186f5d9b7f23299d115408e62047447fd3189d/kaminari-core/lib/kaminari/models/page_scope_methods.rb#L82) method to the `kaminari_plugin.rb` file. This method didn't seem to fit with the pattern of the other methods generated by `add_relation_query_method`, since it does not return a `Model::RelationType` (can't chain). Not sure if this is the best way to generate this method, but I added generators for `Model::ActiveRecord_Relation`, `Model::ActiveRecord_AssociationRelation`, and `Model::ActiveRecord_Associations_CollectionProxy`