### PR TITLE
Fix typo in job_rbi_formatter

### DIFF
--- a/lib/sorbet-rails/job_rbi_formatter.rb
+++ b/lib/sorbet-rails/job_rbi_formatter.rb
@@ -80,7 +80,7 @@ module SorbetRails
 
     sig { returns(String) }
     def generate_rbi
-      puts "-- Generate sigs for mailer #{@job_class.name} --"
+      puts "-- Generate sigs for ActiveJob #{@job_class.name} --"
       populate_rbi
       @rbi_generator.rbi
     end


### PR DESCRIPTION
This was referencing mailers in the output when its really about jobs.