### PR TITLE
✏️ Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ end
 ❯ bundle exec  rake rails_rbi:custom
 ```
 
-`sorbet-rails` adds `TypedParams` to extact typed controller parameters.
+`sorbet-rails` adds `TypedParams` to extract typed controller parameters.
 
 TypedParams takes a parameter definition, which is a subclass of `T::Struct` and coerces the `params` object into an instance of that subclass using [sorbet-coerce](https://github.com/chanzuckerberg/sorbet-coerce):
 ```ruby


### PR DESCRIPTION
I think this was meant to be 'extract' instead of 'extact'.