### PR TITLE
Don't use #try to get serialization coder

### DIFF
--- a/lib/sorbet-rails/model_plugins/base.rb
+++ b/lib/sorbet-rails/model_plugins/base.rb
@@ -35,7 +35,11 @@ module SorbetRails::ModelPlugins
       column_type = @model_class.type_for_attribute(column_name)
       return unless column_type.is_a?(ActiveRecord::Type::Serialized)
 
-      column_type.coder.try(:object_class) || Object
+      if column_type.coder.respond_to?(:object_class)
+        column_type.coder.object_class
+      else
+        Object
+      end
     end
   end
 end


### PR DESCRIPTION
[`Object#try`](https://apidock.com/rails/Object/try) is defined by ActiveSupport as helper method for calling a method if it exists. Unfortunately, [`Dry::Struct.try`](https://github.com/dry-rb/dry-struct/blob/v0.4.0/lib/dry/struct/class_interface.rb#L144) does something completely different, so when a model is using that library as a serializer, it fails with the error:

> Error when handling model ExampleModel: can't convert Symbol into Hash

which prevents the rbi file from being generated (and is also extremely unhelpful as an explanation for the cause).

This change drops the `.try` call in favor of using the (more verbose but ideally less naming-conflict-prone) native Ruby method [`Object#respond_to?`](https://apidock.com/ruby/Object/respond_to%3F) to achieve the same result.