### PR TITLE
Default ActiveRecord Serialized type to Coder

### DIFF
--- a/lib/sorbet-rails/model_plugins/active_record_serialized_attribute.rb
+++ b/lib/sorbet-rails/model_plugins/active_record_serialized_attribute.rb
@@ -60,9 +60,8 @@ class SorbetRails::ModelPlugins::ActiveRecordSerializedAttribute < SorbetRails::
       # ActiveSupport::JSON.encode/ActiveSupport::JSON.decode
       # note that Hash keys are Strings since this is JSON
       'T.any(T::Array[T.untyped], T::Boolean, Float, T::Hash[String, T.untyped], Integer, String)'
-    else
-      # unknown uses YAML.load/YAML.dump
+    when 'Object', ''
       'T.any(T::Array[T.untyped], T::Boolean, Float, T::Hash[T.untyped, T.untyped], Integer, String)'
-    end
+      serialization_coder.to_s
   end
 end

--- a/lib/sorbet-rails/model_plugins/base.rb
+++ b/lib/sorbet-rails/model_plugins/base.rb
@@ -35,7 +35,14 @@ module SorbetRails::ModelPlugins
       column_type = @model_class.type_for_attribute(column_name)
       return unless column_type.is_a?(ActiveRecord::Type::Serialized)
 
-      column_type.coder.try(:object_class) || Object
+      object_class = column_type.coder.try(:object_class)
+      if object_class
+        object_class
+      elsif column_type.coder.is_a? Class
+        column_type.coder
+      else
+        Object
+      end
     end
   end
 end


### PR DESCRIPTION
When attempting to serialize a model attribute to a specific type[0], sorbet-rails generates generic type signatures as if that attribute were unknown [1]. That shouldn't be the case, given that we are explicitly serializing & deserializing to a given class. 

I am proposing that we pass that directly to the RBI definitions[2]. Given these examples, this will allow us to do 
```
model = Model.first
model.data.a_prop
```

rather than

```
model = Model.first
data = T.cast(model.data, Serialized)
data.a_prop
```


**[0] sample model definition**

```
class Model < ActiveRecord::Base
  class Serialized < T::Struct
    sig { params(data: T.nilable(T::Hash[String, String])).returns(T.self_type) }
    def load(data)
      TypeCoerce[self].new.from(data)
    end
  
    sig { params(data: T.untyped).returns(T.nilable(T::Hash[String, String])) }
    def dump(data)
      data.serialize
    end
    
    prop :a_prop, T.nilable(String)
  end

  # ie. data's DB column is a Postgres JSONB
  serialize :data, Serialized
end
```

**[1] generated types before this PR**

``` 
   sig { returns(T.any(T::Array[T.untyped], T::Boolean, Float, T::Hash[T.untyped, T.untyped], Integer, String)) }
  def data; end

  sig { params(value: T.any(T::Array[T.untyped], T::Boolean, Float, T::Hash[T.untyped, T.untyped], Integer, String)).void }
  def data=(value); end

  sig { returns(T::Boolean) }
  def data?; end
```

**[2] generated types after this PR**

``` 
   sig { returns(Model::Serialized) }
  def data; end

  sig { params(value: Model::Serialized).void }
  def data=(value); end

  sig { returns(T::Boolean) }
  def data?; end
```