### PR TITLE
Better error if not able to initialize model

### DIFF
--- a/lib/sorbet-rails/model_rbi_formatter.rb
+++ b/lib/sorbet-rails/model_rbi_formatter.rb
@@ -28,7 +28,10 @@ class SorbetRails::ModelRbiFormatter
       # Load all dynamic instance methods of this model by instantiating a fake model
       @model_class.new unless @model_class.abstract_class?
     rescue StandardError => err
-      puts "#{err.class}: Note: Unable to create new instance of #{model_class_name}"
+      puts
+      puts "Note: Unable to create new instance of #{model_class_name}"
+      puts "Got a #{err.class}, with this message: #{err.message}"
+      puts
     end
   end
 


### PR DESCRIPTION
The current message is easy to miss. This hopefully draws more attention to it. It now looks like this:

```
$ bundle exec rake rails_rbi:models[Foo]

Note: Unable to create new instance of Foo
Got a ActiveRecord::StatementInvalid, with this message: PG::UndefinedTable: ERROR:  relation "foos" does not exist
LINE 8:  WHERE a.attrelid = '"foos"'::regclass
                            ^

-- Generate sigs for Foo --
```