### PR TITLE
Create modules for AASM auto generated status constants

### DIFF
--- a/lib/sorbet-rails/gem_plugins/aasm_plugin.rb
+++ b/lib/sorbet-rails/gem_plugins/aasm_plugin.rb
@@ -38,12 +38,17 @@ class AasmPlugin < SorbetRails::ModelPlugins::Base
       )
     end
 
-    # - If you have a state like :baz, you get these methods:
-    # - `baz?`
+    # - If you have a state like :baz, you get:
+    # - a method `baz?`
+    # - a constant `STATE_BAZ`
     aasm_states.each do |state|
       model_rbi.create_method(
         "#{state}?",
         return_type: 'T::Boolean'
+      )
+
+      root.create_module(
+        "#{model_class_name}::STATE_#{state.to_s.upcase}"
       )
     end
   end


### PR DESCRIPTION
This is an enhancement to the AASM gem plugin.

The AASM gem [auto-generates constants](https://github.com/aasm/aasm#auto-generated-status-constants) for each AASM status. Currently, the plugin does not account for this, so Sorbet is unable to resolve these auto-generated constants. This PR adds that functionality.