### PR TITLE
📝  Update `README.md` for dynamic attribute methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,6 +365,7 @@ Following are the list of attribute dynamic methods and their static counterpart
 - `<attribute>_was` -> `attribute_was(<attribute>)`
 - `saved_change_to_<attribute>?` -> `saved_change_to_attribute?(<attribute>)`
 - `<attribute>_before_type_cast` -> `read_attribute_before_type_cast(<attribute>)`
+- `will_save_change_to_<attribute>?` -> `will_save_change_to_attribute?(<attribute>)`
 
 ### `after_commit` and other callbacks
 


### PR DESCRIPTION
### Context

Looks like `will_save_change_to_<attribute>?` -> `will_save_change_to_attribute?(<attribute>)` [Rails docs](https://api.rubyonrails.org/classes/ActiveRecord/AttributeMethods/Dirty.html#method-i-will_save_change_to_attribute-3F) was missing. Let me know if this is incorrect - happy to close if so!