### PR TITLE
Disable autoreleases on master

### DIFF
--- a/.github/workflows/publish-gem.yml
+++ b/.github/workflows/publish-gem.yml
@@ -12,6 +12,7 @@ jobs:
 
     env:
       RAILS_VERSION: 6.0
+      CI: true
 
     steps:
     - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -9,8 +9,6 @@ This gem adds a few Rake tasks to generate Ruby Interface (RBI) files for dynami
 
 `sorbet-rails` supports Rails 5+ or later.
 
-**Notice**: we automatically creates a new release on Rubygems with every merges to the master branch
-
 **Notice**: we no longer support Rails 4.2. [Version 0.5.6](https://github.com/chanzuckerberg/sorbet-rails/releases/tag/v0.5.6) is the last version supporting Rails 4.2.
 
 ## Initial Setup

--- a/sorbet-rails.gemspec
+++ b/sorbet-rails.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name          = %q{sorbet-rails}
-  s.version       = "0.7.#{ENV['GITHUB_RUN_NUMBER'] || 100}".strip
+  s.version       = "0.7.32"
   s.date          = %q{2019-04-18}
   s.summary       = %q{Set of tools to make Sorbet work with Rails seamlessly.}
   s.authors       = ["Chan Zuckerberg Initiative"]


### PR DESCRIPTION
Reverts https://github.com/chanzuckerberg/sorbet-rails/pull/465

While this gem's maintenance status is unclear, I'm not sure this is a great idea.

Additionally, using `ENV['GITHUB_RUN_NUMBER']` in the gemspec made it not possible to use this gem using a github ref in your gemfile.