### PR TITLE
[Fix] Skip missing active-records components

### DIFF
--- a/lib/sorbet-rails/tasks/rails_rbi.rake
+++ b/lib/sorbet-rails/tasks/rails_rbi.rake
@@ -26,6 +26,9 @@ namespace :rails_rbi do
 
   desc "Generate rbis for rails routes"
   task :routes, [:root_dir] => :environment do |t, args|
+    # Skip ActionDispatch if not included
+    next unless defined?(ActionDispatch)
+
     all_routes = Rails.application.routes.routes
     require "action_dispatch/routing/inspector"
     inspector = ActionDispatch::Routing::RoutesInspector.new(all_routes)
@@ -61,6 +64,9 @@ namespace :rails_rbi do
 
   desc "Generate rbis for rails models. Pass models name to regenerate rbi for only the given models."
   task models: :environment do |t, args|
+    # Skip ActiveRecord if not included
+    next unless defined?(ActiveRecord)
+
     SorbetRails::Utils.rails_eager_load_all!
 
     all_models = Set.new(ActiveRecord::Base.descendants + whitelisted_models - blacklisted_models)
@@ -95,6 +101,9 @@ namespace :rails_rbi do
 
   desc "Generate rbis for rails helpers."
   task helpers: :environment do |t, args|
+    # Skip ActionController if not included
+    next unless defined?(ActionController)
+
     SorbetRails::Utils.rails_eager_load_all!
 
     # API controller does not include ActionController::Helpers
@@ -120,6 +129,9 @@ namespace :rails_rbi do
 
   desc "Generate rbis for rails mailers"
   task :mailers, [:root_dir] => :environment do |t, args|
+    # Skip ActiveRecord if not included
+    next unless defined?(ActionMailer)
+
     SorbetRails::Utils.rails_eager_load_all!
     all_mailers = ActionMailer::Base.descendants
 
@@ -138,6 +150,9 @@ namespace :rails_rbi do
 
   desc "Generate rbis for rails mailers"
   task :jobs, [:root_dir] => :environment do |t, args|
+    # Skip ActiveJob if not included
+    next unless defined?(ActiveJob)
+
     SorbetRails::Utils.rails_eager_load_all!
     all_jobs = ActiveJob::Base.descendants
 


### PR DESCRIPTION
## Issue
When Rails projects are initialized without certain components, say without ActiveRecord, `bundle exec rake rails_rbi:all` will fail.

## Steps to Repro
- Start a new rails project
  - `rails new test --skip-active-record`
- Install sorbet-rails
- `bundle exec rake rails_rbi:all`
```
rake aborted!
NameError: uninitialized constant ActiveRecord
Did you mean?  ActiveModel
/Users/dxd/sorbet-rails/lib/sorbet-rails/tasks/rails_rbi.rake:66:in `block (2 levels) in <main>'
/Users/dxd/sorbet-rails/lib/sorbet-rails/tasks/rails_rbi.rake:20:in `block (2 levels) in <main>'
/Users/dxd/.rvm/gems/ruby-3.0.0/gems/rake-13.0.6/exe/rake:27:in `<top (required)>'
/Users/dxd/.rvm/rubies/ruby-3.0.0/bin/bundle:23:in `load'
/Users/dxd/.rvm/rubies/ruby-3.0.0/bin/bundle:23:in `<main>'
/Users/dxd/.rvm/gems/ruby-3.0.0/bin/ruby_executable_hooks:22:in `eval'
/Users/dxd/.rvm/gems/ruby-3.0.0/bin/ruby_executable_hooks:22:in `<main>'
Tasks: TOP => rails_rbi:models
(See full trace by running task with --trace)
```

## Fix
Check if constants are defined before each sub rake task. With the diff, I can no longer repro this issue.
