### PR TITLE
Add support for `ActiveRecord::QueryMethods#in_order_of`

### DIFF
--- a/lib/sorbet-rails/model_plugins/active_record_querying.rb
+++ b/lib/sorbet-rails/model_plugins/active_record_querying.rb
@@ -30,6 +30,7 @@ class SorbetRails::ModelPlugins::ActiveRecordQuerying < SorbetRails::ModelPlugin
       :where, :rewhere, :preload, :extract_associated, :eager_load, :includes, :from, :lock, :readonly, :or,
       :having, :create_with, :distinct, :references, :none, :unscope, :optimizer_hints, :merge, :except, :only,
     ]
+
     model_query_relation_methods.each do |method_name|
       add_relation_query_method(
         root,
@@ -72,6 +73,19 @@ class SorbetRails::ModelPlugins::ActiveRecordQuerying < SorbetRails::ModelPlugin
         "where_missing", # where_missing is injected by sorbet-rails
         parameters: [
           Parameter.new("*args", type: "Symbol"),
+        ],
+        builtin_query_method: true,
+      )
+    end
+
+    # https://api.rubyonrails.org/v7.0.0/classes/ActiveRecord/QueryMethods.html#method-i-in_order_of
+    if Rails.version >= "7.0"
+      add_relation_query_method(
+        root,
+        "in_order_of",
+        parameters: [
+          Parameter.new("column", type: "Symbol"),
+          Parameter.new("values", type: "T::Array[T.untyped]")
         ],
         builtin_query_method: true,
       )

--- a/spec/support/v7.0/Gemfile.lock
+++ b/spec/support/v7.0/Gemfile.lock
@@ -178,6 +178,7 @@ GEM
       sorbet-runtime (>= 0.4.4704)
     sorbet-runtime (0.5.10139)
     sorbet-static (0.5.10139-universal-darwin-20)
+    sorbet-static (0.5.10139-universal-darwin-21)
     sqlite3 (1.4.4)
     strscan (3.0.3)
     thor (1.2.1)
@@ -196,6 +197,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-20
+  x86_64-darwin-21
 
 DEPENDENCIES
   debug

--- a/spec/support/v7.0/sorbet_test_cases.rb
+++ b/spec/support/v7.0/sorbet_test_cases.rb
@@ -86,6 +86,8 @@ T.assert_type!(Wizard.eager_load(:spell_books), Wizard::ActiveRecord_Relation)
 T.assert_type!(Wizard.order(:id), Wizard::ActiveRecord_Relation)
 T.assert_type!(Wizard.select { |r| r.id == 1 }, T::Array[Wizard])
 T.assert_type!(Wizard.select_columns(:id, :name), Wizard::ActiveRecord_Relation)
+T.assert_type!(Wizard.where_missing(:wand), Wizard::ActiveRecord_Relation)
+T.assert_type!(Wizard.in_order_of(:id, [1, 2, 3]), Wizard::ActiveRecord_Relation)
 
 # Finder methods -- ActiveRecord::Relation
 T.assert_type!(Wizard.all.exists?(name: 'Harry Potter'), T::Boolean)
@@ -150,6 +152,9 @@ T.assert_type!(Wizard.all.eager_load(:spell_books), Wizard::ActiveRecord_Relatio
 T.assert_type!(Wizard.all.order(:id), Wizard::ActiveRecord_Relation)
 T.assert_type!(Wizard.all.select { |r| r.id == 1 }, T::Array[Wizard])
 T.assert_type!(Wizard.all.select_columns(:id, :name), Wizard::ActiveRecord_Relation)
+T.assert_type!(Wizard.all.where_missing(:wand), Wizard::ActiveRecord_Relation)
+T.assert_type!(Wizard.all.in_order_of(:id, [1, 2, 3]), Wizard::ActiveRecord_Relation)
+
 # Enumerable methods
 Wizard.all.each { |w| T.assert_type!(w, Wizard) }
 Wizard.all.map { |w| T.assert_type!(w, Wizard) }
@@ -206,6 +211,7 @@ T.assert_type!(spell_books.none? { |r| r.id > 1 }, T::Boolean)
 T.assert_type!(spell_books.one? { |r| r.id > 1 }, T::Boolean)
 # T.assert_type!(spell_books.update_all(name: 'Fantastic Beasts'), Integer) # Ignored until we add support
 # T.assert_type!(spell_books.delete_all, Integer) # Ignored until we add support
+
 # Query methods
 T.assert_type!(spell_books.all, SpellBook::ActiveRecord_AssociationRelation)
 T.assert_type!(spell_books.recent, SpellBook::ActiveRecord_AssociationRelation) # Named scope
@@ -220,6 +226,8 @@ T.assert_type!(spell_books.eager_load(:wizard), SpellBook::ActiveRecord_Associat
 T.assert_type!(spell_books.order(:id), SpellBook::ActiveRecord_AssociationRelation)
 T.assert_type!(spell_books.select { |r| r.id == 1 }, T::Array[SpellBook])
 T.assert_type!(spell_books.select_columns(:id, :name), SpellBook::ActiveRecord_AssociationRelation)
+T.assert_type!(spell_books.where_missing(:wizard), SpellBook::ActiveRecord_AssociationRelation)
+T.assert_type!(spell_books.in_order_of(:id, [1, 2, 3]), SpellBook::ActiveRecord_AssociationRelation)
 
 # Enumerable methods
 spell_books.each { |s| T.assert_type!(s, SpellBook) }

--- a/spec/test_data/v7.0/expected_attachment.rbi
+++ b/spec/test_data/v7.0/expected_attachment.rbi
@@ -216,6 +216,9 @@ module ActiveStorage::Attachment::QueryMethodsReturningRelation
   sig { params(args: Symbol).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
   def where_missing(*args); end
 
+  sig { params(column: Symbol, values: T::Array[T.untyped]).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
+  def in_order_of(column, values); end
+
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_Relation) }
   def extending(*args, &block); end
 
@@ -334,6 +337,9 @@ module ActiveStorage::Attachment::QueryMethodsReturningAssociationRelation
 
   sig { params(args: Symbol).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
   def where_missing(*args); end
+
+  sig { params(column: Symbol, values: T::Array[T.untyped]).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
+  def in_order_of(column, values); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Attachment::ActiveRecord_AssociationRelation) }
   def extending(*args, &block); end

--- a/spec/test_data/v7.0/expected_blob.rbi
+++ b/spec/test_data/v7.0/expected_blob.rbi
@@ -190,6 +190,9 @@ module ActiveStorage::Blob::QueryMethodsReturningRelation
   sig { params(args: Symbol).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
   def where_missing(*args); end
 
+  sig { params(column: Symbol, values: T::Array[T.untyped]).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
+  def in_order_of(column, values); end
+
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_Relation) }
   def extending(*args, &block); end
 
@@ -308,6 +311,9 @@ module ActiveStorage::Blob::QueryMethodsReturningAssociationRelation
 
   sig { params(args: Symbol).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
   def where_missing(*args); end
+
+  sig { params(column: Symbol, values: T::Array[T.untyped]).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
+  def in_order_of(column, values); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Blob::ActiveRecord_AssociationRelation) }
   def extending(*args, &block); end

--- a/spec/test_data/v7.0/expected_headmaster.rbi
+++ b/spec/test_data/v7.0/expected_headmaster.rbi
@@ -202,6 +202,9 @@ module Headmaster::QueryMethodsReturningRelation
   sig { params(args: Symbol).returns(Headmaster::ActiveRecord_Relation) }
   def where_missing(*args); end
 
+  sig { params(column: Symbol, values: T::Array[T.untyped]).returns(Headmaster::ActiveRecord_Relation) }
+  def in_order_of(column, values); end
+
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Headmaster::ActiveRecord_Relation) }
   def extending(*args, &block); end
 
@@ -320,6 +323,9 @@ module Headmaster::QueryMethodsReturningAssociationRelation
 
   sig { params(args: Symbol).returns(Headmaster::ActiveRecord_AssociationRelation) }
   def where_missing(*args); end
+
+  sig { params(column: Symbol, values: T::Array[T.untyped]).returns(Headmaster::ActiveRecord_AssociationRelation) }
+  def in_order_of(column, values); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Headmaster::ActiveRecord_AssociationRelation) }
   def extending(*args, &block); end

--- a/spec/test_data/v7.0/expected_internal_metadata.rbi
+++ b/spec/test_data/v7.0/expected_internal_metadata.rbi
@@ -172,6 +172,9 @@ module ActiveRecord::InternalMetadata::QueryMethodsReturningRelation
   sig { params(args: Symbol).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
   def where_missing(*args); end
 
+  sig { params(column: Symbol, values: T::Array[T.untyped]).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
+  def in_order_of(column, values); end
+
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_Relation) }
   def extending(*args, &block); end
 
@@ -290,6 +293,9 @@ module ActiveRecord::InternalMetadata::QueryMethodsReturningAssociationRelation
 
   sig { params(args: Symbol).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
   def where_missing(*args); end
+
+  sig { params(column: Symbol, values: T::Array[T.untyped]).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
+  def in_order_of(column, values); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::InternalMetadata::ActiveRecord_AssociationRelation) }
   def extending(*args, &block); end

--- a/spec/test_data/v7.0/expected_potion.rbi
+++ b/spec/test_data/v7.0/expected_potion.rbi
@@ -154,6 +154,9 @@ module Potion::QueryMethodsReturningRelation
   sig { params(args: Symbol).returns(Potion::ActiveRecord_Relation) }
   def where_missing(*args); end
 
+  sig { params(column: Symbol, values: T::Array[T.untyped]).returns(Potion::ActiveRecord_Relation) }
+  def in_order_of(column, values); end
+
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_Relation) }
   def extending(*args, &block); end
 
@@ -272,6 +275,9 @@ module Potion::QueryMethodsReturningAssociationRelation
 
   sig { params(args: Symbol).returns(Potion::ActiveRecord_AssociationRelation) }
   def where_missing(*args); end
+
+  sig { params(column: Symbol, values: T::Array[T.untyped]).returns(Potion::ActiveRecord_AssociationRelation) }
+  def in_order_of(column, values); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Potion::ActiveRecord_AssociationRelation) }
   def extending(*args, &block); end

--- a/spec/test_data/v7.0/expected_record.rbi
+++ b/spec/test_data/v7.0/expected_record.rbi
@@ -133,6 +133,9 @@ module ActiveStorage::Record::QueryMethodsReturningRelation
   sig { params(args: Symbol).returns(ActiveStorage::Record::ActiveRecord_Relation) }
   def where_missing(*args); end
 
+  sig { params(column: Symbol, values: T::Array[T.untyped]).returns(ActiveStorage::Record::ActiveRecord_Relation) }
+  def in_order_of(column, values); end
+
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Record::ActiveRecord_Relation) }
   def extending(*args, &block); end
 
@@ -251,6 +254,9 @@ module ActiveStorage::Record::QueryMethodsReturningAssociationRelation
 
   sig { params(args: Symbol).returns(ActiveStorage::Record::ActiveRecord_AssociationRelation) }
   def where_missing(*args); end
+
+  sig { params(column: Symbol, values: T::Array[T.untyped]).returns(ActiveStorage::Record::ActiveRecord_AssociationRelation) }
+  def in_order_of(column, values); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::Record::ActiveRecord_AssociationRelation) }
   def extending(*args, &block); end

--- a/spec/test_data/v7.0/expected_robe.rbi
+++ b/spec/test_data/v7.0/expected_robe.rbi
@@ -175,6 +175,9 @@ module Robe::QueryMethodsReturningRelation
   sig { params(args: Symbol).returns(Robe::ActiveRecord_Relation) }
   def where_missing(*args); end
 
+  sig { params(column: Symbol, values: T::Array[T.untyped]).returns(Robe::ActiveRecord_Relation) }
+  def in_order_of(column, values); end
+
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Robe::ActiveRecord_Relation) }
   def extending(*args, &block); end
 
@@ -293,6 +296,9 @@ module Robe::QueryMethodsReturningAssociationRelation
 
   sig { params(args: Symbol).returns(Robe::ActiveRecord_AssociationRelation) }
   def where_missing(*args); end
+
+  sig { params(column: Symbol, values: T::Array[T.untyped]).returns(Robe::ActiveRecord_AssociationRelation) }
+  def in_order_of(column, values); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Robe::ActiveRecord_AssociationRelation) }
   def extending(*args, &block); end

--- a/spec/test_data/v7.0/expected_schema_migration.rbi
+++ b/spec/test_data/v7.0/expected_schema_migration.rbi
@@ -145,6 +145,9 @@ module ActiveRecord::SchemaMigration::QueryMethodsReturningRelation
   sig { params(args: Symbol).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
   def where_missing(*args); end
 
+  sig { params(column: Symbol, values: T::Array[T.untyped]).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
+  def in_order_of(column, values); end
+
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_Relation) }
   def extending(*args, &block); end
 
@@ -263,6 +266,9 @@ module ActiveRecord::SchemaMigration::QueryMethodsReturningAssociationRelation
 
   sig { params(args: Symbol).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
   def where_missing(*args); end
+
+  sig { params(column: Symbol, values: T::Array[T.untyped]).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
+  def in_order_of(column, values); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveRecord::SchemaMigration::ActiveRecord_AssociationRelation) }
   def extending(*args, &block); end

--- a/spec/test_data/v7.0/expected_school.rbi
+++ b/spec/test_data/v7.0/expected_school.rbi
@@ -175,6 +175,9 @@ module School::QueryMethodsReturningRelation
   sig { params(args: Symbol).returns(School::ActiveRecord_Relation) }
   def where_missing(*args); end
 
+  sig { params(column: Symbol, values: T::Array[T.untyped]).returns(School::ActiveRecord_Relation) }
+  def in_order_of(column, values); end
+
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(School::ActiveRecord_Relation) }
   def extending(*args, &block); end
 
@@ -293,6 +296,9 @@ module School::QueryMethodsReturningAssociationRelation
 
   sig { params(args: Symbol).returns(School::ActiveRecord_AssociationRelation) }
   def where_missing(*args); end
+
+  sig { params(column: Symbol, values: T::Array[T.untyped]).returns(School::ActiveRecord_AssociationRelation) }
+  def in_order_of(column, values); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(School::ActiveRecord_AssociationRelation) }
   def extending(*args, &block); end

--- a/spec/test_data/v7.0/expected_spell.rbi
+++ b/spec/test_data/v7.0/expected_spell.rbi
@@ -166,6 +166,9 @@ module Spell::QueryMethodsReturningRelation
   sig { params(args: Symbol).returns(Spell::ActiveRecord_Relation) }
   def where_missing(*args); end
 
+  sig { params(column: Symbol, values: T::Array[T.untyped]).returns(Spell::ActiveRecord_Relation) }
+  def in_order_of(column, values); end
+
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Spell::ActiveRecord_Relation) }
   def extending(*args, &block); end
 
@@ -284,6 +287,9 @@ module Spell::QueryMethodsReturningAssociationRelation
 
   sig { params(args: Symbol).returns(Spell::ActiveRecord_AssociationRelation) }
   def where_missing(*args); end
+
+  sig { params(column: Symbol, values: T::Array[T.untyped]).returns(Spell::ActiveRecord_AssociationRelation) }
+  def in_order_of(column, values); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Spell::ActiveRecord_AssociationRelation) }
   def extending(*args, &block); end

--- a/spec/test_data/v7.0/expected_spell/habtm_spell_books.rbi
+++ b/spec/test_data/v7.0/expected_spell/habtm_spell_books.rbi
@@ -193,6 +193,9 @@ module Spell::HABTM_SpellBooks::QueryMethodsReturningRelation
   sig { params(args: Symbol).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
   def where_missing(*args); end
 
+  sig { params(column: Symbol, values: T::Array[T.untyped]).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
+  def in_order_of(column, values); end
+
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Spell::HABTM_SpellBooks::ActiveRecord_Relation) }
   def extending(*args, &block); end
 
@@ -311,6 +314,9 @@ module Spell::HABTM_SpellBooks::QueryMethodsReturningAssociationRelation
 
   sig { params(args: Symbol).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
   def where_missing(*args); end
+
+  sig { params(column: Symbol, values: T::Array[T.untyped]).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
+  def in_order_of(column, values); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Spell::HABTM_SpellBooks::ActiveRecord_AssociationRelation) }
   def extending(*args, &block); end

--- a/spec/test_data/v7.0/expected_spell_book.rbi
+++ b/spec/test_data/v7.0/expected_spell_book.rbi
@@ -357,6 +357,9 @@ module SpellBook::QueryMethodsReturningRelation
   sig { params(args: Symbol).returns(SpellBook::ActiveRecord_Relation) }
   def where_missing(*args); end
 
+  sig { params(column: Symbol, values: T::Array[T.untyped]).returns(SpellBook::ActiveRecord_Relation) }
+  def in_order_of(column, values); end
+
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_Relation) }
   def extending(*args, &block); end
 
@@ -475,6 +478,9 @@ module SpellBook::QueryMethodsReturningAssociationRelation
 
   sig { params(args: Symbol).returns(SpellBook::ActiveRecord_AssociationRelation) }
   def where_missing(*args); end
+
+  sig { params(column: Symbol, values: T::Array[T.untyped]).returns(SpellBook::ActiveRecord_AssociationRelation) }
+  def in_order_of(column, values); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::ActiveRecord_AssociationRelation) }
   def extending(*args, &block); end

--- a/spec/test_data/v7.0/expected_spell_book/habtm_spells.rbi
+++ b/spec/test_data/v7.0/expected_spell_book/habtm_spells.rbi
@@ -193,6 +193,9 @@ module SpellBook::HABTM_Spells::QueryMethodsReturningRelation
   sig { params(args: Symbol).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
   def where_missing(*args); end
 
+  sig { params(column: Symbol, values: T::Array[T.untyped]).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
+  def in_order_of(column, values); end
+
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::HABTM_Spells::ActiveRecord_Relation) }
   def extending(*args, &block); end
 
@@ -311,6 +314,9 @@ module SpellBook::HABTM_Spells::QueryMethodsReturningAssociationRelation
 
   sig { params(args: Symbol).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
   def where_missing(*args); end
+
+  sig { params(column: Symbol, values: T::Array[T.untyped]).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
+  def in_order_of(column, values); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(SpellBook::HABTM_Spells::ActiveRecord_AssociationRelation) }
   def extending(*args, &block); end

--- a/spec/test_data/v7.0/expected_squib.rbi
+++ b/spec/test_data/v7.0/expected_squib.rbi
@@ -1062,6 +1062,9 @@ module Squib::QueryMethodsReturningRelation
   sig { params(args: Symbol).returns(Squib::ActiveRecord_Relation) }
   def where_missing(*args); end
 
+  sig { params(column: Symbol, values: T::Array[T.untyped]).returns(Squib::ActiveRecord_Relation) }
+  def in_order_of(column, values); end
+
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_Relation) }
   def extending(*args, &block); end
 
@@ -1180,6 +1183,9 @@ module Squib::QueryMethodsReturningAssociationRelation
 
   sig { params(args: Symbol).returns(Squib::ActiveRecord_AssociationRelation) }
   def where_missing(*args); end
+
+  sig { params(column: Symbol, values: T::Array[T.untyped]).returns(Squib::ActiveRecord_AssociationRelation) }
+  def in_order_of(column, values); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Squib::ActiveRecord_AssociationRelation) }
   def extending(*args, &block); end

--- a/spec/test_data/v7.0/expected_subject.rbi
+++ b/spec/test_data/v7.0/expected_subject.rbi
@@ -166,6 +166,9 @@ module Subject::QueryMethodsReturningRelation
   sig { params(args: Symbol).returns(Subject::ActiveRecord_Relation) }
   def where_missing(*args); end
 
+  sig { params(column: Symbol, values: T::Array[T.untyped]).returns(Subject::ActiveRecord_Relation) }
+  def in_order_of(column, values); end
+
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Subject::ActiveRecord_Relation) }
   def extending(*args, &block); end
 
@@ -284,6 +287,9 @@ module Subject::QueryMethodsReturningAssociationRelation
 
   sig { params(args: Symbol).returns(Subject::ActiveRecord_AssociationRelation) }
   def where_missing(*args); end
+
+  sig { params(column: Symbol, values: T::Array[T.untyped]).returns(Subject::ActiveRecord_AssociationRelation) }
+  def in_order_of(column, values); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Subject::ActiveRecord_AssociationRelation) }
   def extending(*args, &block); end

--- a/spec/test_data/v7.0/expected_subject/habtm_wizards.rbi
+++ b/spec/test_data/v7.0/expected_subject/habtm_wizards.rbi
@@ -193,6 +193,9 @@ module Subject::HABTM_Wizards::QueryMethodsReturningRelation
   sig { params(args: Symbol).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
   def where_missing(*args); end
 
+  sig { params(column: Symbol, values: T::Array[T.untyped]).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
+  def in_order_of(column, values); end
+
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Subject::HABTM_Wizards::ActiveRecord_Relation) }
   def extending(*args, &block); end
 
@@ -311,6 +314,9 @@ module Subject::HABTM_Wizards::QueryMethodsReturningAssociationRelation
 
   sig { params(args: Symbol).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
   def where_missing(*args); end
+
+  sig { params(column: Symbol, values: T::Array[T.untyped]).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
+  def in_order_of(column, values); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Subject::HABTM_Wizards::ActiveRecord_AssociationRelation) }
   def extending(*args, &block); end

--- a/spec/test_data/v7.0/expected_variant_record.rbi
+++ b/spec/test_data/v7.0/expected_variant_record.rbi
@@ -178,6 +178,9 @@ module ActiveStorage::VariantRecord::QueryMethodsReturningRelation
   sig { params(args: Symbol).returns(ActiveStorage::VariantRecord::ActiveRecord_Relation) }
   def where_missing(*args); end
 
+  sig { params(column: Symbol, values: T::Array[T.untyped]).returns(ActiveStorage::VariantRecord::ActiveRecord_Relation) }
+  def in_order_of(column, values); end
+
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::VariantRecord::ActiveRecord_Relation) }
   def extending(*args, &block); end
 
@@ -296,6 +299,9 @@ module ActiveStorage::VariantRecord::QueryMethodsReturningAssociationRelation
 
   sig { params(args: Symbol).returns(ActiveStorage::VariantRecord::ActiveRecord_AssociationRelation) }
   def where_missing(*args); end
+
+  sig { params(column: Symbol, values: T::Array[T.untyped]).returns(ActiveStorage::VariantRecord::ActiveRecord_AssociationRelation) }
+  def in_order_of(column, values); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(ActiveStorage::VariantRecord::ActiveRecord_AssociationRelation) }
   def extending(*args, &block); end

--- a/spec/test_data/v7.0/expected_wand.rbi
+++ b/spec/test_data/v7.0/expected_wand.rbi
@@ -469,6 +469,9 @@ module Wand::QueryMethodsReturningRelation
   sig { params(args: Symbol).returns(Wand::ActiveRecord_Relation) }
   def where_missing(*args); end
 
+  sig { params(column: Symbol, values: T::Array[T.untyped]).returns(Wand::ActiveRecord_Relation) }
+  def in_order_of(column, values); end
+
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_Relation) }
   def extending(*args, &block); end
 
@@ -587,6 +590,9 @@ module Wand::QueryMethodsReturningAssociationRelation
 
   sig { params(args: Symbol).returns(Wand::ActiveRecord_AssociationRelation) }
   def where_missing(*args); end
+
+  sig { params(column: Symbol, values: T::Array[T.untyped]).returns(Wand::ActiveRecord_AssociationRelation) }
+  def in_order_of(column, values); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wand::ActiveRecord_AssociationRelation) }
   def extending(*args, &block); end

--- a/spec/test_data/v7.0/expected_wizard.rbi
+++ b/spec/test_data/v7.0/expected_wizard.rbi
@@ -1138,6 +1138,9 @@ module Wizard::QueryMethodsReturningRelation
   sig { params(args: Symbol).returns(Wizard::ActiveRecord_Relation) }
   def where_missing(*args); end
 
+  sig { params(column: Symbol, values: T::Array[T.untyped]).returns(Wizard::ActiveRecord_Relation) }
+  def in_order_of(column, values); end
+
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def extending(*args, &block); end
 
@@ -1256,6 +1259,9 @@ module Wizard::QueryMethodsReturningAssociationRelation
 
   sig { params(args: Symbol).returns(Wizard::ActiveRecord_AssociationRelation) }
   def where_missing(*args); end
+
+  sig { params(column: Symbol, values: T::Array[T.untyped]).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def in_order_of(column, values); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
   def extending(*args, &block); end

--- a/spec/test_data/v7.0/expected_wizard/habtm_subjects.rbi
+++ b/spec/test_data/v7.0/expected_wizard/habtm_subjects.rbi
@@ -193,6 +193,9 @@ module Wizard::HABTM_Subjects::QueryMethodsReturningRelation
   sig { params(args: Symbol).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
   def where_missing(*args); end
 
+  sig { params(column: Symbol, values: T::Array[T.untyped]).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
+  def in_order_of(column, values); end
+
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::HABTM_Subjects::ActiveRecord_Relation) }
   def extending(*args, &block); end
 
@@ -311,6 +314,9 @@ module Wizard::HABTM_Subjects::QueryMethodsReturningAssociationRelation
 
   sig { params(args: Symbol).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
   def where_missing(*args); end
+
+  sig { params(column: Symbol, values: T::Array[T.untyped]).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
+  def in_order_of(column, values); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::HABTM_Subjects::ActiveRecord_AssociationRelation) }
   def extending(*args, &block); end

--- a/spec/test_data/v7.0/expected_wizard_wo_spellbook.rbi
+++ b/spec/test_data/v7.0/expected_wizard_wo_spellbook.rbi
@@ -1132,6 +1132,9 @@ module Wizard::QueryMethodsReturningRelation
   sig { params(args: Symbol).returns(Wizard::ActiveRecord_Relation) }
   def where_missing(*args); end
 
+  sig { params(column: Symbol, values: T::Array[T.untyped]).returns(Wizard::ActiveRecord_Relation) }
+  def in_order_of(column, values); end
+
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_Relation) }
   def extending(*args, &block); end
 
@@ -1250,6 +1253,9 @@ module Wizard::QueryMethodsReturningAssociationRelation
 
   sig { params(args: Symbol).returns(Wizard::ActiveRecord_AssociationRelation) }
   def where_missing(*args); end
+
+  sig { params(column: Symbol, values: T::Array[T.untyped]).returns(Wizard::ActiveRecord_AssociationRelation) }
+  def in_order_of(column, values); end
 
   sig { params(args: T.untyped, block: T.nilable(T.proc.void)).returns(Wizard::ActiveRecord_AssociationRelation) }
   def extending(*args, &block); end


### PR DESCRIPTION
https://api.rubyonrails.org/v7.0.0/classes/ActiveRecord/QueryMethods.html#method-i-in_order_of
<img width="1016" alt="image" src="https://user-images.githubusercontent.com/13454550/179888758-fdbda5ed-8589-4134-a960-d8e334d255b6.png">