### PR TITLE
Support methods with forward everything syntax

### DIFF
--- a/lib/sorbet-rails/sorbet_utils.rb
+++ b/lib/sorbet-rails/sorbet_utils.rb
@@ -26,8 +26,14 @@ module SorbetRails
 
       parameters_with_type = signature.nil? ?
         method_def.parameters.map { |p|
+          # give param without name default name _
+          name = if p.size == 1 || %i[* ** &].include?(p[1])
+                   :_
+                 else
+                   p[1]
+                 end
           ParsedParamDef.new(
-            name: p.size == 1 ? :_ : p[1],  # give param without name default name _
+            name: name,
             kind: p[0], # append untyped as type of each param
             type_str: 'T.untyped',
           )

--- a/spec/sorbet_utils_spec.rb
+++ b/spec/sorbet_utils_spec.rb
@@ -42,6 +42,8 @@ class SorbetUtilsExampleClass
   def method_with_missing_args_name(p1, *); end
 
   def method_with_missing_kwargs_name(p1, **); end
+
+  def method_with_forward_everything(...); end
 end
 
 RSpec.describe SorbetRails::SorbetUtils do
@@ -171,5 +173,24 @@ RSpec.describe SorbetRails::SorbetUtils do
       Parameter.new('p1', type: 'T.untyped'),
       Parameter.new('**_', type: 'T.untyped'),
     ])
+  end
+
+  it 'works when using forward everything syntax' do
+    method_def = SorbetUtilsExampleClass.instance_method(:method_with_forward_everything)
+    parameters = SorbetRails::SorbetUtils.parameters_from_method_def(method_def)
+
+    # Ruby 3.2 changed now the forwarding syntax gets parsed to include kwargs
+    if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.2.0')
+      expect(parameters).to match_array([
+        Parameter.new('*_', type: 'T.untyped'),
+        Parameter.new('**_', type: 'T.untyped'),
+        Parameter.new('&_', type: 'T.untyped'),
+      ])
+    else
+      expect(parameters).to match_array([
+        Parameter.new('*_', type: 'T.untyped'),
+        Parameter.new('&_', type: 'T.untyped'),
+      ])
+    end
   end
 end


### PR DESCRIPTION
Fixes #538.

With this change, sorbet-rails can correctly generate types for methods like:

```ruby
class MyClass
  def foo(...); end
end
```